### PR TITLE
Refactor agentParams handling and remove unused function

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -395,62 +395,6 @@ function joinWakePayloadSections(structuredWakePrompt: string, structuredWakeJso
   return sections.join("\n");
 }
 
-function buildStandardPaperclipPayload(
-  ctx: AdapterExecutionContext,
-  wakePayload: WakePayload,
-  paperclipEnv: Record<string, string>,
-  payloadTemplate: Record<string, unknown>,
-): Record<string, unknown> {
-  const templatePaperclip = parseObject(payloadTemplate.paperclip);
-  const workspace = asRecord(ctx.context.paperclipWorkspace);
-  const workspaces = Array.isArray(ctx.context.paperclipWorkspaces)
-    ? ctx.context.paperclipWorkspaces.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
-    : [];
-  const configuredWorkspaceRuntime = parseObject(ctx.config.workspaceRuntime);
-  const runtimeServiceIntents = Array.isArray(ctx.context.paperclipRuntimeServiceIntents)
-    ? ctx.context.paperclipRuntimeServiceIntents.filter(
-        (entry): entry is Record<string, unknown> => Boolean(asRecord(entry)),
-      )
-    : [];
-
-  const standardPaperclip: Record<string, unknown> = {
-    runId: ctx.runId,
-    companyId: ctx.agent.companyId,
-    agentId: ctx.agent.id,
-    agentName: ctx.agent.name,
-    taskId: wakePayload.taskId,
-    issueId: wakePayload.issueId,
-    issueIds: wakePayload.issueIds,
-    wakeReason: wakePayload.wakeReason,
-    wakeCommentId: wakePayload.wakeCommentId,
-    approvalId: wakePayload.approvalId,
-    approvalStatus: wakePayload.approvalStatus,
-    apiUrl: paperclipEnv.BIZBOX_API_URL ?? null,
-  };
-  const structuredWake = parseObject(ctx.context.paperclipWake);
-  if (Object.keys(structuredWake).length > 0) {
-    standardPaperclip.wake = structuredWake;
-  }
-
-  if (workspace) {
-    standardPaperclip.workspace = workspace;
-  }
-  if (workspaces.length > 0) {
-    standardPaperclip.workspaces = workspaces;
-  }
-  if (runtimeServiceIntents.length > 0 || Object.keys(configuredWorkspaceRuntime).length > 0) {
-    standardPaperclip.workspaceRuntime = {
-      ...configuredWorkspaceRuntime,
-      ...(runtimeServiceIntents.length > 0 ? { services: runtimeServiceIntents } : {}),
-    };
-  }
-
-  return {
-    ...templatePaperclip,
-    ...standardPaperclip,
-  };
-}
-
 function normalizeUrl(input: string): URL | null {
   try {
     return new URL(input);
@@ -1068,8 +1012,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
-  agentParams.paperclip = paperclipPayload;
+  delete agentParams.paperclip;
 
   const configuredAgentId = nonEmpty(parsedConfig.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -20,6 +20,22 @@ import {
 } from "@paperclipai/db";
 import { heartbeatService } from "../services/heartbeat.ts";
 
+function extractStructuredWakePayload(message: unknown): Record<string, unknown> | null {
+  const text = String(message ?? "");
+  const marker = "Structured wake payload JSON:";
+  const markerIndex = text.indexOf(marker);
+  if (markerIndex < 0) return null;
+  const jsonStart = text.indexOf("```json", markerIndex);
+  if (jsonStart < 0) return null;
+  const bodyStart = text.indexOf("\n", jsonStart);
+  if (bodyStart < 0) return null;
+  const fenceEnd = text.indexOf("\n```", bodyStart);
+  if (fenceEnd < 0) return null;
+  const json = text.slice(bodyStart + 1, fenceEnd).trim();
+  if (!json) return null;
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
 type EmbeddedPostgresInstance = {
   initialise(): Promise<void>;
   start(): Promise<void>;
@@ -523,11 +539,9 @@ describe("heartbeat comment wake batching", () => {
       }, 90_000);
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          commentIds: [comment2.id, comment3.id],
-          latestCommentId: comment3.id,
-        },
+      expect(extractStructuredWakePayload(secondPayload.message)).toMatchObject({
+        commentIds: [comment2.id, comment3.id],
+        latestCommentId: comment3.id,
       });
       expect(String(secondPayload.message ?? "")).toContain("Second comment");
       expect(String(secondPayload.message ?? "")).toContain("Third comment");
@@ -646,22 +660,18 @@ describe("heartbeat comment wake batching", () => {
 
       await waitFor(() => gateway.getAgentPayloads().length === 2);
       const promotedPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(promotedPayload.paperclip).toMatchObject({
-        wake: {
-          commentIds: [queuedComment.id],
-          latestCommentId: queuedComment.id,
-          comments: [
-            expect.objectContaining({
-              id: queuedComment.id,
-              body: "Queued follow-up",
-            }),
-          ],
-          commentWindow: {
-            requestedCount: 1,
-            includedCount: 1,
-            missingCount: 0,
-          },
-        },
+      expect(extractStructuredWakePayload(promotedPayload.message)).toMatchObject({
+        commentIds: [queuedComment.id],
+        latestCommentId: queuedComment.id,
+        comments: [
+          expect.objectContaining({
+            id: queuedComment.id,
+            body: "Queued follow-up",
+          }),
+        ],
+        requestedCount: 1,
+        includedCount: 1,
+        missingCount: 0,
       });
       expect(String(promotedPayload.message ?? "")).toContain("Queued follow-up");
 
@@ -841,18 +851,16 @@ describe("heartbeat comment wake batching", () => {
       });
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_commented",
-          commentIds: [comment2.id],
-          latestCommentId: comment2.id,
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Reopen after deferred comment",
-            status: "in_progress",
-            priority: "medium",
-          },
+      expect(extractStructuredWakePayload(secondPayload.message)).toMatchObject({
+        reason: "issue_commented",
+        commentIds: [comment2.id],
+        latestCommentId: comment2.id,
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Reopen after deferred comment",
+          status: "in_progress",
+          priority: "medium",
         },
       });
       expect(String(secondPayload.message ?? "")).toContain("Please handle this follow-up after you finish");
@@ -927,19 +935,17 @@ describe("heartbeat comment wake batching", () => {
       expect(firstRun).not.toBeNull();
       await waitFor(() => gateway.getAgentPayloads().length === 1);
       const firstPayload = gateway.getAgentPayloads()[0] ?? {};
-      expect(firstPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_assigned",
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Require a comment",
-            status: "in_progress",
-            priority: "medium",
-          },
-          checkedOutByHarness: true,
-          commentIds: [],
+      expect(extractStructuredWakePayload(firstPayload.message)).toMatchObject({
+        reason: "issue_assigned",
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Require a comment",
+          status: "in_progress",
+          priority: "medium",
         },
+        checkedOutByHarness: true,
+        commentIds: [],
       });
       expect(String(firstPayload.message ?? "")).toContain("## Paperclip Wake Payload");
       expect(String(firstPayload.message ?? "")).toContain("Do not switch to another issue until you have handled this wake.");

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -9,6 +9,22 @@ import {
 } from "@paperclipai/adapter-openclaw-gateway/ui";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 
+function extractStructuredWakePayload(message: unknown): Record<string, unknown> | null {
+  const text = String(message ?? "");
+  const marker = "Structured wake payload JSON:";
+  const markerIndex = text.indexOf(marker);
+  if (markerIndex < 0) return null;
+  const jsonStart = text.indexOf("```json", markerIndex);
+  if (jsonStart < 0) return null;
+  const bodyStart = text.indexOf("\n", jsonStart);
+  if (bodyStart < 0) return null;
+  const fenceEnd = text.indexOf("\n```", bodyStart);
+  if (fenceEnd < 0) return null;
+  const json = text.slice(bodyStart + 1, fenceEnd).trim();
+  if (!json) return null;
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
 function buildContext(
   config: Record<string, unknown>,
   overrides?: Partial<AdapterExecutionContext>,
@@ -531,12 +547,21 @@ describe("openclaw gateway adapter execute", () => {
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
       expect(String(payload?.message ?? "")).toContain("\"latestCommentId\":\"comment-2\"");
-      // paperclip structured payload is now forwarded to the gateway agent.
-      expect(payload?.paperclip).toMatchObject({
-        runId: "run-123",
-        taskId: "task-123",
-        issueId: "issue-123",
-        wakeReason: "issue_assigned",
+      expect(payload?.paperclip).toBeUndefined();
+      expect(extractStructuredWakePayload(payload?.message)).toMatchObject({
+        reason: "issue_commented",
+        issue: {
+          id: "issue-123",
+          identifier: "PAP-874",
+          title: "chat-speed issues",
+          status: "in_progress",
+          priority: "medium",
+        },
+        commentIds: ["comment-1", "comment-2"],
+        latestCommentId: "comment-2",
+        requestedCount: 2,
+        includedCount: 2,
+        missingCount: 0,
       });
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);


### PR DESCRIPTION
**Why This Change Is Needed**

`v0.0.6` introduced a regression in the OpenClaw gateway adapter that changed the outbound agent request shape. In commit `e2c98c460` on April 30, 2026, the adapter stopped stripping the top-level `paperclip` field and began sending it to OpenClaw as part of `agent` params.

That conflicts with the adapter’s own documented contract:

- [packages/adapters/openclaw-gateway/README.md](/Users/citro/Developer/bizbox/bizbox/packages/adapters/openclaw-gateway/README.md:60) says top-level `paperclip` is not sent because the gateway rejects unknown top-level fields.
- [packages/adapters/openclaw-gateway/src/index.ts](/Users/citro/Developer/bizbox/bizbox/packages/adapters/openclaw-gateway/src/index.ts:53) says the same thing.

Production behavior matched the docs, not the regression. In `citro-openclaw` Fly logs on May 5, 2026 at `00:31:34Z`, `00:31:35Z`, and `00:31:36Z`, OpenClaw rejected the request with:

`invalid agent params: at root: unexpected property 'paperclip'`

That rejection caused Bizbox to surface `openclaw_gateway_request_failed`, and then the heartbeat recovery path moved the issue to `blocked` because the retry still had no live execution path. That blocked comment is expected recovery behavior from [server/src/services/heartbeat.ts](/Users/citro/Developer/bizbox/bizbox/server/src/services/heartbeat.ts:6132), not the root bug.

**What This PR Changes**

This PR restores the previous, documented adapter contract by reverting the request builder to:

```ts
delete agentParams.paperclip;
```

in [packages/adapters/openclaw-gateway/src/server/execute.ts](/Users/citro/Developer/bizbox/bizbox/packages/adapters/openclaw-gateway/src/server/execute.ts:1016).

**Why This Is the Right Fix**

- It is the smallest possible hotfix.
- It restores known-good behavior from before `v0.0.6`.
- It matches both local package documentation and observed OpenClaw server behavior.
- It avoids changing recovery logic, task execution logic, or any other runtime path unrelated to the regression.

**Suggested PR Sections**

Thinking Path:
A recent release caused OpenClaw-backed Bizbox issue executions to fail in production. Investigation traced the failure to a payload-shape regression in the OpenClaw gateway adapter. The adapter docs explicitly state that top-level `paperclip` must be stripped, and production OpenClaw logs confirmed that the gateway rejects it. This change restores the documented pre-release behavior with the smallest possible diff.

What Changed:
- Reverted the OpenClaw gateway agent param builder to strip top-level `paperclip` before sending the request.
- Left all other wake-message and execution behavior unchanged.

Verification:
- Confirmed the regression was introduced by commit `e2c98c460` in the `v0.0.5...v0.0.6` range.
- Confirmed OpenClaw production logs rejected the request with `unexpected property 'paperclip'` on May 5, 2026.
- Ran `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`.

Risks:
- Low risk. This restores previous behavior rather than introducing a new payload shape.
- Remaining gap: this package’s tests are not currently exercised by the repo-wide `pnpm test` path, which likely helped the regression slip through.
