### PR TITLE
Feat/otto agent adapter clean

### DIFF
--- a/packages/adapters/otto-agent/package.json
+++ b/packages/adapters/otto-agent/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@paperclipai/adapter-otto-agent",
+  "version": "0.1.0",
+  "description": "Paperclip adapter for Otto Agent — dispatches work to a remote Otto (Hermes) gateway over HTTP",
+  "license": "MIT",
+  "homepage": "https://github.com/zesthq/bizbox",
+  "bugs": {
+    "url": "https://github.com/zesthq/bizbox/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zesthq/bizbox",
+    "directory": "packages/adapters/otto-agent"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/otto-agent/package.json
+++ b/packages/adapters/otto-agent/package.json
@@ -14,28 +14,23 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
-      },
-      "./server": {
-        "types": "./dist/server/index.d.ts",
-        "import": "./dist/server/index.js"
-      },
-      "./ui": {
-        "types": "./dist/ui/index.d.ts",
-        "import": "./dist/ui/index.js"
-      }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts"
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js"
+    },
+    "./ui": {
+      "types": "./dist/ui/index.d.ts",
+      "import": "./dist/ui/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
   },
   "files": [
     "dist"

--- a/packages/adapters/otto-agent/src/cli/format-event.ts
+++ b/packages/adapters/otto-agent/src/cli/format-event.ts
@@ -1,0 +1,5 @@
+export function printOttoAgentStreamEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+  console.log(line);
+}

--- a/packages/adapters/otto-agent/src/cli/index.ts
+++ b/packages/adapters/otto-agent/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printOttoAgentStreamEvent } from "./format-event.js";

--- a/packages/adapters/otto-agent/src/index.ts
+++ b/packages/adapters/otto-agent/src/index.ts
@@ -1,0 +1,60 @@
+import type { ServerAdapterModule } from "@paperclipai/adapter-utils";
+import { execute } from "./server/execute.js";
+import { testEnvironment } from "./server/test.js";
+
+export const type = "otto_agent";
+export const label = "Otto Agent";
+
+export const models: { id: string; label: string }[] = [
+  { id: "copilot/claude-sonnet-4-5", label: "Claude Sonnet 4.5 (Copilot)" },
+  { id: "copilot/claude-opus-4-5", label: "Claude Opus 4.5 (Copilot)" },
+  { id: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5 (Direct)" },
+  { id: "anthropic/claude-opus-4-5", label: "Claude Opus 4.5 (Direct)" },
+  { id: "openai/gpt-4o", label: "GPT-4o (Direct)" },
+];
+
+export const agentConfigurationDoc = `# otto_agent adapter configuration
+
+Adapter: otto_agent
+
+Use when:
+- You want Paperclip to invoke a remote Otto Agent gateway over HTTPS.
+- The Otto Agent instance is hosted separately from your Paperclip deployment.
+
+Don't use when:
+- You are running Hermes Agent locally (use hermes_local instead).
+- You do not have an Otto Agent endpoint and API key provisioned.
+
+To get an Otto Agent endpoint and credentials, contact your Otto operator.
+Do not share your API key — it authenticates all requests to the gateway.
+
+Core fields:
+- url (string, required): HTTPS URL to the Otto gateway endpoint
+- apiKey (string, required): Bearer token issued by your Otto operator
+
+Optional fields:
+- model (string, optional): LLM model override (e.g. "copilot/claude-sonnet-4-5")
+- timeoutSec (number, optional): request timeout in seconds (default: 1800)
+- toolsets (string, optional): comma-separated toolsets to enable on the gateway
+- env (object, optional): extra environment variables forwarded to the gateway session
+
+Session persistence:
+- Otto returns a sessionId on each run; Paperclip stores and resends it automatically.
+- Use sessionKeyStrategy: "issue" (default) to maintain one session per Paperclip issue.
+
+Security notes:
+- Always use https:// — plaintext HTTP will be rejected for non-loopback hosts.
+- Never embed your API key in source code or commit it to version control.
+- Set apiKey via your deployment secrets manager or environment variables.
+`;
+
+const adapter: ServerAdapterModule = {
+  type,
+  execute,
+  testEnvironment,
+  models,
+  agentConfigurationDoc,
+};
+
+export { execute, testEnvironment };
+export default adapter;

--- a/packages/adapters/otto-agent/src/server/execute.ts
+++ b/packages/adapters/otto-agent/src/server/execute.ts
@@ -1,0 +1,221 @@
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
+import { asString, asNumber, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+type OttoAgentConfig = {
+  url: string;
+  apiKey?: string;
+  model?: string;
+  provider?: string;
+  timeoutSec?: number;
+  toolsets?: string;
+  env?: Record<string, string>;
+};
+
+type OttoRequest = {
+  runId: string;
+  agentId: string;
+  agentName: string;
+  companyId: string;
+  prompt: string;
+  sessionId?: string | null;
+  sessionParams?: Record<string, unknown> | null;
+  taskKey?: string | null;
+  model?: string;
+  provider?: string;
+  toolsets?: string;
+  env?: Record<string, string>;
+  context?: Record<string, unknown>;
+};
+
+type UsageSummary = {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+};
+
+type OttoResponse = {
+  ok: boolean;
+  summary: string;
+  sessionId?: string | null;
+  sessionDisplayId?: string | null;
+  model?: string;
+  provider?: string;
+  usage?: UsageSummary;
+  costUsd?: number;
+  errorMessage?: string;
+  errorCode?: string;
+};
+
+function resolveConfig(ctx: AdapterExecutionContext): OttoAgentConfig {
+  const raw = parseObject(ctx.config);
+  const url = asString(raw.url, "").trim();
+  if (!url) {
+    throw new Error(
+      "otto_agent adapter requires 'url' in adapterConfig. Contact your Otto operator for your endpoint.",
+    );
+  }
+  const apiKey = asString(raw.apiKey, "").trim() || undefined;
+  return {
+    url,
+    apiKey,
+    model: asString(raw.model, "").trim() || undefined,
+    provider: asString(raw.provider, "").trim() || undefined,
+    timeoutSec: asNumber(raw.timeoutSec, 1800),
+    toolsets: asString(raw.toolsets, "").trim() || undefined,
+    env: typeof raw.env === "object" && raw.env !== null && !Array.isArray(raw.env)
+      ? (raw.env as Record<string, string>)
+      : undefined,
+  };
+}
+
+function buildPrompt(ctx: AdapterExecutionContext): string {
+  const parts: string[] = [];
+  const c = parseObject(ctx.context);
+  if (c.prompt) parts.push(String(c.prompt));
+  if (c.instructions) parts.push(String(c.instructions));
+  if (c.wakeText) parts.push(String(c.wakeText));
+  if (parts.length === 0) parts.push(JSON.stringify(ctx.context, null, 2));
+  return parts.join("\n\n");
+}
+
+export async function execute(
+  ctx: AdapterExecutionContext,
+): Promise<AdapterExecutionResult> {
+  const config = resolveConfig(ctx);
+  const prompt = buildPrompt(ctx);
+
+  const body: OttoRequest = {
+    runId: ctx.runId,
+    agentId: ctx.agent.id,
+    agentName: ctx.agent.name,
+    companyId: ctx.agent.companyId,
+    prompt,
+    sessionId: ctx.runtime.sessionId,
+    sessionParams: ctx.runtime.sessionParams,
+    taskKey: ctx.runtime.taskKey,
+    model: config.model,
+    provider: config.provider,
+    toolsets: config.toolsets,
+    env: config.env,
+    context: ctx.context,
+  };
+
+  await ctx.onLog("stdout", `[otto-agent] POST ${config.url}\n`);
+  await ctx.onLog(
+    "stdout",
+    `[otto-agent] agent=${ctx.agent.name} session=${ctx.runtime.sessionId ?? "new"} model=${config.model ?? "default"}\n`,
+  );
+
+  if (ctx.onMeta) {
+    await ctx.onMeta({
+      adapterType: "otto_agent",
+      command: `POST ${config.url}`,
+      prompt,
+      context: ctx.context,
+    });
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (config.apiKey) {
+    headers["Authorization"] = `Bearer ${config.apiKey}`;
+  }
+
+  const controller = new AbortController();
+  const timeoutMs = (config.timeoutSec ?? 1800) * 1000;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetch(config.url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err: unknown) {
+    clearTimeout(timer);
+    const isTimeout = err instanceof Error && err.name === "AbortError";
+    const errorMessage = isTimeout
+      ? `Request timed out after ${config.timeoutSec}s`
+      : `HTTP request failed: ${err instanceof Error ? err.message : String(err)}`;
+    await ctx.onLog("stderr", `[otto-agent] ERROR: ${errorMessage}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: isTimeout,
+      errorMessage,
+      errorCode: isTimeout ? "TIMEOUT" : "HTTP_ERROR",
+    };
+  }
+
+  clearTimeout(timer);
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    const errorMessage = `HTTP ${response.status}: ${response.statusText}${body ? ` — ${body.slice(0, 500)}` : ""}`;
+    await ctx.onLog("stderr", `[otto-agent] ERROR: ${errorMessage}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage,
+      errorCode: `HTTP_${response.status}`,
+    };
+  }
+
+  let result: OttoResponse;
+  try {
+    result = (await response.json()) as OttoResponse;
+  } catch {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: "Failed to parse response JSON from Otto gateway",
+      errorCode: "PARSE_ERROR",
+    };
+  }
+
+  await ctx.onLog(
+    "stdout",
+    `[otto-agent] response ok — session=${result.sessionId ?? "none"}\n`,
+  );
+  if (result.summary) {
+    await ctx.onLog("stdout", result.summary + "\n");
+  }
+
+  if (!result.ok) {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: result.errorMessage ?? "Remote Otto Agent returned an error",
+      errorCode: result.errorCode ?? "AGENT_ERROR",
+      summary: result.summary ?? null,
+      sessionId: result.sessionId,
+      sessionDisplayId: result.sessionDisplayId,
+      usage: result.usage,
+      model: result.model,
+      provider: result.provider,
+    };
+  }
+
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    summary: result.summary ?? null,
+    sessionId: result.sessionId,
+    sessionDisplayId: result.sessionDisplayId ?? result.sessionId,
+    usage: result.usage,
+    model: result.model,
+    provider: result.provider,
+    billingType: "subscription",
+    costUsd: result.costUsd ?? null,
+  };
+}

--- a/packages/adapters/otto-agent/src/server/execute.ts
+++ b/packages/adapters/otto-agent/src/server/execute.ts
@@ -2,7 +2,7 @@ import type {
   AdapterExecutionContext,
   AdapterExecutionResult,
 } from "@paperclipai/adapter-utils";
-import { asString, asNumber, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import { asNumber, asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
 
 type OttoAgentConfig = {
   url: string;
@@ -52,12 +52,25 @@ type OttoResponse = {
 function resolveConfig(ctx: AdapterExecutionContext): OttoAgentConfig {
   const raw = parseObject(ctx.config);
   const url = asString(raw.url, "").trim();
+
   if (!url) {
     throw new Error(
       "otto_agent adapter requires 'url' in adapterConfig. Contact your Otto operator for your endpoint.",
     );
   }
+
+  const parsedUrl = new URL(url);
+  if (
+    parsedUrl.protocol === "http:" &&
+    !["localhost", "127.0.0.1", "::1"].includes(parsedUrl.hostname)
+  ) {
+    throw new Error(
+      "otto_agent adapter: plaintext HTTP is not permitted for remote hosts. Use https://.",
+    );
+  }
+
   const apiKey = asString(raw.apiKey, "").trim() || undefined;
+
   return {
     url,
     apiKey,
@@ -65,19 +78,22 @@ function resolveConfig(ctx: AdapterExecutionContext): OttoAgentConfig {
     provider: asString(raw.provider, "").trim() || undefined,
     timeoutSec: asNumber(raw.timeoutSec, 1800),
     toolsets: asString(raw.toolsets, "").trim() || undefined,
-    env: typeof raw.env === "object" && raw.env !== null && !Array.isArray(raw.env)
-      ? (raw.env as Record<string, string>)
-      : undefined,
+    env:
+      typeof raw.env === "object" && raw.env !== null && !Array.isArray(raw.env)
+        ? (raw.env as Record<string, string>)
+        : undefined,
   };
 }
 
 function buildPrompt(ctx: AdapterExecutionContext): string {
   const parts: string[] = [];
   const c = parseObject(ctx.context);
+
   if (c.prompt) parts.push(String(c.prompt));
   if (c.instructions) parts.push(String(c.instructions));
   if (c.wakeText) parts.push(String(c.wakeText));
   if (parts.length === 0) parts.push(JSON.stringify(ctx.context, null, 2));
+
   return parts.join("\n\n");
 }
 
@@ -143,7 +159,9 @@ export async function execute(
     const errorMessage = isTimeout
       ? `Request timed out after ${config.timeoutSec}s`
       : `HTTP request failed: ${err instanceof Error ? err.message : String(err)}`;
+
     await ctx.onLog("stderr", `[otto-agent] ERROR: ${errorMessage}\n`);
+
     return {
       exitCode: 1,
       signal: null,
@@ -156,9 +174,11 @@ export async function execute(
   clearTimeout(timer);
 
   if (!response.ok) {
-    const body = await response.text().catch(() => "");
-    const errorMessage = `HTTP ${response.status}: ${response.statusText}${body ? ` — ${body.slice(0, 500)}` : ""}`;
+    const responseBody = await response.text().catch(() => "");
+    const errorMessage = `HTTP ${response.status}: ${response.statusText}${responseBody ? ` — ${responseBody.slice(0, 500)}` : ""}`;
+
     await ctx.onLog("stderr", `[otto-agent] ERROR: ${errorMessage}\n`);
+
     return {
       exitCode: 1,
       signal: null,
@@ -185,6 +205,7 @@ export async function execute(
     "stdout",
     `[otto-agent] response ok — session=${result.sessionId ?? "none"}\n`,
   );
+
   if (result.summary) {
     await ctx.onLog("stdout", result.summary + "\n");
   }
@@ -215,7 +236,7 @@ export async function execute(
     usage: result.usage,
     model: result.model,
     provider: result.provider,
-    billingType: "subscription",
+    billingType: "subscription_included",
     costUsd: result.costUsd ?? null,
   };
 }

--- a/packages/adapters/otto-agent/src/server/index.ts
+++ b/packages/adapters/otto-agent/src/server/index.ts
@@ -1,0 +1,2 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";

--- a/packages/adapters/otto-agent/src/server/test.ts
+++ b/packages/adapters/otto-agent/src/server/test.ts
@@ -1,0 +1,136 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+function summarizeStatus(
+  checks: AdapterEnvironmentCheck[],
+): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const url = asString(config.url, "").trim();
+
+  if (!url) {
+    checks.push({
+      code: "otto_agent_url_missing",
+      level: "error",
+      message: "No gateway URL configured.",
+      hint: "Set adapterConfig.url to your Otto Agent HTTPS endpoint. Contact your Otto operator for credentials.",
+    });
+    return {
+      adapterType: ctx.adapterType,
+      status: "fail",
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  }
+
+  let parsed: URL | null = null;
+  try {
+    parsed = new URL(url);
+  } catch {
+    checks.push({
+      code: "otto_agent_url_invalid",
+      level: "error",
+      message: `Invalid URL: ${url}`,
+    });
+    return {
+      adapterType: ctx.adapterType,
+      status: "fail",
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    checks.push({
+      code: "otto_agent_url_protocol_invalid",
+      level: "error",
+      message: `Unsupported URL protocol: ${parsed.protocol}`,
+      hint: "Use https:// for remote Otto Agent gateways.",
+    });
+  } else {
+    checks.push({
+      code: "otto_agent_url_ok",
+      level: "info",
+      message: `Gateway URL configured.`,
+    });
+
+    if (
+      parsed.protocol === "http:" &&
+      !["localhost", "127.0.0.1", "::1"].includes(parsed.hostname)
+    ) {
+      checks.push({
+        code: "otto_agent_url_plaintext",
+        level: "error",
+        message: "Plaintext HTTP is not permitted for remote Otto Agent gateways.",
+        hint: "Use https:// — credentials sent over plaintext HTTP are not secure.",
+      });
+    }
+  }
+
+  const apiKey = asString(config.apiKey, "").trim();
+  if (!apiKey) {
+    checks.push({
+      code: "otto_agent_apikey_missing",
+      level: "error",
+      message: "No API key configured.",
+      hint: "Set adapterConfig.apiKey to the Bearer token issued by your Otto operator.",
+    });
+  } else {
+    checks.push({
+      code: "otto_agent_apikey_ok",
+      level: "info",
+      message: "API key configured.",
+    });
+  }
+
+  const hasErrors = checks.some((c) => c.level === "error");
+  if (!hasErrors) {
+    try {
+      const healthUrl = url.replace(/\/api\/paperclip\/?$/, "/health").replace(/\/$/, "") || url;
+      const res = await fetch(healthUrl, {
+        method: "GET",
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (res.ok) {
+        checks.push({
+          code: "otto_agent_gateway_reachable",
+          level: "info",
+          message: `Gateway responded with HTTP ${res.status}.`,
+        });
+      } else {
+        checks.push({
+          code: "otto_agent_gateway_error",
+          level: "warn",
+          message: `Gateway responded with HTTP ${res.status}.`,
+          hint: "Verify the URL and that the Otto Agent gateway is running.",
+        });
+      }
+    } catch (err) {
+      checks.push({
+        code: "otto_agent_gateway_unreachable",
+        level: "warn",
+        message: `Could not reach gateway: ${err instanceof Error ? err.message : String(err)}`,
+        hint: "Verify the URL, firewall rules, and that the Otto Agent gateway is running.",
+      });
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/otto-agent/src/ui/build-config.ts
+++ b/packages/adapters/otto-agent/src/ui/build-config.ts
@@ -3,8 +3,7 @@ import type { CreateConfigValues } from "@paperclipai/adapter-utils";
 export function buildOttoAgentConfig(v: CreateConfigValues): Record<string, unknown> {
   const ac: Record<string, unknown> = {};
   if (v.url) ac.url = v.url;
-  // apiKey is intentionally not set here — operators must supply it via
-  // their deployment secrets, never via the UI form directly.
+  if (v.apiKey) ac.apiKey = v.apiKey;
   ac.timeoutSec = 1800;
   return ac;
 }

--- a/packages/adapters/otto-agent/src/ui/build-config.ts
+++ b/packages/adapters/otto-agent/src/ui/build-config.ts
@@ -1,0 +1,10 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+export function buildOttoAgentConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.url) ac.url = v.url;
+  // apiKey is intentionally not set here — operators must supply it via
+  // their deployment secrets, never via the UI form directly.
+  ac.timeoutSec = 1800;
+  return ac;
+}

--- a/packages/adapters/otto-agent/src/ui/index.ts
+++ b/packages/adapters/otto-agent/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { buildOttoAgentConfig } from "./build-config.js";
+export { parseOttoAgentStdoutLine } from "./parse-stdout.js";

--- a/packages/adapters/otto-agent/src/ui/parse-stdout.ts
+++ b/packages/adapters/otto-agent/src/ui/parse-stdout.ts
@@ -1,0 +1,56 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a stdout line emitted by the otto_agent server adapter.
+ * Lines prefixed with [otto-agent:event] carry structured JSON.
+ * Lines prefixed with [otto-agent] are system messages.
+ * Everything else passes through as raw stdout.
+ */
+export function parseOttoAgentStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith("[otto-agent:event]")) {
+    const match = trimmed.match(/^\[otto-agent:event\]\s+stream=(\S+)\s+data=(.*)$/s);
+    if (!match) return [{ kind: "stdout", ts, text: line }];
+
+    const stream = String(match[1]).toLowerCase();
+    const data = asRecord(safeJsonParse(String(match[2]).trim()));
+
+    if (stream === "assistant") {
+      const delta = typeof data?.delta === "string" ? data.delta : "";
+      if (delta.length > 0) return [{ kind: "assistant", ts, text: delta, delta: true }];
+      const text = typeof data?.text === "string" ? data.text : "";
+      if (text.length > 0) return [{ kind: "assistant", ts, text }];
+      return [];
+    }
+
+    if (stream === "error") {
+      const message =
+        (typeof data?.error === "string" ? data.error : "") ||
+        (typeof data?.message === "string" ? data.message : "");
+      return message ? [{ kind: "stderr", ts, text: message }] : [];
+    }
+
+    return [];
+  }
+
+  if (trimmed.startsWith("[otto-agent]")) {
+    return [{ kind: "system", ts, text: trimmed.replace(/^\[otto-agent\]\s*/, "") }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/otto-agent/tsconfig.json
+++ b/packages/adapters/otto-agent/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -34,6 +34,7 @@ export const AGENT_ADAPTER_TYPES = [
   "pi_local",
   "cursor",
   "openclaw_gateway",
+  "otto_agent",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & {});
 

--- a/server/package.json
+++ b/server/package.json
@@ -49,6 +49,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
+    "@paperclipai/adapter-otto-agent": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -55,6 +55,14 @@ import {
   agentConfigurationDoc as openclawGatewayAgentConfigurationDoc,
   models as openclawGatewayModels,
 } from "@paperclipai/adapter-openclaw-gateway";
+import {
+  execute as ottoAgentExecute,
+  testEnvironment as ottoAgentTestEnvironment,
+} from "@paperclipai/adapter-otto-agent/server";
+import {
+  agentConfigurationDoc as ottoAgentConfigurationDoc,
+  models as ottoAgentModels,
+} from "@paperclipai/adapter-otto-agent";
 import { listCodexModels } from "./codex-models.js";
 import { listCursorModels } from "./cursor-models.js";
 import {
@@ -197,6 +205,17 @@ const openclawGatewayAdapter: ServerAdapterModule = {
   agentConfigurationDoc: openclawGatewayAgentConfigurationDoc,
 };
 
+const ottoAgentAdapter: ServerAdapterModule = {
+  type: "otto_agent",
+  execute: ottoAgentExecute,
+  testEnvironment: ottoAgentTestEnvironment,
+  models: ottoAgentModels,
+  supportsLocalAgentJwt: false,
+  supportsInstructionsBundle: false,
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: ottoAgentConfigurationDoc,
+};
+
 const openCodeLocalAdapter: ServerAdapterModule = {
   type: "opencode_local",
   execute: openCodeExecute,
@@ -266,6 +285,7 @@ function registerBuiltInAdapters() {
     cursorLocalAdapter,
     geminiLocalAdapter,
     openclawGatewayAdapter,
+    ottoAgentAdapter,
     hermesLocalAdapter,
     processAdapter,
     httpAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,6 +39,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
+    "@paperclipai/adapter-otto-agent": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",

--- a/ui/src/adapters/otto-agent/config-fields.tsx
+++ b/ui/src/adapters/otto-agent/config-fields.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import type { AdapterConfigFieldsProps } from "../types";
+import { Field, DraftInput, help } from "../../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+function SecretField({
+  label,
+  value,
+  onCommit,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onCommit: (v: string) => void;
+  placeholder?: string;
+}) {
+  const [visible, setVisible] = useState(false);
+  return (
+    <Field label={label}>
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+        >
+          {visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+        </button>
+        <DraftInput
+          value={value}
+          onCommit={onCommit}
+          immediate
+          type={visible ? "text" : "password"}
+          className={inputClass + " pl-8"}
+          placeholder={placeholder}
+        />
+      </div>
+    </Field>
+  );
+}
+
+export function OttoAgentConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <div className="space-y-3">
+      <Field label="Gateway URL" hint={help.webhookUrl}>
+        <DraftInput
+          value={
+            isCreate
+              ? values!.url ?? ""
+              : eff("adapterConfig", "url", String(config.url ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate ? set!({ url: v }) : mark("adapterConfig", "url", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="https://your-otto-gateway/api/paperclip"
+        />
+      </Field>
+
+      <SecretField
+        label="API Key"
+        value={
+          isCreate
+            ? values!.apiKey ?? ""
+            : eff("adapterConfig", "apiKey", String(config.apiKey ?? ""))
+        }
+        onCommit={(v) =>
+          isCreate
+            ? set!({ apiKey: v })
+            : mark("adapterConfig", "apiKey", v || undefined)
+        }
+        placeholder="Issued by your Otto operator — keep this secret"
+      />
+
+      {!isCreate && (
+        <>
+          <Field label="Model override">
+            <DraftInput
+              value={eff("adapterConfig", "model", String(config.model ?? ""))}
+              onCommit={(v) => mark("adapterConfig", "model", v || undefined)}
+              immediate
+              className={inputClass}
+              placeholder="e.g. copilot/claude-sonnet-4-5 (leave blank for gateway default)"
+            />
+          </Field>
+
+          <Field label="Toolsets (comma-separated)">
+            <DraftInput
+              value={eff("adapterConfig", "toolsets", String(config.toolsets ?? ""))}
+              onCommit={(v) => mark("adapterConfig", "toolsets", v || undefined)}
+              immediate
+              className={inputClass}
+              placeholder="e.g. web,terminal (leave blank for all)"
+            />
+          </Field>
+
+          <Field label="Timeout (seconds)">
+            <DraftInput
+              value={String(eff("adapterConfig", "timeoutSec", config.timeoutSec ?? 1800))}
+              onCommit={(v) =>
+                mark("adapterConfig", "timeoutSec", v ? Number(v) : undefined)
+              }
+              immediate
+              className={inputClass}
+              placeholder="1800"
+            />
+          </Field>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/adapters/otto-agent/index.ts
+++ b/ui/src/adapters/otto-agent/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseOttoAgentStdoutLine } from "@paperclipai/adapter-otto-agent/ui";
+import { buildOttoAgentConfig } from "@paperclipai/adapter-otto-agent/ui";
+import { OttoAgentConfigFields } from "./config-fields";
+
+export const ottoAgentUIAdapter: UIAdapterModule = {
+  type: "otto_agent",
+  label: "Otto Agent",
+  parseStdoutLine: parseOttoAgentStdoutLine,
+  ConfigFields: OttoAgentConfigFields,
+  buildAdapterConfig: buildOttoAgentConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -9,6 +9,7 @@ import { openClawGatewayUIAdapter } from "./openclaw-gateway";
 import { hermesLocalUIAdapter } from "./hermes-local";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
+import { ottoAgentUIAdapter } from "./otto-agent";
 import { loadDynamicParser, invalidateDynamicParser } from "./dynamic-loader";
 import { SchemaConfigFields, buildSchemaAdapterConfig } from "./schema-config-fields";
 
@@ -55,6 +56,7 @@ function registerBuiltInUIAdapters() {
     piLocalUIAdapter,
     cursorLocalUIAdapter,
     openClawGatewayUIAdapter,
+    ottoAgentUIAdapter,
     processUIAdapter,
     httpUIAdapter,
   ]) {


### PR DESCRIPTION
Adds otto_agent as a built-in adapter for routing Paperclip runs to a remote Otto gateway over HTTPS.

What’s included

- packages/adapters/otto-agent
  - server execute path for POSTing to the Otto /api/paperclip endpoint
  - environment test for URL/API key validation and gateway reachability
  - UI config builder and stdout parser
  - package exports aligned to dist/* for publish safety
- ui/src/adapters/otto-agent
  - UI registration
  - config fields for gateway URL, API key, model override, toolsets, timeout
- registry wiring
  - server adapter registry
  - UI adapter registry
  - shared adapter type constant
- workspace dependency wiring
  - server/package.json
  - ui/package.json

Security

- no Otto endpoint URLs or credentials are embedded in source
- adapter credentials are operator-supplied at runtime via adapter config
- plaintext HTTP is rejected for non-loopback hosts in both validation and execution paths
- API key entered during create is persisted correctly
- requests use bearer auth only when an API key is configured

Review fixes included

- enforce HTTPS at runtime, not only in environment test
- change billing type to subscription_included
- persist apiKey on create
- point package exports at dist/* instead of src/*