### PR TITLE
Fix company skill import reimport lifecycle

### DIFF
--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -1185,51 +1185,54 @@ describeEmbeddedPostgres("companySkillService.list", () => {
       throw new Error(`Unexpected fetch ${url}`);
     });
     vi.stubGlobal("fetch", fetchMock);
+    try {
+      // Step 1: Initial import
+      const importResult1 = await svc.importFromSource(companyId, { source });
+      expect(importResult1.imported).toHaveLength(1);
+      const skill1 = importResult1.imported[0]!;
+      expect(skill1.key).toBe("testorg/testrepo/test-skill");
+      expect(skill1.slug).toBe("test-skill");
+      expect(skill1.name).toBe("Test Skill");
+      expect(skill1.sourceRef).toBe(initialSha);
+      expect(skill1.markdown).toContain("Test Skill Initial");
 
-    // Step 1: Initial import
-    const importResult1 = await svc.importFromSource(companyId, { source });
-    expect(importResult1.imported).toHaveLength(1);
-    const skill1 = importResult1.imported[0]!;
-    expect(skill1.key).toBe("testorg/testrepo/test-skill");
-    expect(skill1.slug).toBe("test-skill");
-    expect(skill1.name).toBe("Test Skill");
-    expect(skill1.sourceRef).toBe(initialSha);
-    expect(skill1.markdown).toContain("Test Skill Initial");
+      // Step 2: Re-import same source (simulating update)
+      const importResult2 = await svc.importFromSource(companyId, { source });
+      expect(importResult2.imported).toHaveLength(1);
+      const skill2 = importResult2.imported[0]!;
 
-    // Step 2: Re-import same source (simulating update)
-    const importResult2 = await svc.importFromSource(companyId, { source });
-    expect(importResult2.imported).toHaveLength(1);
-    const skill2 = importResult2.imported[0]!;
-    
-    // Should update existing skill, not create new one
-    expect(skill2.id).toBe(skill1.id);
-    expect(skill2.key).toBe("testorg/testrepo/test-skill");
-    expect(skill2.sourceRef).toBe(updatedSha);
-    expect(skill2.markdown).toContain("Test Skill Updated");
+      // Should update existing skill, not create new one
+      expect(skill2.id).toBe(skill1.id);
+      expect(skill2.key).toBe("testorg/testrepo/test-skill");
+      expect(skill2.sourceRef).toBe(updatedSha);
+      expect(skill2.markdown).toContain("Test Skill Updated");
 
-    // Step 3: Delete skill
-    const deleted = await svc.deleteSkill(companyId, skill1.id);
-    expect(deleted).toBeTruthy();
-    expect(deleted!.id).toBe(skill1.id);
+      // Step 3: Delete skill
+      const deleted = await svc.deleteSkill(companyId, skill1.id);
+      expect(deleted).toBeTruthy();
+      expect(deleted!.id).toBe(skill1.id);
 
-    // Step 4: Re-import after deletion (this should NOT throw duplicate key error)
-    const importResult3 = await svc.importFromSource(companyId, { source });
-    expect(importResult3.imported).toHaveLength(1);
-    const skill3 = importResult3.imported[0]!;
-    
-    // Should create new skill (different ID from original)
-    expect(skill3.id).not.toBe(skill1.id);
-    expect(skill3.key).toBe("testorg/testrepo/test-skill");
-    expect(skill3.slug).toBe("test-skill");
-    expect(skill3.sourceRef).toBe(updatedSha);
+      // Step 4: Re-import after deletion (this should NOT throw duplicate key error)
+      const importResult3 = await svc.importFromSource(companyId, { source });
+      expect(importResult3.imported).toHaveLength(1);
+      const skill3 = importResult3.imported[0]!;
 
-    // Verify no duplicate key constraint violation occurred
-    const allSkills = await db
-      .select()
-      .from(companySkills)
-      .where(eq(companySkills.companyId, companyId));
-    const testSkills = allSkills.filter((s) => s.key === "testorg/testrepo/test-skill");
-    expect(testSkills).toHaveLength(1);
-    expect(testSkills[0]!.id).toBe(skill3.id);
+      // Should create new skill (different ID from original)
+      expect(skill3.id).not.toBe(skill1.id);
+      expect(skill3.key).toBe("testorg/testrepo/test-skill");
+      expect(skill3.slug).toBe("test-skill");
+      expect(skill3.sourceRef).toBe(updatedSha);
+
+      // Verify no duplicate key constraint violation occurred
+      const allSkills = await db
+        .select()
+        .from(companySkills)
+        .where(eq(companySkills.companyId, companyId));
+      const testSkills = allSkills.filter((s) => s.key === "testorg/testrepo/test-skill");
+      expect(testSkills).toHaveLength(1);
+      expect(testSkills[0]!.id).toBe(skill3.id);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { promises as fs } from "node:fs";
+import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   companies,
@@ -1114,5 +1115,121 @@ describeEmbeddedPostgres("companySkillService.list", () => {
     await expect(svc.listGitHubCredentialAssociations(companyId, { hostname: "gist.github.com" })).resolves.toMatchObject([
       { hostname: "github.com", owner: "acme", secretId: secret.id },
     ]);
+  });
+
+  it("supports import → update → delete → re-import lifecycle without duplicate key errors", async () => {
+    const companyId = randomUUID();
+    const initialSha = "abc123initial";
+    const updatedSha = "def456updated";
+    const source = "https://github.com/testorg/testrepo";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Test Company",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    // Mock GitHub API responses
+    let commitCallCount = 0;
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      
+      if (url === "https://api.github.com/repos/testorg/testrepo") {
+        return new Response(JSON.stringify({ default_branch: "main" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      
+      if (url === "https://api.github.com/repos/testorg/testrepo/commits/main") {
+        // Return initial SHA on first import, updated SHA on re-imports
+        commitCallCount++;
+        const sha = commitCallCount <= 1 ? initialSha : updatedSha;
+        return new Response(JSON.stringify({ sha }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      
+      if (url === `https://api.github.com/repos/testorg/testrepo/git/trees/${initialSha}?recursive=1`) {
+        return new Response(JSON.stringify({
+          tree: [
+            { path: "test-skill/SKILL.md", type: "blob" },
+          ],
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      
+      if (url === `https://api.github.com/repos/testorg/testrepo/git/trees/${updatedSha}?recursive=1`) {
+        return new Response(JSON.stringify({
+          tree: [
+            { path: "test-skill/SKILL.md", type: "blob" },
+          ],
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      
+      if (url === `https://raw.githubusercontent.com/testorg/testrepo/${initialSha}/test-skill/SKILL.md`) {
+        return new Response("---\nslug: test-skill\nname: Test Skill\n---\n# Test Skill Initial\n", { status: 200 });
+      }
+      
+      if (url === `https://raw.githubusercontent.com/testorg/testrepo/${updatedSha}/test-skill/SKILL.md`) {
+        return new Response("---\nslug: test-skill\nname: Test Skill\n---\n# Test Skill Updated\n", { status: 200 });
+      }
+      
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Step 1: Initial import
+    const importResult1 = await svc.importFromSource(companyId, { source });
+    expect(importResult1.imported).toHaveLength(1);
+    const skill1 = importResult1.imported[0]!;
+    expect(skill1.key).toBe("testorg/testrepo/test-skill");
+    expect(skill1.slug).toBe("test-skill");
+    expect(skill1.name).toBe("Test Skill");
+    expect(skill1.sourceRef).toBe(initialSha);
+    expect(skill1.markdown).toContain("Test Skill Initial");
+
+    // Step 2: Re-import same source (simulating update)
+    const importResult2 = await svc.importFromSource(companyId, { source });
+    expect(importResult2.imported).toHaveLength(1);
+    const skill2 = importResult2.imported[0]!;
+    
+    // Should update existing skill, not create new one
+    expect(skill2.id).toBe(skill1.id);
+    expect(skill2.key).toBe("testorg/testrepo/test-skill");
+    expect(skill2.sourceRef).toBe(updatedSha);
+    expect(skill2.markdown).toContain("Test Skill Updated");
+
+    // Step 3: Delete skill
+    const deleted = await svc.deleteSkill(companyId, skill1.id);
+    expect(deleted).toBeTruthy();
+    expect(deleted!.id).toBe(skill1.id);
+
+    // Step 4: Re-import after deletion (this should NOT throw duplicate key error)
+    const importResult3 = await svc.importFromSource(companyId, { source });
+    expect(importResult3.imported).toHaveLength(1);
+    const skill3 = importResult3.imported[0]!;
+    
+    // Should create new skill (different ID from original)
+    expect(skill3.id).not.toBe(skill1.id);
+    expect(skill3.key).toBe("testorg/testrepo/test-skill");
+    expect(skill3.slug).toBe("test-skill");
+    expect(skill3.sourceRef).toBe(updatedSha);
+
+    // Verify no duplicate key constraint violation occurred
+    const allSkills = await db
+      .select()
+      .from(companySkills)
+      .where(eq(companySkills.companyId, companyId));
+    const testSkills = allSkills.filter((s) => s.key === "testorg/testrepo/test-skill");
+    expect(testSkills).toHaveLength(1);
+    expect(testSkills[0]!.id).toBe(skill3.id);
   });
 });

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2628,7 +2628,11 @@ export function companySkillService(db: Db) {
   ): Promise<CompanySkill[]> {
     const out: CompanySkill[] = [];
     for (const skill of imported) {
-      const existing = await getByKey(companyId, skill.key);
+      const existing = await dbOrTx
+        .select()
+        .from(companySkills)
+        .where(and(eq(companySkills.companyId, companyId), eq(companySkills.key, skill.key)))
+        .then((rows) => rows[0] ? toCompanySkill(rows[0]) : null);
       const existingMeta = existing ? getSkillMeta(existing) : {};
       const incomingMeta = skill.metadata && isPlainRecord(skill.metadata) ? skill.metadata : {};
       const incomingOwner = asString(incomingMeta.owner);

--- a/tests/e2e/company-skills.spec.ts
+++ b/tests/e2e/company-skills.spec.ts
@@ -16,6 +16,9 @@ const COMPANY_NAME = `E2E Skills ${TEST_SUFFIX}`;
 const SKILL_NAME = `E2E Test Skill ${TEST_SUFFIX}`;
 const SKILL_SLUG = `e2e-test-skill-${TEST_SUFFIX}`;
 const SKILL_DESCRIPTION = `A test skill created by E2E automation ${TEST_SUFFIX}`;
+const IMPORTED_SKILL_SLUG = "doc-maintenance";
+const IMPORTED_SKILL_SOURCE =
+  "https://github.com/zesthq/bizbox/tree/master/.agents/skills/doc-maintenance";
 
 type Company = {
   id: string;
@@ -27,7 +30,8 @@ type Company = {
 // ---------------------------------------------------------------------------
 
 test.describe("Company Skills", () => {
-  let company: Company;
+  let company!: Company;
+  let companyIdForCleanup: string | null = null;
 
   test.beforeEach(async ({ page }) => {
     // Navigate to root to initialize page context, then create company via API
@@ -47,6 +51,7 @@ test.describe("Company Skills", () => {
       id: companyData.id,
       prefix: companyData.issuePrefix ?? companyData.id,
     };
+    companyIdForCleanup = company.id;
 
     // The UI company list is loaded before this out-of-band API setup runs.
     // Reload so route-prefix resolution and company-scoped queries target the
@@ -55,13 +60,18 @@ test.describe("Company Skills", () => {
     await page.waitForLoadState("networkidle");
   });
 
+  test.afterEach(async ({ page }) => {
+    if (!companyIdForCleanup) {
+      return;
+    }
+
+    await page.request.delete(`/api/companies/${companyIdForCleanup}`);
+    companyIdForCleanup = null;
+  });
+
   test("supports skill delete → re-import lifecycle with same slug", async ({ page }) => {
     // This test verifies the fix for the duplicate key constraint bug
     // that occurred when re-importing a skill with the same slug after deletion.
-
-    // Use a GitHub skill source that we can import multiple times
-    // Using anthropics/skills/pdf as a stable public test fixture
-    const skillSource = "https://github.com/anthropics/skills/tree/main/skills/pdf";
 
     // Navigate to Skills page
     await page.goto(`/${company.prefix}/skills`);
@@ -80,7 +90,7 @@ test.describe("Company Skills", () => {
     const sourceInput = skillsSidebar.getByPlaceholder(/Paste path, GitHub URL, or skills\.sh command/i);
     await expect(sourceInput).toBeVisible({ timeout: 5_000 });
     await expect(sourceInput).toBeEditable({ timeout: 5_000 });
-    await sourceInput.fill(skillSource);
+    await sourceInput.fill(IMPORTED_SKILL_SOURCE);
 
     const addButton = skillsSidebar.getByRole("button", { name: "Add" });
     await expect(addButton).toBeVisible({ timeout: 5_000 });
@@ -91,7 +101,7 @@ test.describe("Company Skills", () => {
     // The page may already be on another skill detail route before import.
     // Wait for the imported skill title and a URL change before capturing the id.
     await expect(
-      mainContent.getByRole("heading", { level: 1, name: "pdf", exact: true })
+      mainContent.getByRole("heading", { level: 1, name: IMPORTED_SKILL_SLUG, exact: true })
     ).toBeVisible({ timeout: 15_000 });
     await expect.poll(() => page.url(), { timeout: 15_000 }).not.toBe(detailUrlBeforeImport);
     await expect(page).toHaveURL(new RegExp(`/${company.prefix}/skills/[0-9a-f-]+$`), {
@@ -148,7 +158,7 @@ test.describe("Company Skills", () => {
     // Ensure the input is ready, then fill it (fill() automatically clears first)
     await expect(sourceInput).toBeVisible({ timeout: 5_000 });
     await expect(sourceInput).toBeEditable({ timeout: 5_000 });
-    await sourceInput.fill(skillSource);
+    await sourceInput.fill(IMPORTED_SKILL_SOURCE);
 
     await expect(addButton).toBeVisible({ timeout: 5_000 });
     await expect(addButton).toBeEnabled({ timeout: 5_000 });
@@ -156,7 +166,7 @@ test.describe("Company Skills", () => {
     await addButton.click();
     
     await expect(
-      mainContent.getByRole("heading", { level: 1, name: "pdf", exact: true })
+      mainContent.getByRole("heading", { level: 1, name: IMPORTED_SKILL_SLUG, exact: true })
     ).toBeVisible({ timeout: 15_000 });
     await expect.poll(() => page.url(), { timeout: 15_000 }).not.toBe(detailUrlBeforeReimport);
     await expect(page).toHaveURL(new RegExp(`/${company.prefix}/skills/[0-9a-f-]+$`), {
@@ -169,17 +179,17 @@ test.describe("Company Skills", () => {
     // Verify different skill ID (new import creates new record)
     expect(skillId2).not.toBe(skillId1);
 
-    // Verify the skill with slug 'pdf' exists and is the new one
+    // Verify the imported skill exists and is the new one
     const allSkillsRes = await page.request.get(
       `/api/companies/${company.id}/skills`
     );
     expect(allSkillsRes.ok()).toBe(true);
     const allSkills = await allSkillsRes.json();
-    const pdfSkills = allSkills.filter(
-      (s: { slug: string }) => s.slug === "pdf"
+    const importedSkills = allSkills.filter(
+      (s: { slug: string }) => s.slug === IMPORTED_SKILL_SLUG
     );
-    expect(pdfSkills.length).toBe(1);
-    expect(pdfSkills[0].id).toBe(skillId2);
+    expect(importedSkills.length).toBe(1);
+    expect(importedSkills[0].id).toBe(skillId2);
   });
 
   test("creates a new skill via the form", async ({ page }) => {

--- a/tests/e2e/company-skills.spec.ts
+++ b/tests/e2e/company-skills.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type APIRequestContext } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 /**
  * E2E: Company Skills flow.

--- a/tests/e2e/company-skills.spec.ts
+++ b/tests/e2e/company-skills.spec.ts
@@ -1,73 +1,190 @@
-import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
+import { test, expect, type Page, type APIRequestContext } from "@playwright/test";
 
 /**
  * E2E: Company Skills flow.
  *
  * Covers:
- *   1. Create an isolated company for the test
- *   2. Open the company Skills page
- *   3. Create a local editable skill from the sidebar form
- *   4. Verify the detail pane opens for the new skill
- *   5. Verify the skill exists through the company skills API
- *   6. Verify the generated SKILL.md content
+ *   1. Create a company (via API for setup)
+ *   2. Navigate to Skills page via UI
+ *   3. Create skills via UI
+ *   4. Delete skills via UI
+ *   5. Test delete → re-create lifecycle with same slug (bug fix verification)
  */
 
-const STORAGE_KEY = "paperclip.selectedCompanyId";
 const TEST_SUFFIX = Date.now();
 const COMPANY_NAME = `E2E Skills ${TEST_SUFFIX}`;
 const SKILL_NAME = `E2E Test Skill ${TEST_SUFFIX}`;
 const SKILL_SLUG = `e2e-test-skill-${TEST_SUFFIX}`;
 const SKILL_DESCRIPTION = `A test skill created by E2E automation ${TEST_SUFFIX}`;
 
-type CreatedCompany = {
+type Company = {
   id: string;
-  issuePrefix: string;
+  prefix: string;
 };
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-async function createCompany(
-  request: APIRequestContext,
-  name: string
-): Promise<CreatedCompany> {
-  const companyRes = await request.post("/api/companies", {
-    data: { name },
-  });
-  if (!companyRes.ok()) {
-    const errText = await companyRes.text();
-    throw new Error(
-      `Failed to create company (${companyRes.status()}): ${errText}`
-    );
-  }
-
-  const company = await companyRes.json();
-  return {
-    id: company.id,
-    issuePrefix: company.issuePrefix,
-  };
-}
-
-async function selectCompany(page: Page, companyId: string): Promise<void> {
-  await page.addInitScript(
-    ([storageKey, selectedCompanyId]) => {
-      window.localStorage.setItem(storageKey, selectedCompanyId);
-    },
-    [STORAGE_KEY, companyId]
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 test.describe("Company Skills", () => {
-  test("creates a new skill via the form", async ({ page }) => {
-    const company = await createCompany(page.request, COMPANY_NAME);
-    await selectCompany(page, company.id);
+  let company: Company;
 
-    await page.goto(`/${company.issuePrefix}/skills`);
+  test.beforeEach(async ({ page }) => {
+    // Navigate to root to initialize page context, then create company via API
+    await page.goto("/");
+
+    const createRes = await page.request.post("/api/companies", {
+      data: { name: COMPANY_NAME },
+    });
+
+    if (!createRes.ok()) {
+      const errText = await createRes.text();
+      throw new Error(`Failed to create company (${createRes.status()}): ${errText}`);
+    }
+
+    const companyData = await createRes.json();
+    company = {
+      id: companyData.id,
+      prefix: companyData.issuePrefix ?? companyData.id,
+    };
+
+    // The UI company list is loaded before this out-of-band API setup runs.
+    // Reload so route-prefix resolution and company-scoped queries target the
+    // newly created company instead of stale client state.
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("supports skill delete → re-import lifecycle with same slug", async ({ page }) => {
+    // This test verifies the fix for the duplicate key constraint bug
+    // that occurred when re-importing a skill with the same slug after deletion.
+
+    // Use a GitHub skill source that we can import multiple times
+    // Using anthropics/skills/pdf as a stable public test fixture
+    const skillSource = "https://github.com/anthropics/skills/tree/main/skills/pdf";
+
+    // Navigate to Skills page
+    await page.goto(`/${company.prefix}/skills`);
+    await page.waitForLoadState("networkidle");
+
+    const mainContent = page.locator("#main-content");
+    const skillsSidebar = mainContent.locator("aside");
+
+    await expect(
+      skillsSidebar.getByRole("heading", { name: "Skills", exact: true })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Step 1: Import skill via UI
+    // The import UI has an input field with placeholder "Paste path, GitHub URL, or skills.sh command"
+    // and an "Add" button next to it
+    const sourceInput = skillsSidebar.getByPlaceholder(/Paste path, GitHub URL, or skills\.sh command/i);
+    await expect(sourceInput).toBeVisible({ timeout: 5_000 });
+    await expect(sourceInput).toBeEditable({ timeout: 5_000 });
+    await sourceInput.fill(skillSource);
+
+    const addButton = skillsSidebar.getByRole("button", { name: "Add" });
+    await expect(addButton).toBeVisible({ timeout: 5_000 });
+    await expect(addButton).toBeEnabled({ timeout: 5_000 });
+    const detailUrlBeforeImport = page.url();
+    await addButton.click();
+
+    // The page may already be on another skill detail route before import.
+    // Wait for the imported skill title and a URL change before capturing the id.
+    await expect(
+      mainContent.getByRole("heading", { level: 1, name: "pdf", exact: true })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect.poll(() => page.url(), { timeout: 15_000 }).not.toBe(detailUrlBeforeImport);
+    await expect(page).toHaveURL(new RegExp(`/${company.prefix}/skills/[0-9a-f-]+$`), {
+      timeout: 15_000,
+    });
+
+    // Extract skill ID from URL
+    const skillUrl1 = page.url();
+    const skillId1 = skillUrl1.split("/").pop();
+
+    // Step 2: Delete the imported skill via UI
+    const removeButton = mainContent.locator('button:has-text("Remove")');
+    await expect(removeButton).toBeVisible({ timeout: 5_000 });
+    await expect(removeButton).toBeEnabled({ timeout: 5_000 });
+    await removeButton.click();
+
+    // Confirm deletion in the dialog
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    const confirmButton = dialog.locator('button:has-text("Remove skill")');
+    await expect(confirmButton).toBeVisible({ timeout: 5_000 });
+    await expect(confirmButton).toBeEnabled({ timeout: 5_000 });
+    await confirmButton.click();
+
+    // Wait for dialog to close and deletion to complete
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+    // Wait for network to settle after deletion
+    await page.waitForLoadState('networkidle');
+
+    // Navigate back to skills list
+    await page.goto(`/${company.prefix}/skills`);
+    await page.waitForLoadState("networkidle");
+
+    // Ensure the skills sidebar is loaded before proceeding
+    await expect(
+      skillsSidebar.getByRole("heading", { name: "Skills", exact: true })
+    ).toBeVisible({ timeout: 10_000 });
+    
+    // Verify via API that the skill was actually deleted
+    const skillsAfterDelete = await page.request.get(
+      `/api/companies/${company.id}/skills`
+    );
+    expect(skillsAfterDelete.ok()).toBe(true);
+    const skillsListAfterDelete = await skillsAfterDelete.json();
+    const deletedSkillExists = skillsListAfterDelete.some(
+      (s: { id: string }) => s.id === skillId1
+    );
+    expect(deletedSkillExists).toBe(false);
+
+    // Step 3: Re-import the same skill source via UI
+    // This would previously fail with duplicate key error
+    // Ensure the input is ready, then fill it (fill() automatically clears first)
+    await expect(sourceInput).toBeVisible({ timeout: 5_000 });
+    await expect(sourceInput).toBeEditable({ timeout: 5_000 });
+    await sourceInput.fill(skillSource);
+
+    await expect(addButton).toBeVisible({ timeout: 5_000 });
+    await expect(addButton).toBeEnabled({ timeout: 5_000 });
+    const detailUrlBeforeReimport = page.url();
+    await addButton.click();
+    
+    await expect(
+      mainContent.getByRole("heading", { level: 1, name: "pdf", exact: true })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect.poll(() => page.url(), { timeout: 15_000 }).not.toBe(detailUrlBeforeReimport);
+    await expect(page).toHaveURL(new RegExp(`/${company.prefix}/skills/[0-9a-f-]+$`), {
+      timeout: 15_000,
+    });
+    
+    const skillUrl2 = page.url();
+    const skillId2 = skillUrl2.split("/").pop();
+    
+    // Verify different skill ID (new import creates new record)
+    expect(skillId2).not.toBe(skillId1);
+
+    // Verify the skill with slug 'pdf' exists and is the new one
+    const allSkillsRes = await page.request.get(
+      `/api/companies/${company.id}/skills`
+    );
+    expect(allSkillsRes.ok()).toBe(true);
+    const allSkills = await allSkillsRes.json();
+    const pdfSkills = allSkills.filter(
+      (s: { slug: string }) => s.slug === "pdf"
+    );
+    expect(pdfSkills.length).toBe(1);
+    expect(pdfSkills[0].id).toBe(skillId2);
+  });
+
+  test("creates a new skill via the form", async ({ page }) => {
+    await page.goto(`/${company.prefix}/skills`);
+    await page.waitForLoadState("networkidle");
 
     const mainContent = page.locator("#main-content");
     const skillsSidebar = mainContent.locator("aside");
@@ -90,7 +207,7 @@ test.describe("Company Skills", () => {
 
     await skillsSidebar.getByRole("button", { name: "Create skill" }).click();
 
-    await expect(page).toHaveURL(new RegExp(`/${company.issuePrefix}/skills/[0-9a-f-]+$`), {
+    await expect(page).toHaveURL(new RegExp(`/${company.prefix}/skills/[0-9a-f-]+$`), {
       timeout: 10_000,
     });
 


### PR DESCRIPTION
## Summary
- Fix company skill import matching to scope updates by both company and skill key
- Add a service test for import, update, delete, and re-import without duplicate key errors
- Harden the E2E company skills flow to target the imported skill reliably and avoid stale company selection in setup

## Testing
- `server/src/__tests__/company-skills-service.test.ts`: added lifecycle coverage for re-import after delete
- `tests/e2e/company-skills.spec.ts`: validated the delete → re-import flow with Playwright