### PR TITLE
feat: enhance routine execution handling and testing

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -150,6 +150,10 @@ Blocked issues should stay idle while blockers remain unresolved. Paperclip shou
 
 If a parent is truly waiting on a child, model that with blockers. Do not rely on the parent/child relationship alone.
 
+For `routine_execution` issues, this blocked state is also a healthy parked wait state. Moving a routine execution issue to `blocked` must not fail its linked `routine_runs` row. The linked routine run stays open in `issue_created` until the execution issue reaches a terminal outcome such as `done` or `cancelled`.
+
+Blocked routine execution issues should resume only from normal dependency wake semantics. When all blockers resolve, `issue_blockers_resolved` is the expected automatic wake path. Generic stranded-assigned-work reconciliation does not manage blocked routine execution issues and must not enqueue assignment-recovery or continuation-recovery retries for them.
+
 ## 7. Consistent Execution Path Rules
 
 For agent-assigned, non-terminal, actionable issues, Bizbox should not leave work in a state where nobody is working it and nothing will wake it.
@@ -213,6 +217,8 @@ Recovery rule:
 - if that continuation wake also finishes and the issue is still stranded, Bizbox moves the issue to `blocked` and posts a visible comment
 
 This is an active-work continuity recovery.
+
+Routine execution issues are excluded from this generic continuation recovery path. Their resume behavior comes from routine execution state and blocker wakeups, not from stranded `in_progress` reconciliation.
 
 ## 9. Startup and Periodic Reconciliation
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1396,7 +1396,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       linkedIssueId: parentIssueId,
     });
 
-    const routineSvc = issueService(db);
+    const issueSvc = issueService(db);
     const heartbeat = heartbeatService(db);
 
     const reconcileBefore = await heartbeat.reconcileStrandedAssignedIssues();
@@ -1420,7 +1420,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     await db.update(issues).set({ status: "done", updatedAt: new Date("2026-03-19T00:10:00.000Z") }).where(eq(issues.id, blockerId));
 
-    const dependents = await routineSvc.listWakeableBlockedDependents(blockerId);
+    const dependents = await issueSvc.listWakeableBlockedDependents(blockerId);
     expect(dependents).toEqual([
       expect.objectContaining({
         id: parentIssueId,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -18,6 +18,8 @@ import {
   issueDocuments,
   issueRelations,
   issues,
+  routines,
+  routineRuns,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -64,6 +66,7 @@ vi.mock("../adapters/index.ts", async () => {
 });
 
 import { heartbeatService } from "../services/heartbeat.ts";
+import { issueService } from "../services/issues.ts";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
@@ -309,6 +312,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(documentRevisions);
     await db.delete(documents);
     await db.delete(issueRelations);
+    await db.delete(routineRuns);
+    await db.delete(routines);
     for (let attempt = 0; attempt < 5; attempt += 1) {
       await db.delete(issueComments);
       await db.delete(issueDocuments);
@@ -445,6 +450,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runStatus: "failed" | "timed_out" | "cancelled" | "succeeded";
     retryReason?: "assignment_recovery" | "issue_continuation_needed" | null;
     assignToUser?: boolean;
+    originKind?: "routine_execution";
+    originId?: string;
+    originRunId?: string;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -521,6 +529,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       assigneeUserId: input.assignToUser ? "user-1" : null,
       checkoutRunId: input.status === "in_progress" ? runId : null,
       executionRunId: null,
+      originKind: input.originKind ?? "manual",
+      originId: input.originId ?? null,
+      originRunId: input.originRunId ?? null,
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
       startedAt: input.status === "in_progress" ? now : null,
@@ -1241,6 +1252,223 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     if (retryRun) {
       await waitForRunToSettle(heartbeat, retryRun.id);
     }
+  });
+
+  it("skips routine_execution todo issues in generic stranded-work reconciliation", async () => {
+    const routineId = randomUUID();
+    const routineRunId = randomUUID();
+    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      originKind: "routine_execution",
+      originId: routineId,
+      originRunId: routineRunId,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skippedRoutineExecutions).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(runs).toHaveLength(1);
+  });
+
+  it("skips routine_execution in-progress issues in generic stranded-work reconciliation", async () => {
+    const routineId = randomUUID();
+    const routineRunId = randomUUID();
+    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      originKind: "routine_execution",
+      originId: routineId,
+      originRunId: routineRunId,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skippedRoutineExecutions).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(runs).toHaveLength(1);
+  });
+
+  it("keeps blocked routine execution parked until blocker resolution wakes it", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const routineId = randomUUID();
+    const routineRunId = randomUUID();
+    const blockerId = randomUUID();
+    const parentIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const now = new Date("2026-03-19T00:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      projectId: null,
+      goalId: null,
+      parentIssueId: null,
+      title: "Routine parent waits on child",
+      description: "Wait until the blocker is resolved",
+      assigneeAgentId: agentId,
+      priority: "high",
+      status: "active",
+      concurrencyPolicy: "coalesce_if_active",
+      catchUpPolicy: "skip_missed",
+      variables: [],
+    });
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        title: "Finish child task",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: parentIssueId,
+        companyId,
+        title: "Routine parent waits on child",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: agentId,
+        originKind: "routine_execution",
+        originId: routineId,
+        originRunId: routineRunId,
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+        startedAt: now,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: parentIssueId,
+      type: "blocks",
+      createdByAgentId: agentId,
+    });
+    await db.insert(routineRuns).values({
+      id: routineRunId,
+      companyId,
+      routineId,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: now,
+      linkedIssueId: parentIssueId,
+    });
+
+    const routineSvc = issueService(db);
+    const heartbeat = heartbeatService(db);
+
+    const reconcileBefore = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(reconcileBefore.dispatchRequeued).toBe(0);
+    expect(reconcileBefore.continuationRequeued).toBe(0);
+    expect(reconcileBefore.skippedRoutineExecutions).toBe(0);
+
+    const runBefore = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.id, routineRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(runBefore?.status).toBe("issue_created");
+    expect(runBefore?.completedAt).toBeNull();
+
+    const wakeupsBefore = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeupsBefore).toHaveLength(0);
+
+    await db.update(issues).set({ status: "done", updatedAt: new Date("2026-03-19T00:10:00.000Z") }).where(eq(issues.id, blockerId));
+
+    const dependents = await routineSvc.listWakeableBlockedDependents(blockerId);
+    expect(dependents).toEqual([
+      expect.objectContaining({
+        id: parentIssueId,
+        assigneeAgentId: agentId,
+        blockerIssueIds: [blockerId],
+      }),
+    ]);
+
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: {
+        issueId: parentIssueId,
+        resolvedBlockerIssueId: blockerId,
+        blockerIssueIds: [blockerId],
+      },
+      contextSnapshot: {
+        issueId: parentIssueId,
+        taskId: parentIssueId,
+        wakeReason: "issue_blockers_resolved",
+        source: "issue.blockers_resolved",
+        resolvedBlockerIssueId: blockerId,
+        blockerIssueIds: [blockerId],
+      },
+    });
+    expect(wake).not.toBeNull();
+    if (wake?.id) {
+      await waitForRunToSettle(heartbeat, wake.id);
+    }
+
+    const wakeupsAfter = await db
+      .select({
+        reason: agentWakeupRequests.reason,
+        payload: agentWakeupRequests.payload,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeupsAfter).toHaveLength(1);
+    expect(wakeupsAfter[0]?.reason).toBe("issue_blockers_resolved");
+
+    const runAfter = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.id, routineRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(runAfter?.status).toBe("issue_created");
+    expect(runAfter?.completedAt).toBeNull();
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -174,6 +174,35 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     return { companyId, agentId, issueSvc, projectId, routine, svc, wakeups };
   }
 
+  async function seedRoutineExecutionRunFixture(status: "todo" | "blocked" | "cancelled" | "done") {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const runId = randomUUID();
+    const issue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status,
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: runId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: runId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: issue.id,
+    });
+
+    return { issueId: issue.id, runId, svc };
+  }
+
   it("creates a fresh execution issue when the previous routine issue is open but idle", async () => {
     const { companyId, issueSvc, routine, svc } = await seedFixture();
     const previousRunId = randomUUID();
@@ -916,5 +945,38 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
 
     expect(run.source).toBe("webhook");
     expect(run.status).toBe("issue_created");
+  });
+
+  it("keeps routine runs open when the linked execution issue is blocked", async () => {
+    const { issueId, runId, svc } = await seedRoutineExecutionRunFixture("blocked");
+
+    await svc.syncRunStatusForIssue(issueId);
+
+    const run = await db.select().from(routineRuns).where(eq(routineRuns.id, runId)).then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("issue_created");
+    expect(run?.failureReason).toBeNull();
+    expect(run?.completedAt).toBeNull();
+  });
+
+  it("fails routine runs when the linked execution issue is cancelled", async () => {
+    const { issueId, runId, svc } = await seedRoutineExecutionRunFixture("cancelled");
+
+    await svc.syncRunStatusForIssue(issueId);
+
+    const run = await db.select().from(routineRuns).where(eq(routineRuns.id, runId)).then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("failed");
+    expect(run?.failureReason).toBe("Execution issue moved to cancelled");
+    expect(run?.completedAt).toBeTruthy();
+  });
+
+  it("completes routine runs when the linked execution issue is done", async () => {
+    const { issueId, runId, svc } = await seedRoutineExecutionRunFixture("done");
+
+    await svc.syncRunStatusForIssue(issueId);
+
+    const run = await db.select().from(routineRuns).where(eq(routineRuns.id, runId)).then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("completed");
+    expect(run?.failureReason).toBeNull();
+    expect(run?.completedAt).toBeTruthy();
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -124,6 +124,7 @@ vi.mock("../services/index.js", () => ({
       dispatchRequeued: 0,
       continuationRequeued: 0,
       escalated: 0,
+      skippedRoutineExecutions: 0,
       skipped: 0,
       issueIds: [],
     })),

--- a/server/src/onboarding-assets/ceo/HEARTBEAT.md
+++ b/server/src/onboarding-assets/ceo/HEARTBEAT.md
@@ -41,7 +41,7 @@ Status quick guide:
 - `todo`: ready to execute, but not yet checked out.
 - `in_progress`: actively owned work. Agents should reach this by checkout, not by manually flipping status.
 - `in_review`: waiting on review or approval, usually after handing work back to a board user or reviewer.
-- `blocked`: cannot move until something specific changes. Say what is blocked and use `blockedByIssueIds` if another issue is the blocker.
+- `blocked`: cannot move until something specific changes. Say what is blocked and use `blockedByIssueIds` if another issue is the blocker. For `routine_execution` parent issues, this is a healthy parked wait state and the routine run should stay open until dependency wakeup resumes the work or the issue is cancelled.
 - `done`: finished.
 - `cancelled`: intentionally dropped.
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4237,11 +4237,18 @@ export function heartbeatService(db: Db) {
       continuationRequeued: 0,
       orphanBlockersAssigned: 0,
       escalated: 0,
+      skippedRoutineExecutions: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
 
     for (const issue of candidates) {
+      if (issue.originKind === "routine_execution") {
+        result.skippedRoutineExecutions += 1;
+        result.skipped += 1;
+        continue;
+      }
+
       const agentId = issue.assigneeAgentId;
       if (!agentId) {
         result.skipped += 1;

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1644,7 +1644,7 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
           completedAt: new Date(),
         });
       }
-      if (issue.status === "blocked" || issue.status === "cancelled") {
+      if (issue.status === "cancelled") {
         return finalizeRun(issue.originRunId, {
           status: "failed",
           failureReason: `Execution issue moved to ${issue.status}`,


### PR DESCRIPTION
This pull request introduces and enforces correct handling of `routine_execution` issues in both the execution and recovery logic. The main goal is to ensure that routine execution issues in a `blocked` state are treated as a healthy, parked wait state, and are not prematurely failed or resumed by generic stranded-work reconciliation. It also adds comprehensive tests and documentation to clarify these semantics.

**Execution and recovery behavior for routine executions:**

* Routine execution issues in the `blocked` state are now considered "parked" and do not cause their linked `routineRuns` row to fail; the run remains open until a terminal outcome (`done` or `cancelled`) is reached. Blocked routine execution issues are only resumed by normal dependency wakeups, not by generic stranded-work reconciliation. [[1]](diffhunk://#diff-b1e96a247955e130d82dcc77ceac622a95f66a8fe4f19d2f9cf502e96bafda7aR153-R156) [[2]](diffhunk://#diff-aa5f72ead421a57a0fb00b4238821041415ca37eb01c4098ad82f6e1a8ce2a2fL44-R44) [[3]](diffhunk://#diff-b1e96a247955e130d82dcc77ceac622a95f66a8fe4f19d2f9cf502e96bafda7aR221-R222)

* The generic stranded-work reconciliation logic in `heartbeatService` now explicitly skips `routine_execution` issues, tracking them separately in the reconciliation result. [[1]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R4240-R4251) [[2]](diffhunk://#diff-8965ec17b64f64db26c15431c6df7bf34d08d6dd3c51fc5ea94507bce5a65f64R127)

**Testing and fixtures:**

* Extensive tests are added for routine execution issues, verifying that:
  - Stranded-work reconciliation skips both `todo` and `in_progress` routine execution issues.
  - Blocked routine execution issues remain parked until their blockers are resolved, after which they are correctly resumed.
  - Routine runs remain open when the linked execution issue is `blocked`, and are only marked as failed or completed when the issue is moved to `cancelled` or `done`, respectively. [[1]](diffhunk://#diff-dad769737ae07e59e6ea81ee9b0666970d9b50ac1cfc99cd5905af9fc0c30b78R1257-R1473) [[2]](diffhunk://#diff-7dd5b805c7e4acf7a53c8afc48f4ee40b42afe85622982ecdccd3c0922094e1dR177-R205) [[3]](diffhunk://#diff-7dd5b805c7e4acf7a53c8afc48f4ee40b42afe85622982ecdccd3c0922094e1dR949-R981)

**Supporting changes:**

* Test utilities and fixtures are updated to support seeding and cleaning up `routines` and `routineRuns` tables, and to allow specifying `originKind`, `originId`, and `originRunId` for issues. [[1]](diffhunk://#diff-dad769737ae07e59e6ea81ee9b0666970d9b50ac1cfc99cd5905af9fc0c30b78R21-R22) [[2]](diffhunk://#diff-dad769737ae07e59e6ea81ee9b0666970d9b50ac1cfc99cd5905af9fc0c30b78R315-R316) [[3]](diffhunk://#diff-dad769737ae07e59e6ea81ee9b0666970d9b50ac1cfc99cd5905af9fc0c30b78R453-R455) [[4]](diffhunk://#diff-dad769737ae07e59e6ea81ee9b0666970d9b50ac1cfc99cd5905af9fc0c30b78R532-R534)

**Documentation:**

* The execution semantics documentation is updated to clarify the correct handling of blocked routine execution issues and their exclusion from generic continuation recovery. [[1]](diffhunk://#diff-b1e96a247955e130d82dcc77ceac622a95f66a8fe4f19d2f9cf502e96bafda7aR153-R156) [[2]](diffhunk://#diff-b1e96a247955e130d82dcc77ceac622a95f66a8fe4f19d2f9cf502e96bafda7aR221-R222)

**Routine run status sync:**

* The routine service is updated so that only `cancelled` execution issues cause the linked routine run to fail; `blocked` issues no longer trigger failure, aligning with the intended parked state behavior.