### PR TITLE
Kill switch

### DIFF
--- a/server/src/__tests__/emergency-stop-routes.test.ts
+++ b/server/src/__tests__/emergency-stop-routes.test.ts
@@ -1,0 +1,224 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  cancelRun: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  heartbeatService: () => mockHeartbeatService,
+  logActivity: mockLogActivity,
+}));
+
+// Mock db chain
+const mockQueryBuilder = {
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn().mockResolvedValue([]),
+  then: function(resolve: any) {
+    resolve([]);
+  }
+};
+
+const mockDb = {
+  select: vi.fn().mockReturnValue(mockQueryBuilder),
+};
+
+async function createApp(actor: any) {
+  const [{ errorHandler }, { emergencyStopRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+    vi.importActual<typeof import("../routes/emergency-stop.js")>("../routes/emergency-stop.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", emergencyStopRoutes(mockDb as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("emergency stop routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("authz", () => {
+    it("rejects non-admin board users with 403", async () => {
+      const app = await createApp({
+        type: "board",
+        userId: "user-1",
+        source: "session",
+        isInstanceAdmin: false,
+      });
+
+      const res = await request(app).get("/api/instance/emergency-stop/status");
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects agent actors with 403", async () => {
+      const app = await createApp({
+        type: "agent",
+        agentId: "agent-1",
+        companyId: "company-1",
+        source: "agent_key",
+      });
+
+      const res = await request(app).post("/api/instance/emergency-stop/runs");
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET /instance/emergency-stop/status", () => {
+    it("returns active run counts", async () => {
+      // Mock db returning some runs
+      const localMockQueryBuilder = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([
+          { id: "run-1", status: "running", companyId: "c1", agentId: "a1" },
+          { id: "run-2", status: "queued", companyId: "c2", agentId: "a2" },
+        ]),
+        then: function(resolve: any) {
+          resolve([]);
+        }
+      };
+      mockDb.select.mockReturnValueOnce(localMockQueryBuilder as any);
+
+      const app = await createApp({
+        type: "board",
+        userId: "admin-1",
+        source: "session",
+        isInstanceAdmin: true,
+      });
+
+      const res = await request(app).get("/api/instance/emergency-stop/status");
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        totalActive: 2,
+        runningCount: 1,
+        queuedCount: 1,
+        companyCount: 2,
+        agentCount: 2,
+      });
+    });
+  });
+
+  describe("POST /instance/emergency-stop/runs", () => {
+    it("returns 200 and cancels active runs", async () => {
+      const localMockQueryBuilder = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([
+          { id: "run-1", status: "running", companyId: "c1", agentId: "a1" },
+        ]),
+        then: function(resolve: any) {
+          resolve([]);
+        }
+      };
+      mockDb.select.mockReturnValueOnce(localMockQueryBuilder as any);
+
+      const app = await createApp({
+        type: "board",
+        userId: "admin-1",
+        source: "session",
+        isInstanceAdmin: true,
+      });
+
+      const res = await request(app).post("/api/instance/emergency-stop/runs");
+      
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        status: "ok",
+        cancelledCount: 1,
+        totalAttempted: 1,
+        message: "Cancelled 1 of 1 active runs.",
+      });
+      // errors should be undefined
+      expect(res.body.errors).toBeUndefined();
+
+      expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("run-1");
+      expect(mockLogActivity).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /instance/emergency-stop/server", () => {
+    it("fails with 400 if confirmation string is missing", async () => {
+      const app = await createApp({
+        type: "board",
+        userId: "admin-1",
+        source: "session",
+        isInstanceAdmin: true,
+      });
+
+      const res = await request(app).post("/api/instance/emergency-stop/server").send({});
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/Explicit 'SHUTDOWN' confirmation required/);
+    });
+
+    it("fails with 400 if confirmation string is incorrect", async () => {
+      const app = await createApp({
+        type: "board",
+        userId: "admin-1",
+        source: "session",
+        isInstanceAdmin: true,
+      });
+
+      const res = await request(app).post("/api/instance/emergency-stop/server").send({ confirm: "yes" });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/Explicit 'SHUTDOWN' confirmation required/);
+    });
+
+    it("succeeds and initiates shutdown with valid confirmation", async () => {
+      // Mock db first returning active runs, then all companies
+      const localMockQueryBuilderRuns = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([
+          { id: "run-1", companyId: "c1" },
+        ]),
+        then: function(resolve: any) { resolve([]); }
+      };
+      const localMockQueryBuilderCompanies = {
+        from: vi.fn().mockResolvedValue([{ id: "c1" }]),
+        where: vi.fn().mockReturnThis(),
+        then: function(resolve: any) { resolve([]); }
+      };
+
+      mockDb.select
+        .mockReturnValueOnce(localMockQueryBuilderRuns as any)
+        .mockReturnValueOnce(localMockQueryBuilderCompanies as any);
+
+      // We should mock process.kill to avert actual test process death
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const app = await createApp({
+        type: "board",
+        userId: "admin-1",
+        source: "session",
+        isInstanceAdmin: true,
+      });
+
+      const res = await request(app)
+        .post("/api/instance/emergency-stop/server")
+        .send({ confirm: "SHUTDOWN" });
+      
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        status: "shutting_down",
+        cancelledCount: 1,
+        totalAttempted: 1,
+        message: "Cancelled 1 runs. Server is shutting down.",
+      });
+
+      expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("run-1");
+      expect(mockLogActivity).toHaveBeenCalled();
+      
+      // Cleanup
+      killSpy.mockRestore();
+    });
+  });
+});

--- a/server/src/__tests__/emergency-stop-routes.test.ts
+++ b/server/src/__tests__/emergency-stop-routes.test.ts
@@ -3,10 +3,10 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockHeartbeatService = vi.hoisted(() => ({
-  cancelRun: vi.fn(),
+  cancelRun: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockLogActivity = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock("../services/index.js", () => ({
   heartbeatService: () => mockHeartbeatService,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -28,6 +28,7 @@ import { sidebarBadgeRoutes } from "./routes/sidebar-badges.js";
 import { sidebarPreferenceRoutes } from "./routes/sidebar-preferences.js";
 import { inboxDismissalRoutes } from "./routes/inbox-dismissals.js";
 import { instanceSettingsRoutes } from "./routes/instance-settings.js";
+import { emergencyStopRoutes } from "./routes/emergency-stop.js";
 import {
   instanceDatabaseBackupRoutes,
   type InstanceDatabaseBackupService,
@@ -202,6 +203,7 @@ export async function createApp(
   api.use(sidebarPreferenceRoutes(db));
   api.use(inboxDismissalRoutes(db));
   api.use(instanceSettingsRoutes(db));
+  api.use(emergencyStopRoutes(db));
   if (opts.databaseBackupService) {
     api.use(instanceDatabaseBackupRoutes(opts.databaseBackupService));
   }

--- a/server/src/routes/emergency-stop.ts
+++ b/server/src/routes/emergency-stop.ts
@@ -65,25 +65,27 @@ export function emergencyStopRoutes(db: Db) {
 
     // Log the emergency stop action to all affected companies
     const affectedCompanyIds = [...new Set(activeRuns.map((r) => r.companyId))];
-    for (const companyId of affectedCompanyIds) {
-      await logActivity(db, {
-        companyId,
-        actorType: actor.actorType,
-        actorId: actor.actorId,
-        agentId: actor.agentId,
-        runId: actor.runId,
-        action: "instance.emergency_stop.runs",
-        entityType: "instance_settings",
-        entityId: "emergency-stop",
-        details: {
-          cancelledCount,
-          totalAttempted: activeRuns.length,
-          errorCount: errors.length,
-        },
-      }).catch((logErr) => {
-        logger.error({ err: logErr }, "emergency-stop: failed to log activity");
-      });
-    }
+    await Promise.allSettled(
+      affectedCompanyIds.map((companyId) =>
+        logActivity(db, {
+          companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "instance.emergency_stop.runs",
+          entityType: "instance_settings",
+          entityId: "emergency-stop",
+          details: {
+            cancelledCount,
+            totalAttempted: activeRuns.length,
+            errorCount: errors.length,
+          },
+        }).catch((logErr) => {
+          logger.error({ err: logErr }, "emergency-stop: failed to log activity");
+        }),
+      ),
+    );
 
     logger.warn(
       { cancelledCount, errorCount: errors.length, totalAttempted: activeRuns.length },
@@ -137,19 +139,21 @@ export function emergencyStopRoutes(db: Db) {
     // Log to all companies before exiting
     const allCompanies = await db.select({ id: companies.id }).from(companies);
     const affectedCompanyIds = allCompanies.map((c) => c.id);
-    for (const companyId of affectedCompanyIds) {
-      await logActivity(db, {
-        companyId,
-        actorType: actor.actorType,
-        actorId: actor.actorId,
-        agentId: actor.agentId,
-        runId: actor.runId,
-        action: "instance.emergency_stop.server",
-        entityType: "instance_settings",
-        entityId: "emergency-stop",
-        details: { cancelledCount, totalAttempted: activeRuns.length },
-      }).catch(() => {});
-    }
+    await Promise.allSettled(
+      affectedCompanyIds.map((companyId) =>
+        logActivity(db, {
+          companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "instance.emergency_stop.server",
+          entityType: "instance_settings",
+          entityId: "emergency-stop",
+          details: { cancelledCount, totalAttempted: activeRuns.length },
+        }).catch(() => {}),
+      ),
+    );
 
     logger.warn(
       { cancelledCount, totalAttempted: activeRuns.length },

--- a/server/src/routes/emergency-stop.ts
+++ b/server/src/routes/emergency-stop.ts
@@ -109,6 +109,12 @@ export function emergencyStopRoutes(db: Db) {
    */
   router.post("/instance/emergency-stop/server", async (req, res) => {
     assertInstanceAdmin(req);
+    
+    if (req.body?.confirm !== "SHUTDOWN") {
+      res.status(400).json({ error: "Explicit 'SHUTDOWN' confirmation required." });
+      return;
+    }
+
     const actor = getActorInfo(req);
     const heartbeat = heartbeatService(db);
 

--- a/server/src/routes/emergency-stop.ts
+++ b/server/src/routes/emergency-stop.ts
@@ -9,8 +9,8 @@
 
 import { Router } from "express";
 import type { Db } from "@paperclipai/db";
-import { heartbeatRuns } from "@paperclipai/db";
-import { eq, inArray } from "drizzle-orm";
+import { heartbeatRuns, companies } from "@paperclipai/db";
+import { inArray } from "drizzle-orm";
 import { assertInstanceAdmin, getActorInfo } from "./authz.js";
 import { heartbeatService, logActivity } from "../services/index.js";
 import { logger } from "../middleware/logger.js";
@@ -47,16 +47,21 @@ export function emergencyStopRoutes(db: Db) {
     let cancelledCount = 0;
     const errors: Array<{ runId: string; error: string }> = [];
 
-    for (const run of activeRuns) {
-      try {
-        await heartbeat.cancelRun(run.id);
+    const results = await Promise.allSettled(
+      activeRuns.map((run) => heartbeat.cancelRun(run.id))
+    );
+
+    results.forEach((result, i) => {
+      if (result.status === "fulfilled") {
         cancelledCount++;
-      } catch (err) {
+      } else {
+        const run = activeRuns[i]!;
+        const err = result.reason;
         const message = err instanceof Error ? err.message : String(err);
         errors.push({ runId: run.id, error: message });
         logger.error({ runId: run.id, err: message }, "emergency-stop: failed to cancel run");
       }
-    }
+    });
 
     // Log the emergency stop action to all affected companies
     const affectedCompanyIds = [...new Set(activeRuns.map((r) => r.companyId))];
@@ -111,20 +116,27 @@ export function emergencyStopRoutes(db: Db) {
       .where(inArray(heartbeatRuns.status, ["queued", "running"]));
 
     let cancelledCount = 0;
-    for (const run of activeRuns) {
-      try {
-        await heartbeat.cancelRun(run.id);
+    
+    const results = await Promise.allSettled(
+      activeRuns.map((run) => heartbeat.cancelRun(run.id))
+    );
+
+    results.forEach((result, i) => {
+      if (result.status === "fulfilled") {
         cancelledCount++;
-      } catch (err) {
+      } else {
+        const run = activeRuns[i]!;
+        const err = result.reason;
         logger.error(
           { runId: run.id, err: err instanceof Error ? err.message : String(err) },
           "emergency-stop-server: failed to cancel run",
         );
       }
-    }
+    });
 
     // Log to all companies before exiting
-    const affectedCompanyIds = [...new Set(activeRuns.map((r) => r.companyId))];
+    const allCompanies = await db.select({ id: companies.id }).from(companies);
+    const affectedCompanyIds = allCompanies.map((c) => c.id);
     for (const companyId of affectedCompanyIds) {
       await logActivity(db, {
         companyId,

--- a/server/src/routes/emergency-stop.ts
+++ b/server/src/routes/emergency-stop.ts
@@ -39,6 +39,8 @@ export function emergencyStopRoutes(db: Db) {
       res.json({
         status: "ok",
         cancelledCount: 0,
+        totalAttempted: 0,
+        errors: undefined,
         message: "No active runs to cancel.",
       });
       return;

--- a/server/src/routes/emergency-stop.ts
+++ b/server/src/routes/emergency-stop.ts
@@ -1,0 +1,193 @@
+/**
+ * Emergency Stop routes — instance-admin-only endpoints to cancel all running
+ * agent processes across every company, or fully shut down the server.
+ *
+ * Two modes:
+ *   POST /instance/emergency-stop/runs   — Cancel all active runs but keep server alive
+ *   POST /instance/emergency-stop/server — Cancel all runs then shut down the server process
+ */
+
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+import { eq, inArray } from "drizzle-orm";
+import { assertInstanceAdmin, getActorInfo } from "./authz.js";
+import { heartbeatService, logActivity } from "../services/index.js";
+import { logger } from "../middleware/logger.js";
+
+export function emergencyStopRoutes(db: Db) {
+  const router = Router();
+
+  /**
+   * POST /instance/emergency-stop/runs
+   *
+   * Cancels every queued and running heartbeat run across all companies.
+   * The server remains alive and operational after this call.
+   */
+  router.post("/instance/emergency-stop/runs", async (req, res) => {
+    assertInstanceAdmin(req);
+    const actor = getActorInfo(req);
+    const heartbeat = heartbeatService(db);
+
+    // Find all active runs across all companies
+    const activeRuns = await db
+      .select({ id: heartbeatRuns.id, companyId: heartbeatRuns.companyId, agentId: heartbeatRuns.agentId })
+      .from(heartbeatRuns)
+      .where(inArray(heartbeatRuns.status, ["queued", "running"]));
+
+    if (activeRuns.length === 0) {
+      res.json({
+        status: "ok",
+        cancelledCount: 0,
+        message: "No active runs to cancel.",
+      });
+      return;
+    }
+
+    let cancelledCount = 0;
+    const errors: Array<{ runId: string; error: string }> = [];
+
+    for (const run of activeRuns) {
+      try {
+        await heartbeat.cancelRun(run.id);
+        cancelledCount++;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        errors.push({ runId: run.id, error: message });
+        logger.error({ runId: run.id, err: message }, "emergency-stop: failed to cancel run");
+      }
+    }
+
+    // Log the emergency stop action to all affected companies
+    const affectedCompanyIds = [...new Set(activeRuns.map((r) => r.companyId))];
+    for (const companyId of affectedCompanyIds) {
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "instance.emergency_stop.runs",
+        entityType: "instance_settings",
+        entityId: "emergency-stop",
+        details: {
+          cancelledCount,
+          totalAttempted: activeRuns.length,
+          errorCount: errors.length,
+        },
+      }).catch((logErr) => {
+        logger.error({ err: logErr }, "emergency-stop: failed to log activity");
+      });
+    }
+
+    logger.warn(
+      { cancelledCount, errorCount: errors.length, totalAttempted: activeRuns.length },
+      "emergency-stop: cancelled all active runs",
+    );
+
+    res.json({
+      status: "ok",
+      cancelledCount,
+      totalAttempted: activeRuns.length,
+      errors: errors.length > 0 ? errors : undefined,
+      message: `Cancelled ${cancelledCount} of ${activeRuns.length} active runs.`,
+    });
+  });
+
+  /**
+   * POST /instance/emergency-stop/server
+   *
+   * Cancels all active runs then shuts down the server process.
+   * The HTTP response is sent BEFORE the process exits.
+   */
+  router.post("/instance/emergency-stop/server", async (req, res) => {
+    assertInstanceAdmin(req);
+    const actor = getActorInfo(req);
+    const heartbeat = heartbeatService(db);
+
+    const activeRuns = await db
+      .select({ id: heartbeatRuns.id, companyId: heartbeatRuns.companyId })
+      .from(heartbeatRuns)
+      .where(inArray(heartbeatRuns.status, ["queued", "running"]));
+
+    let cancelledCount = 0;
+    for (const run of activeRuns) {
+      try {
+        await heartbeat.cancelRun(run.id);
+        cancelledCount++;
+      } catch (err) {
+        logger.error(
+          { runId: run.id, err: err instanceof Error ? err.message : String(err) },
+          "emergency-stop-server: failed to cancel run",
+        );
+      }
+    }
+
+    // Log to all companies before exiting
+    const affectedCompanyIds = [...new Set(activeRuns.map((r) => r.companyId))];
+    for (const companyId of affectedCompanyIds) {
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "instance.emergency_stop.server",
+        entityType: "instance_settings",
+        entityId: "emergency-stop",
+        details: { cancelledCount, totalAttempted: activeRuns.length },
+      }).catch(() => {});
+    }
+
+    logger.warn(
+      { cancelledCount, totalAttempted: activeRuns.length },
+      "emergency-stop-server: shutting down server process",
+    );
+
+    // Respond BEFORE exiting so the client knows the command was received
+    res.json({
+      status: "shutting_down",
+      cancelledCount,
+      totalAttempted: activeRuns.length,
+      message: `Cancelled ${cancelledCount} runs. Server is shutting down.`,
+    });
+
+    // Defer the exit so the response flushes
+    setTimeout(() => {
+      process.kill(process.pid, "SIGTERM");
+    }, 500);
+  });
+
+  /**
+   * GET /instance/emergency-stop/status
+   *
+   * Returns the count of currently active runs across all companies.
+   * Used by the UI to show live state on the emergency stop panel.
+   */
+  router.get("/instance/emergency-stop/status", async (req, res) => {
+    assertInstanceAdmin(req);
+
+    const activeRuns = await db
+      .select({
+        id: heartbeatRuns.id,
+        status: heartbeatRuns.status,
+        companyId: heartbeatRuns.companyId,
+        agentId: heartbeatRuns.agentId,
+      })
+      .from(heartbeatRuns)
+      .where(inArray(heartbeatRuns.status, ["queued", "running"]));
+
+    const runningCount = activeRuns.filter((r) => r.status === "running").length;
+    const queuedCount = activeRuns.filter((r) => r.status === "queued").length;
+
+    res.json({
+      totalActive: activeRuns.length,
+      runningCount,
+      queuedCount,
+      companyCount: new Set(activeRuns.map((r) => r.companyId)).size,
+      agentCount: new Set(activeRuns.map((r) => r.agentId)).size,
+    });
+  });
+
+  return router;
+}

--- a/ui/src/api/emergencyStop.ts
+++ b/ui/src/api/emergencyStop.ts
@@ -1,0 +1,28 @@
+import { api } from "./client";
+
+export interface EmergencyStopStatus {
+  totalActive: number;
+  runningCount: number;
+  queuedCount: number;
+  companyCount: number;
+  agentCount: number;
+}
+
+export interface EmergencyStopResult {
+  status: string;
+  cancelledCount: number;
+  totalAttempted: number;
+  errors?: Array<{ runId: string; error: string }>;
+  message: string;
+}
+
+export const emergencyStopApi = {
+  getStatus: () =>
+    api.get<EmergencyStopStatus>("/instance/emergency-stop/status"),
+
+  stopAllRuns: () =>
+    api.post<EmergencyStopResult>("/instance/emergency-stop/runs", {}),
+
+  shutdownServer: () =>
+    api.post<EmergencyStopResult>("/instance/emergency-stop/server", {}),
+};

--- a/ui/src/api/emergencyStop.ts
+++ b/ui/src/api/emergencyStop.ts
@@ -23,6 +23,6 @@ export const emergencyStopApi = {
   stopAllRuns: () =>
     api.post<EmergencyStopResult>("/instance/emergency-stop/runs", {}),
 
-  shutdownServer: () =>
-    api.post<EmergencyStopResult>("/instance/emergency-stop/server", {}),
+  shutdownServer: (confirm: string) =>
+    api.post<EmergencyStopResult>("/instance/emergency-stop/server", { confirm }),
 };

--- a/ui/src/pages/InstanceSettings.tsx
+++ b/ui/src/pages/InstanceSettings.tsx
@@ -163,12 +163,14 @@ export function InstanceSettings() {
     },
   });
 
+  const [isStopRunsOpen, setIsStopRunsOpen] = useState(false);
   const stopAllRunsMutation = useMutation({
     mutationFn: () => emergencyStopApi.stopAllRuns(),
     onSuccess: (data) => {
       setActionError(null);
       pushToast({ title: "Success", body: data.message, tone: "success" });
       queryClient.invalidateQueries({ queryKey: ["instance", "emergency-stop", "status"] });
+      setIsStopRunsOpen(false);
     },
     onError: (error) => {
       setActionError(error instanceof Error ? error.message : "Failed to stop runs.");
@@ -352,7 +354,10 @@ export function InstanceSettings() {
               <div className="text-sm">
                 Currently tracking <strong>{emergencyStatusQuery.data?.totalActive ?? 0}</strong> active run(s).
               </div>
-              <Dialog onOpenChange={(open) => { if (!open) stopAllRunsMutation.reset(); }}>
+              <Dialog open={isStopRunsOpen} onOpenChange={(open) => {
+                setIsStopRunsOpen(open);
+                if (!open) stopAllRunsMutation.reset();
+              }}>
                 <DialogTrigger asChild>
                   <Button variant="outline" className="w-full text-destructive border-destructive/20 hover:bg-destructive/10">
                     Cancel All Runs
@@ -369,15 +374,13 @@ export function InstanceSettings() {
                     <DialogClose asChild>
                       <Button variant="outline">Cancel</Button>
                     </DialogClose>
-                    <DialogClose asChild>
-                      <Button 
-                        variant="destructive" 
-                        onClick={() => stopAllRunsMutation.mutate()}
-                        disabled={stopAllRunsMutation.isPending}
-                      >
-                        {stopAllRunsMutation.isPending ? "Cancelling..." : "Yes, Cancel All Runs"}
-                      </Button>
-                    </DialogClose>
+                    <Button 
+                      variant="destructive" 
+                      onClick={() => stopAllRunsMutation.mutate()}
+                      disabled={stopAllRunsMutation.isPending}
+                    >
+                      {stopAllRunsMutation.isPending ? "Cancelling..." : "Yes, Cancel All Runs"}
+                    </Button>
                   </DialogFooter>
                 </DialogContent>
               </Dialog>

--- a/ui/src/pages/InstanceSettings.tsx
+++ b/ui/src/pages/InstanceSettings.tsx
@@ -153,7 +153,7 @@ export function InstanceSettings() {
 
   const [confirmShutdownText, setConfirmShutdownText] = useState("");
   const shutdownServerMutation = useMutation({
-    mutationFn: () => emergencyStopApi.shutdownServer(),
+    mutationFn: (confirm: string) => emergencyStopApi.shutdownServer(confirm),
     onSuccess: (data) => {
       setActionError(null);
       pushToast({ title: "Shutdown initiated", body: `${data.message} The UI will now lose connection.`, tone: "info" });
@@ -430,7 +430,7 @@ export function InstanceSettings() {
                     <Button 
                       variant="destructive"
                       disabled={confirmShutdownText !== "SHUTDOWN" || shutdownServerMutation.isPending}
-                      onClick={() => shutdownServerMutation.mutate()}
+                      onClick={() => shutdownServerMutation.mutate(confirmShutdownText)}
                     >
                       {shutdownServerMutation.isPending ? "Shutting down..." : "Terminate Server"}
                     </Button>

--- a/ui/src/pages/InstanceSettings.tsx
+++ b/ui/src/pages/InstanceSettings.tsx
@@ -19,6 +19,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  DialogClose,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";

--- a/ui/src/pages/InstanceSettings.tsx
+++ b/ui/src/pages/InstanceSettings.tsx
@@ -1,15 +1,27 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Clock3, ExternalLink, Settings } from "lucide-react";
+import { Clock3, ExternalLink, Settings, AlertTriangle, ShieldAlert } from "lucide-react";
 import type { InstanceSchedulerHeartbeatAgent } from "@paperclipai/shared";
 import { Link } from "@/lib/router";
 import { heartbeatsApi } from "../api/heartbeats";
+import { emergencyStopApi } from "../api/emergencyStop";
 import { agentsApi } from "../api/agents";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { EmptyState } from "../components/EmptyState";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import { queryKeys } from "../lib/queryKeys";
 import { formatDateTime, relativeTime } from "../lib/utils";
 
@@ -42,6 +54,12 @@ export function InstanceSettings() {
     queryKey: queryKeys.instance.schedulerHeartbeats,
     queryFn: () => heartbeatsApi.listInstanceSchedulerAgents(),
     refetchInterval: 15_000,
+  });
+
+  const emergencyStatusQuery = useQuery({
+    queryKey: ["instance", "emergency-stop", "status"],
+    queryFn: () => emergencyStopApi.getStatus(),
+    refetchInterval: 5_000,
   });
 
   const toggleMutation = useMutation({
@@ -127,6 +145,30 @@ export function InstanceSettings() {
     },
     onError: (error) => {
       setActionError(error instanceof Error ? error.message : "Failed to disable all heartbeats.");
+    },
+  });
+
+  const [confirmShutdownText, setConfirmShutdownText] = useState("");
+  const shutdownServerMutation = useMutation({
+    mutationFn: () => emergencyStopApi.shutdownServer(),
+    onSuccess: (data) => {
+      setActionError(null);
+      alert(`Shutdown initiated. ${data.message} The UI will now lose connection.`);
+    },
+    onError: (error) => {
+      setActionError(error instanceof Error ? error.message : "Failed to shutdown server.");
+    },
+  });
+
+  const stopAllRunsMutation = useMutation({
+    mutationFn: () => emergencyStopApi.stopAllRuns(),
+    onSuccess: (data) => {
+      setActionError(null);
+      alert(data.message);
+      queryClient.invalidateQueries({ queryKey: ["instance", "emergency-stop", "status"] });
+    },
+    onError: (error) => {
+      setActionError(error instanceof Error ? error.message : "Failed to stop runs.");
     },
   });
 
@@ -278,6 +320,119 @@ export function InstanceSettings() {
           ))}
         </div>
       )}
+
+      {/* Emergency Stop Section */}
+      <div className="pt-8 mt-8 border-t space-y-6">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <ShieldAlert className="h-5 w-5 text-destructive" />
+            <h2 className="text-lg font-semibold text-destructive">Emergency Controls</h2>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Instance-wide emergency actions. Use with extreme caution.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {/* Stop Runs Card */}
+          <Card className="border-destructive/20 bg-destructive/5">
+            <CardHeader>
+              <CardTitle className="text-base flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 text-warning" />
+                Cancel All Active Runs
+              </CardTitle>
+              <CardDescription>
+                Immediately cancels all currently running and queued agent processes across every company. The server will remain running.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="text-sm">
+                Currently tracking <strong>{emergencyStatusQuery.data?.totalActive ?? 0}</strong> active run(s).
+              </div>
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button variant="outline" className="w-full text-destructive border-destructive/20 hover:bg-destructive/10">
+                    Cancel All Runs
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Cancel All Active Runs?</DialogTitle>
+                    <DialogDescription>
+                      This will forcefully terminate {emergencyStatusQuery.data?.totalActive ?? 0} active agent processes across {emergencyStatusQuery.data?.companyCount ?? 0} companies. Data from currently executing steps may be lost.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button variant="outline">Cancel</Button>
+                    </DialogClose>
+                    <Button 
+                      variant="destructive" 
+                      onClick={() => stopAllRunsMutation.mutate()}
+                      disabled={stopAllRunsMutation.isPending}
+                    >
+                      {stopAllRunsMutation.isPending ? "Cancelling..." : "Yes, Cancel All Runs"}
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </CardContent>
+          </Card>
+
+          {/* Full Shutdown Card */}
+          <Card className="border-destructive bg-destructive/10">
+            <CardHeader>
+              <CardTitle className="text-base text-destructive flex items-center gap-2">
+                <ShieldAlert className="h-4 w-4" />
+                Full Server Shutdown
+              </CardTitle>
+              <CardDescription className="text-destructive/80">
+                Cancels all runs and completely terminates the Paperclip server process. You will need CLI access to restart it.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Dialog onOpenChange={(open) => !open && setConfirmShutdownText("")}>
+                <DialogTrigger asChild>
+                  <Button variant="destructive" className="w-full">
+                    Initiate Shutdown
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle className="text-destructive">Initiate Full Server Shutdown?</DialogTitle>
+                    <DialogDescription>
+                      This action cannot be undone from the UI. The Paperclip server will immediately terminate all agents and exit. Connect to the host machine to restart it.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="space-y-4 py-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="confirm">Type SHUTDOWN to confirm</Label>
+                      <Input
+                        id="confirm"
+                        value={confirmShutdownText}
+                        onChange={(e) => setConfirmShutdownText(e.target.value)}
+                        placeholder="SHUTDOWN"
+                      />
+                    </div>
+                  </div>
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button variant="outline">Cancel</Button>
+                    </DialogClose>
+                    <Button 
+                      variant="destructive"
+                      disabled={confirmShutdownText !== "SHUTDOWN" || shutdownServerMutation.isPending}
+                      onClick={() => shutdownServerMutation.mutate()}
+                    >
+                      {shutdownServerMutation.isPending ? "Shutting down..." : "Terminate Server"}
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
     </div>
   );
 }

--- a/ui/src/pages/InstanceSettings.tsx
+++ b/ui/src/pages/InstanceSettings.tsx
@@ -343,7 +343,7 @@ export function InstanceSettings() {
           <Card className="border-destructive/20 bg-destructive/5">
             <CardHeader>
               <CardTitle className="text-base flex items-center gap-2">
-                <AlertTriangle className="h-4 w-4 text-warning" />
+                <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
                 Cancel All Active Runs
               </CardTitle>
               <CardDescription>

--- a/ui/src/pages/InstanceSettings.tsx
+++ b/ui/src/pages/InstanceSettings.tsx
@@ -7,6 +7,7 @@ import { heartbeatsApi } from "../api/heartbeats";
 import { emergencyStopApi } from "../api/emergencyStop";
 import { agentsApi } from "../api/agents";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useToastActions } from "../context/ToastContext";
 import { EmptyState } from "../components/EmptyState";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -43,6 +44,7 @@ export function InstanceSettings() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
+  const { pushToast } = useToastActions();
 
   useEffect(() => {
     setBreadcrumbs([
@@ -154,7 +156,7 @@ export function InstanceSettings() {
     mutationFn: () => emergencyStopApi.shutdownServer(),
     onSuccess: (data) => {
       setActionError(null);
-      alert(`Shutdown initiated. ${data.message} The UI will now lose connection.`);
+      pushToast({ title: "Shutdown initiated", body: `${data.message} The UI will now lose connection.`, tone: "info" });
     },
     onError: (error) => {
       setActionError(error instanceof Error ? error.message : "Failed to shutdown server.");
@@ -165,7 +167,7 @@ export function InstanceSettings() {
     mutationFn: () => emergencyStopApi.stopAllRuns(),
     onSuccess: (data) => {
       setActionError(null);
-      alert(data.message);
+      pushToast({ title: "Success", body: data.message, tone: "success" });
       queryClient.invalidateQueries({ queryKey: ["instance", "emergency-stop", "status"] });
     },
     onError: (error) => {

--- a/ui/src/pages/InstanceSettings.tsx
+++ b/ui/src/pages/InstanceSettings.tsx
@@ -352,7 +352,7 @@ export function InstanceSettings() {
               <div className="text-sm">
                 Currently tracking <strong>{emergencyStatusQuery.data?.totalActive ?? 0}</strong> active run(s).
               </div>
-              <Dialog>
+              <Dialog onOpenChange={(open) => { if (!open) stopAllRunsMutation.reset(); }}>
                 <DialogTrigger asChild>
                   <Button variant="outline" className="w-full text-destructive border-destructive/20 hover:bg-destructive/10">
                     Cancel All Runs
@@ -369,13 +369,15 @@ export function InstanceSettings() {
                     <DialogClose asChild>
                       <Button variant="outline">Cancel</Button>
                     </DialogClose>
-                    <Button 
-                      variant="destructive" 
-                      onClick={() => stopAllRunsMutation.mutate()}
-                      disabled={stopAllRunsMutation.isPending}
-                    >
-                      {stopAllRunsMutation.isPending ? "Cancelling..." : "Yes, Cancel All Runs"}
-                    </Button>
+                    <DialogClose asChild>
+                      <Button 
+                        variant="destructive" 
+                        onClick={() => stopAllRunsMutation.mutate()}
+                        disabled={stopAllRunsMutation.isPending}
+                      >
+                        {stopAllRunsMutation.isPending ? "Cancelling..." : "Yes, Cancel All Runs"}
+                      </Button>
+                    </DialogClose>
                   </DialogFooter>
                 </DialogContent>
               </Dialog>


### PR DESCRIPTION
## Thinking Path
We need to have a kill switch, this is are the processes and invocations that happens that run with Bizbox:

* **1. Bizbox Server (Main Node.js Process):** Core server started via `pnpm dev`. Orchestrates all sub-processes.
* **2. Vite Dev Server:** Runs as an in-process middleware. Dies automatically with the parent server.
* **3. Embedded PostgreSQL:** Separate database process spawned by the server (local dev only).
* **4. Plugin Workers:** Spawned via `child_process.fork` (`detached: false`). Tied to the parent lifecycle and terminate automatically if the server stops.
* **5. Agent / CLI Runs (Claude, Codex, etc.):** Spawned via `child_process.spawn` (`detached: true`).
  * ⚠️ **CRITICAL:** Because these are detached, they **survive the parent process death**. If the main server is killed abruptly, these will remain running as orphaned/zombie processes, making an explicit kill switch and cleanup sequence necessary.

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->
- Added 2 routes. One to kill all sub-agent/plugin workers, one to kill all sub-agent/plugin workers and then the server.
- Added an UI killswitch that would appears in instance setting -> heartbeat -> Initiate shutdown
- Added the shutdown process which do:

1. Cancel All Runs (POST /instance/emergency-stop/runs) check all the plugin workers and kill their processes
2. Full Server Shutdown (POST /instance/emergency-stop/server)
* do 1. again and then shut down the server
* Audit Logging: Logs the incoming server shutdown to affected companies.
* Graceful Disconnect: Responds to the client with an HTTP 200 indicating the shutdown has been initiated before actually exiting.
* Termination: Uses a 500ms deferred setTimeout to call process.kill(process.pid, "SIGTERM"). This slight delay ensures the network layer flushes the HTTP response to the UI instead of violently severing the connection and throwing an ugly network error on the frontend. After the delay, the main Bizbox process cleanly self-terminates.

## Imrpovements
The kill switch feels unreachable and a bit niche. Maybe there should be a persistent UI elements that is in every pages. Since a kill switch should be available anytime, anywhere.

<img width="1341" height="817" alt="image" src="https://github.com/user-attachments/assets/e9ef743f-9be6-4d4a-9a26-931c28776551" />

