### PR TITLE
Enhance artifact validation and schema handling

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -493,7 +493,10 @@ export type {
   QuotaWindow,
   ProviderQuotaResult,
 } from "./types/index.js";
-export { parseIssueArtifactWorkProductMetadata } from "./types/index.js";
+export {
+  isIssueArtifactWorkProductMetadata,
+  parseIssueArtifactWorkProductMetadata,
+} from "./types/index.js";
 export {
   ISSUE_REFERENCE_IDENTIFIER_RE,
   buildIssueReferenceHref,
@@ -653,6 +656,8 @@ export {
   createIssueAttachmentMetadataSchema,
   createIssueWorkProductSchema,
   updateIssueWorkProductSchema,
+  issueArtifactWorkProductMetadataSchema,
+  getIssueArtifactWorkProductValidationIssues,
   issueWorkProductTypeSchema,
   issueWorkProductStatusSchema,
   issueWorkProductReviewStateSchema,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -657,6 +657,7 @@ export {
   createIssueWorkProductSchema,
   updateIssueWorkProductSchema,
   issueArtifactWorkProductMetadataSchema,
+  sanitizeStoredIssueArtifactWorkProductMetadata,
   getIssueArtifactWorkProductValidationIssues,
   issueWorkProductTypeSchema,
   issueWorkProductStatusSchema,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -657,6 +657,7 @@ export {
   createIssueWorkProductSchema,
   updateIssueWorkProductSchema,
   issueArtifactWorkProductMetadataSchema,
+  getStoredIssueArtifactWorkProductValidationIssues,
   sanitizeStoredIssueArtifactWorkProductMetadata,
   getIssueArtifactWorkProductValidationIssues,
   issueWorkProductTypeSchema,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -109,7 +109,10 @@ export type {
   IssueWorkProductReviewState,
   IssueArtifactWorkProductMetadata,
 } from "./work-product.js";
-export { parseIssueArtifactWorkProductMetadata } from "./work-product.js";
+export {
+  isIssueArtifactWorkProductMetadata,
+  parseIssueArtifactWorkProductMetadata,
+} from "./work-product.js";
 export type {
   Issue,
   IssueAssigneeAdapterOverrides,

--- a/packages/shared/src/types/work-product.test.ts
+++ b/packages/shared/src/types/work-product.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  isIssueArtifactWorkProductMetadata,
+  parseIssueArtifactWorkProductMetadata,
+} from "./work-product.js";
+
+const baseMetadata = {
+  attachmentId: "11111111-1111-4111-8111-111111111111",
+  contentPath: "/api/attachments/11111111-1111-4111-8111-111111111111/content",
+  sourcePath: "deliverables/final-packet.md",
+  contentType: "text/markdown",
+  originalFilename: "final-packet.md",
+};
+
+describe("issue artifact work product metadata types", () => {
+  it("keeps the strict type guard rejecting zero-byte metadata", () => {
+    expect(isIssueArtifactWorkProductMetadata({
+      ...baseMetadata,
+      byteSize: 0,
+    })).toBe(false);
+  });
+
+  it("still parses stored zero-byte metadata for cleanup-oriented read paths", () => {
+    expect(parseIssueArtifactWorkProductMetadata({
+      type: "artifact",
+      metadata: {
+        ...baseMetadata,
+        byteSize: 0,
+      },
+    })).toEqual({
+      ...baseMetadata,
+      byteSize: 0,
+    });
+  });
+});

--- a/packages/shared/src/types/work-product.ts
+++ b/packages/shared/src/types/work-product.ts
@@ -88,6 +88,11 @@ export function isIssueArtifactWorkProductMetadata(
   const contentType = readString(metadata.contentType);
   const byteSize = readNumber(metadata.byteSize);
 
+  const originalFilename = metadata.originalFilename;
+  if (originalFilename !== undefined && originalFilename !== null && typeof originalFilename !== "string") {
+    return false;
+  }
+
   return Boolean(
     attachmentId
       && contentPath
@@ -106,5 +111,8 @@ export function parseIssueArtifactWorkProductMetadata(
   const metadata = asRecord(product.metadata);
   if (!isIssueArtifactWorkProductMetadata(metadata)) return null;
 
-  return metadata as IssueArtifactWorkProductMetadata;
+  const originalFilename =
+    typeof metadata.originalFilename === "string" ? metadata.originalFilename : null;
+
+  return { ...(metadata as IssueArtifactWorkProductMetadata), originalFilename };
 }

--- a/packages/shared/src/types/work-product.ts
+++ b/packages/shared/src/types/work-product.ts
@@ -104,12 +104,40 @@ export function isIssueArtifactWorkProductMetadata(
   );
 }
 
+function isStoredIssueArtifactWorkProductMetadata(
+  value: unknown,
+): value is IssueArtifactWorkProductMetadata {
+  const metadata = asRecord(value);
+  if (!metadata) return false;
+
+  const attachmentId = readString(metadata.attachmentId);
+  const contentPath = readString(metadata.contentPath);
+  const sourcePath = readString(metadata.sourcePath);
+  const contentType = readString(metadata.contentType);
+  const byteSize = readNumber(metadata.byteSize);
+
+  const originalFilename = metadata.originalFilename;
+  if (originalFilename !== undefined && originalFilename !== null && typeof originalFilename !== "string") {
+    return false;
+  }
+
+  return Boolean(
+    attachmentId
+      && contentPath
+      && sourcePath
+      && contentType
+      && byteSize !== null
+      && Number.isInteger(byteSize)
+      && byteSize >= 0,
+  );
+}
+
 export function parseIssueArtifactWorkProductMetadata(
   product: Pick<IssueWorkProduct, "type" | "metadata">,
 ): IssueArtifactWorkProductMetadata | null {
   if (product.type !== "artifact") return null;
   const metadata = asRecord(product.metadata);
-  if (!isIssueArtifactWorkProductMetadata(metadata)) return null;
+  if (!isStoredIssueArtifactWorkProductMetadata(metadata)) return null;
 
   const originalFilename =
     typeof metadata.originalFilename === "string" ? metadata.originalFilename : null;

--- a/packages/shared/src/types/work-product.ts
+++ b/packages/shared/src/types/work-product.ts
@@ -106,20 +106,5 @@ export function parseIssueArtifactWorkProductMetadata(
   const metadata = asRecord(product.metadata);
   if (!isIssueArtifactWorkProductMetadata(metadata)) return null;
 
-  const attachmentId = readString(metadata.attachmentId);
-  const contentPath = readString(metadata.contentPath);
-  const sourcePath = readString(metadata.sourcePath);
-  const contentType = readString(metadata.contentType);
-  const byteSize = readNumber(metadata.byteSize);
-  const originalFilename =
-    typeof metadata.originalFilename === "string" ? metadata.originalFilename : null;
-
-  return {
-    attachmentId: attachmentId!,
-    contentPath: contentPath!,
-    sourcePath: sourcePath!,
-    contentType: contentType!,
-    byteSize: byteSize!,
-    originalFilename,
-  };
+  return metadata as IssueArtifactWorkProductMetadata;
 }

--- a/packages/shared/src/types/work-product.ts
+++ b/packages/shared/src/types/work-product.ts
@@ -76,12 +76,35 @@ function readNumber(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+export function isIssueArtifactWorkProductMetadata(
+  value: unknown,
+): value is IssueArtifactWorkProductMetadata {
+  const metadata = asRecord(value);
+  if (!metadata) return false;
+
+  const attachmentId = readString(metadata.attachmentId);
+  const contentPath = readString(metadata.contentPath);
+  const sourcePath = readString(metadata.sourcePath);
+  const contentType = readString(metadata.contentType);
+  const byteSize = readNumber(metadata.byteSize);
+
+  return Boolean(
+    attachmentId
+      && contentPath
+      && sourcePath
+      && contentType
+      && byteSize !== null
+      && Number.isInteger(byteSize)
+      && byteSize > 0,
+  );
+}
+
 export function parseIssueArtifactWorkProductMetadata(
   product: Pick<IssueWorkProduct, "type" | "metadata">,
 ): IssueArtifactWorkProductMetadata | null {
   if (product.type !== "artifact") return null;
   const metadata = asRecord(product.metadata);
-  if (!metadata) return null;
+  if (!isIssueArtifactWorkProductMetadata(metadata)) return null;
 
   const attachmentId = readString(metadata.attachmentId);
   const contentPath = readString(metadata.contentPath);
@@ -91,16 +114,12 @@ export function parseIssueArtifactWorkProductMetadata(
   const originalFilename =
     typeof metadata.originalFilename === "string" ? metadata.originalFilename : null;
 
-  if (!attachmentId || !contentPath || !sourcePath || !contentType || byteSize === null) {
-    return null;
-  }
-
   return {
-    attachmentId,
-    contentPath,
-    sourcePath,
-    contentType,
-    byteSize,
+    attachmentId: attachmentId!,
+    contentPath: contentPath!,
+    sourcePath: sourcePath!,
+    contentType: contentType!,
+    byteSize: byteSize!,
     originalFilename,
   };
 }

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -215,6 +215,7 @@ export {
   createIssueWorkProductSchema,
   updateIssueWorkProductSchema,
   issueArtifactWorkProductMetadataSchema,
+  getStoredIssueArtifactWorkProductValidationIssues,
   sanitizeStoredIssueArtifactWorkProductMetadata,
   getIssueArtifactWorkProductValidationIssues,
   issueWorkProductTypeSchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -215,6 +215,7 @@ export {
   createIssueWorkProductSchema,
   updateIssueWorkProductSchema,
   issueArtifactWorkProductMetadataSchema,
+  sanitizeStoredIssueArtifactWorkProductMetadata,
   getIssueArtifactWorkProductValidationIssues,
   issueWorkProductTypeSchema,
   issueWorkProductStatusSchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -214,6 +214,8 @@ export {
 export {
   createIssueWorkProductSchema,
   updateIssueWorkProductSchema,
+  issueArtifactWorkProductMetadataSchema,
+  getIssueArtifactWorkProductValidationIssues,
   issueWorkProductTypeSchema,
   issueWorkProductStatusSchema,
   issueWorkProductReviewStateSchema,

--- a/packages/shared/src/validators/work-product.test.ts
+++ b/packages/shared/src/validators/work-product.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  createIssueWorkProductSchema,
+  getIssueArtifactWorkProductValidationIssues,
+  updateIssueWorkProductSchema,
+} from "./work-product.js";
+
+const validArtifactMetadata = {
+  attachmentId: "11111111-1111-4111-8111-111111111111",
+  contentPath: "/api/attachments/11111111-1111-4111-8111-111111111111/content",
+  sourcePath: "deliverables/final-packet.md",
+  contentType: "text/markdown",
+  byteSize: 128,
+  originalFilename: "final-packet.md",
+};
+
+describe("work product validators", () => {
+  it("rejects artifact creation without attachment-backed metadata", () => {
+    const parsed = createIssueWorkProductSchema.safeParse({
+      type: "artifact",
+      provider: "paperclip",
+      title: "Final packet",
+      status: "ready_for_review",
+      metadata: null,
+      createdByRunId: null,
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) throw new Error("Expected artifact creation to fail validation");
+    expect(parsed.error.issues.map((issue) => issue.path.join("."))).toEqual(
+      expect.arrayContaining(["metadata", "createdByRunId"]),
+    );
+  });
+
+  it("accepts artifact creation when metadata is attachment-backed and createdByRunId is present", () => {
+    const parsed = createIssueWorkProductSchema.safeParse({
+      type: "artifact",
+      provider: "paperclip",
+      title: "Final packet",
+      url: "https://example.com/artifacts/final-packet",
+      status: "ready_for_review",
+      metadata: validArtifactMetadata,
+      createdByRunId: "22222222-2222-4222-8222-222222222222",
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects partial artifact updates that try to switch to artifact without the required fields", () => {
+    const parsed = updateIssueWorkProductSchema.safeParse({
+      type: "artifact",
+      title: "Final packet",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) throw new Error("Expected artifact update to fail validation");
+    expect(parsed.error.issues.map((issue) => issue.path.join("."))).toEqual(
+      expect.arrayContaining(["metadata", "createdByRunId"]),
+    );
+  });
+
+  it("reports no artifact validation issues for non-artifact products", () => {
+    expect(getIssueArtifactWorkProductValidationIssues({
+      type: "pull_request",
+      metadata: null,
+      createdByRunId: null,
+    })).toEqual([]);
+  });
+});

--- a/packages/shared/src/validators/work-product.test.ts
+++ b/packages/shared/src/validators/work-product.test.ts
@@ -69,6 +69,22 @@ describe("work product validators", () => {
     );
   });
 
+  it("rejects non-artifact work products with raw filesystem paths in url", () => {
+    const parsed = createIssueWorkProductSchema.safeParse({
+      type: "pull_request",
+      provider: "github",
+      title: "PR 123",
+      url: "/etc/passwd",
+      status: "ready_for_review",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) throw new Error("Expected non-artifact filesystem url to fail validation");
+    expect(parsed.error.issues.map((issue) => issue.path.join("."))).toEqual(
+      expect.arrayContaining(["url"]),
+    );
+  });
+
   it("rejects artifact metadata with extra contentBase64 payloads", () => {
     const parsed = createIssueWorkProductSchema.safeParse({
       type: "artifact",
@@ -111,6 +127,18 @@ describe("work product validators", () => {
       metadata: {
         ...validArtifactMetadata,
         contentBase64: "IyBGaW5hbCBwYWNrZXQK",
+      },
+      createdByRunId: null,
+    })).toEqual([]);
+  });
+
+  it("allows stored artifact validation to tolerate zero-byte legacy attachments", () => {
+    expect(getStoredIssueArtifactWorkProductValidationIssues({
+      type: "artifact",
+      url: validArtifactMetadata.contentPath,
+      metadata: {
+        ...validArtifactMetadata,
+        byteSize: 0,
       },
       createdByRunId: null,
     })).toEqual([]);

--- a/packages/shared/src/validators/work-product.test.ts
+++ b/packages/shared/src/validators/work-product.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createIssueWorkProductSchema,
   getIssueArtifactWorkProductValidationIssues,
+  getStoredIssueArtifactWorkProductValidationIssues,
   sanitizeStoredIssueArtifactWorkProductMetadata,
   updateIssueWorkProductSchema,
 } from "./work-product.js";
@@ -100,6 +101,18 @@ describe("work product validators", () => {
       url: validArtifactMetadata.contentPath,
       metadata: sanitized,
       createdByRunId: "22222222-2222-4222-8222-222222222222",
+    })).toEqual([]);
+  });
+
+  it("allows stored artifact validation to tolerate missing legacy createdByRunId", () => {
+    expect(getStoredIssueArtifactWorkProductValidationIssues({
+      type: "artifact",
+      url: validArtifactMetadata.contentPath,
+      metadata: {
+        ...validArtifactMetadata,
+        contentBase64: "IyBGaW5hbCBwYWNrZXQK",
+      },
+      createdByRunId: null,
     })).toEqual([]);
   });
 

--- a/packages/shared/src/validators/work-product.test.ts
+++ b/packages/shared/src/validators/work-product.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createIssueWorkProductSchema,
   getIssueArtifactWorkProductValidationIssues,
+  sanitizeStoredIssueArtifactWorkProductMetadata,
   updateIssueWorkProductSchema,
 } from "./work-product.js";
 
@@ -86,6 +87,20 @@ describe("work product validators", () => {
     expect(parsed.error.issues.map((issue) => issue.path.join("."))).toEqual(
       expect.arrayContaining(["metadata"]),
     );
+  });
+
+  it("strips unknown keys from stored artifact metadata before merged-state validation", () => {
+    const sanitized = sanitizeStoredIssueArtifactWorkProductMetadata({
+      ...validArtifactMetadata,
+      contentBase64: "IyBGaW5hbCBwYWNrZXQK",
+    });
+
+    expect(getIssueArtifactWorkProductValidationIssues({
+      type: "artifact",
+      url: validArtifactMetadata.contentPath,
+      metadata: sanitized,
+      createdByRunId: "22222222-2222-4222-8222-222222222222",
+    })).toEqual([]);
   });
 
   it("rejects partial artifact updates that try to switch to artifact without the required fields", () => {

--- a/packages/shared/src/validators/work-product.test.ts
+++ b/packages/shared/src/validators/work-product.test.ts
@@ -37,13 +37,55 @@ describe("work product validators", () => {
       type: "artifact",
       provider: "paperclip",
       title: "Final packet",
-      url: "https://example.com/artifacts/final-packet",
+      url: validArtifactMetadata.contentPath,
       status: "ready_for_review",
       metadata: validArtifactMetadata,
       createdByRunId: "22222222-2222-4222-8222-222222222222",
     });
 
     expect(parsed.success).toBe(true);
+  });
+
+  it("rejects artifact metadata that points at a raw filesystem path", () => {
+    const parsed = createIssueWorkProductSchema.safeParse({
+      type: "artifact",
+      provider: "paperclip",
+      title: "Final packet",
+      url: "/home/node/.openclaw/workspace-ceo/ceo-config-and-runs-report.md",
+      status: "ready_for_review",
+      metadata: {
+        ...validArtifactMetadata,
+        contentPath: "/home/node/.openclaw/workspace-ceo/ceo-config-and-runs-report.md",
+      },
+      createdByRunId: "22222222-2222-4222-8222-222222222222",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) throw new Error("Expected filesystem-backed artifact metadata to fail validation");
+    expect(parsed.error.issues.map((issue) => issue.path.join("."))).toEqual(
+      expect.arrayContaining(["metadata.contentPath"]),
+    );
+  });
+
+  it("rejects artifact metadata with extra contentBase64 payloads", () => {
+    const parsed = createIssueWorkProductSchema.safeParse({
+      type: "artifact",
+      provider: "paperclip",
+      title: "Final packet",
+      url: validArtifactMetadata.contentPath,
+      status: "ready_for_review",
+      metadata: {
+        ...validArtifactMetadata,
+        contentBase64: "IyBGaW5hbCBwYWNrZXQK",
+      },
+      createdByRunId: "22222222-2222-4222-8222-222222222222",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) throw new Error("Expected extra artifact metadata keys to fail validation");
+    expect(parsed.error.issues.map((issue) => issue.path.join("."))).toEqual(
+      expect.arrayContaining(["metadata"]),
+    );
   });
 
   it("rejects partial artifact updates that try to switch to artifact without the required fields", () => {
@@ -62,6 +104,7 @@ describe("work product validators", () => {
   it("reports no artifact validation issues for non-artifact products", () => {
     expect(getIssueArtifactWorkProductValidationIssues({
       type: "pull_request",
+      url: null,
       metadata: null,
       createdByRunId: null,
     })).toEqual([]);

--- a/packages/shared/src/validators/work-product.ts
+++ b/packages/shared/src/validators/work-product.ts
@@ -29,7 +29,60 @@ export const issueWorkProductReviewStateSchema = z.enum([
   "changes_requested",
 ]);
 
-export const createIssueWorkProductSchema = z.object({
+const issueWorkProductUrlSchema = z.string().trim().min(1).refine((value) => {
+  if (value.startsWith("/")) return true;
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}, "Invalid url");
+
+export const issueArtifactWorkProductMetadataSchema = z.object({
+  attachmentId: z.string().uuid(),
+  contentPath: z.string().trim().min(1),
+  sourcePath: z.string().trim().min(1),
+  contentType: z.string().trim().min(1),
+  byteSize: z.number().int().positive(),
+  originalFilename: z.string().trim().min(1).nullable().optional(),
+}).strict();
+
+const issueArtifactWorkProductPersistenceSchema = z.object({
+  type: z.literal("artifact"),
+  metadata: issueArtifactWorkProductMetadataSchema,
+  createdByRunId: z.string().uuid(),
+});
+
+export function getIssueArtifactWorkProductValidationIssues(value: {
+  type: unknown;
+  metadata: unknown;
+  createdByRunId: unknown;
+}) {
+  if (value.type !== "artifact") return [];
+  const parsed = issueArtifactWorkProductPersistenceSchema.safeParse(value);
+  return parsed.success ? [] : parsed.error.issues;
+}
+
+function validateArtifactWorkProductRequirements(
+  value: {
+    type?: unknown;
+    metadata?: unknown;
+    createdByRunId?: unknown;
+  },
+  ctx: z.RefinementCtx,
+) {
+  if (value.type !== "artifact") return;
+  for (const issue of getIssueArtifactWorkProductValidationIssues({
+    type: value.type,
+    metadata: value.metadata,
+    createdByRunId: value.createdByRunId,
+  })) {
+    ctx.addIssue(issue);
+  }
+}
+
+const issueWorkProductBaseSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
   executionWorkspaceId: z.string().uuid().optional().nullable(),
   runtimeServiceId: z.string().uuid().optional().nullable(),
@@ -37,7 +90,7 @@ export const createIssueWorkProductSchema = z.object({
   provider: z.string().min(1),
   externalId: z.string().optional().nullable(),
   title: z.string().min(1),
-  url: z.string().url().optional().nullable(),
+  url: issueWorkProductUrlSchema.optional().nullable(),
   status: issueWorkProductStatusSchema.default("active"),
   reviewState: issueWorkProductReviewStateSchema.optional().default("none"),
   isPrimary: z.boolean().optional().default(false),
@@ -47,8 +100,14 @@ export const createIssueWorkProductSchema = z.object({
   createdByRunId: z.string().uuid().optional().nullable(),
 });
 
+export const createIssueWorkProductSchema = issueWorkProductBaseSchema.superRefine(
+  validateArtifactWorkProductRequirements,
+);
+
 export type CreateIssueWorkProduct = z.infer<typeof createIssueWorkProductSchema>;
 
-export const updateIssueWorkProductSchema = createIssueWorkProductSchema.partial();
+export const updateIssueWorkProductSchema = issueWorkProductBaseSchema.partial().superRefine(
+  validateArtifactWorkProductRequirements,
+);
 
 export type UpdateIssueWorkProduct = z.infer<typeof updateIssueWorkProductSchema>;

--- a/packages/shared/src/validators/work-product.ts
+++ b/packages/shared/src/validators/work-product.ts
@@ -43,14 +43,16 @@ const issueWorkProductUrlSchema = z.string().trim().min(1).refine((value) => {
   }
 }, "Invalid url");
 
-export const issueArtifactWorkProductMetadataSchema = z.object({
+const issueArtifactWorkProductMetadataFieldsSchema = z.object({
   attachmentId: z.string().uuid(),
   contentPath: z.string().trim().min(1),
   sourcePath: z.string().trim().min(1),
   contentType: z.string().trim().min(1),
   byteSize: z.number().int().positive(),
   originalFilename: z.string().trim().min(1).nullable().optional().transform((v) => v ?? null),
-}).strict().superRefine((value, ctx) => {
+});
+
+function refineIssueArtifactWorkProductMetadata(value: z.infer<typeof issueArtifactWorkProductMetadataFieldsSchema>, ctx: z.RefinementCtx) {
   const expectedPath = buildIssueAttachmentContentPath(value.attachmentId);
   if (value.contentPath !== expectedPath) {
     ctx.addIssue({
@@ -59,7 +61,20 @@ export const issueArtifactWorkProductMetadataSchema = z.object({
       path: ["contentPath"],
     });
   }
-});
+}
+
+export const issueArtifactWorkProductMetadataSchema = issueArtifactWorkProductMetadataFieldsSchema
+  .strict()
+  .superRefine(refineIssueArtifactWorkProductMetadata);
+
+const issueArtifactWorkProductStoredMetadataSchema = issueArtifactWorkProductMetadataFieldsSchema
+  .strip()
+  .superRefine(refineIssueArtifactWorkProductMetadata);
+
+export function sanitizeStoredIssueArtifactWorkProductMetadata(value: unknown): unknown {
+  const parsed = issueArtifactWorkProductStoredMetadataSchema.safeParse(value);
+  return parsed.success ? parsed.data : value;
+}
 
 const issueArtifactWorkProductPersistenceSchema = z.object({
   type: z.literal("artifact"),

--- a/packages/shared/src/validators/work-product.ts
+++ b/packages/shared/src/validators/work-product.ts
@@ -49,7 +49,7 @@ export const issueArtifactWorkProductMetadataSchema = z.object({
   sourcePath: z.string().trim().min(1),
   contentType: z.string().trim().min(1),
   byteSize: z.number().int().positive(),
-  originalFilename: z.string().trim().min(1).nullable().optional(),
+  originalFilename: z.string().trim().min(1).nullable().optional().transform((v) => v ?? null),
 }).strict().superRefine((value, ctx) => {
   const expectedPath = buildIssueAttachmentContentPath(value.attachmentId);
   if (value.contentPath !== expectedPath) {

--- a/packages/shared/src/validators/work-product.ts
+++ b/packages/shared/src/validators/work-product.ts
@@ -91,6 +91,21 @@ const issueArtifactWorkProductPersistenceSchema = z.object({
   }
 });
 
+const issueArtifactWorkProductStoredPersistenceSchema = z.object({
+  type: z.literal("artifact"),
+  url: issueWorkProductUrlSchema.optional().nullable(),
+  metadata: issueArtifactWorkProductStoredMetadataSchema,
+  createdByRunId: z.string().uuid().nullable().optional(),
+}).superRefine((value, ctx) => {
+  if (value.url !== undefined && value.url !== null && value.url !== value.metadata.contentPath) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Artifact url must match metadata.contentPath",
+      path: ["url"],
+    });
+  }
+});
+
 export function getIssueArtifactWorkProductValidationIssues(value: {
   type: unknown;
   url?: unknown;
@@ -99,6 +114,17 @@ export function getIssueArtifactWorkProductValidationIssues(value: {
 }) {
   if (value.type !== "artifact") return [];
   const parsed = issueArtifactWorkProductPersistenceSchema.safeParse(value);
+  return parsed.success ? [] : parsed.error.issues;
+}
+
+export function getStoredIssueArtifactWorkProductValidationIssues(value: {
+  type: unknown;
+  url?: unknown;
+  metadata: unknown;
+  createdByRunId: unknown;
+}) {
+  if (value.type !== "artifact") return [];
+  const parsed = issueArtifactWorkProductStoredPersistenceSchema.safeParse(value);
   return parsed.success ? [] : parsed.error.issues;
 }
 

--- a/packages/shared/src/validators/work-product.ts
+++ b/packages/shared/src/validators/work-product.ts
@@ -29,6 +29,10 @@ export const issueWorkProductReviewStateSchema = z.enum([
   "changes_requested",
 ]);
 
+function buildIssueAttachmentContentPath(attachmentId: string) {
+  return `/api/attachments/${attachmentId}/content`;
+}
+
 const issueWorkProductUrlSchema = z.string().trim().min(1).refine((value) => {
   if (value.startsWith("/")) return true;
   try {
@@ -46,16 +50,35 @@ export const issueArtifactWorkProductMetadataSchema = z.object({
   contentType: z.string().trim().min(1),
   byteSize: z.number().int().positive(),
   originalFilename: z.string().trim().min(1).nullable().optional(),
-}).strict();
+}).strict().superRefine((value, ctx) => {
+  const expectedPath = buildIssueAttachmentContentPath(value.attachmentId);
+  if (value.contentPath !== expectedPath) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Artifact contentPath must reference its attachment API route",
+      path: ["contentPath"],
+    });
+  }
+});
 
 const issueArtifactWorkProductPersistenceSchema = z.object({
   type: z.literal("artifact"),
+  url: issueWorkProductUrlSchema.optional().nullable(),
   metadata: issueArtifactWorkProductMetadataSchema,
   createdByRunId: z.string().uuid(),
+}).superRefine((value, ctx) => {
+  if (value.url !== undefined && value.url !== null && value.url !== value.metadata.contentPath) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Artifact url must match metadata.contentPath",
+      path: ["url"],
+    });
+  }
 });
 
 export function getIssueArtifactWorkProductValidationIssues(value: {
   type: unknown;
+  url?: unknown;
   metadata: unknown;
   createdByRunId: unknown;
 }) {
@@ -67,6 +90,7 @@ export function getIssueArtifactWorkProductValidationIssues(value: {
 function validateArtifactWorkProductRequirements(
   value: {
     type?: unknown;
+    url?: unknown;
     metadata?: unknown;
     createdByRunId?: unknown;
   },
@@ -75,6 +99,7 @@ function validateArtifactWorkProductRequirements(
   if (value.type !== "artifact") return;
   for (const issue of getIssueArtifactWorkProductValidationIssues({
     type: value.type,
+    url: value.url,
     metadata: value.metadata,
     createdByRunId: value.createdByRunId,
   })) {

--- a/packages/shared/src/validators/work-product.ts
+++ b/packages/shared/src/validators/work-product.ts
@@ -34,7 +34,7 @@ function buildIssueAttachmentContentPath(attachmentId: string) {
 }
 
 const issueWorkProductUrlSchema = z.string().trim().min(1).refine((value) => {
-  if (value.startsWith("/")) return true;
+  if (value.startsWith("/api/")) return true;
   try {
     new URL(value);
     return true;
@@ -52,6 +52,10 @@ const issueArtifactWorkProductMetadataFieldsSchema = z.object({
   originalFilename: z.string().trim().min(1).nullable().optional().transform((v) => v ?? null),
 });
 
+const issueArtifactWorkProductStoredMetadataFieldsSchema = issueArtifactWorkProductMetadataFieldsSchema.extend({
+  byteSize: z.number().int().nonnegative(),
+});
+
 function refineIssueArtifactWorkProductMetadata(value: z.infer<typeof issueArtifactWorkProductMetadataFieldsSchema>, ctx: z.RefinementCtx) {
   const expectedPath = buildIssueAttachmentContentPath(value.attachmentId);
   if (value.contentPath !== expectedPath) {
@@ -67,7 +71,7 @@ export const issueArtifactWorkProductMetadataSchema = issueArtifactWorkProductMe
   .strict()
   .superRefine(refineIssueArtifactWorkProductMetadata);
 
-const issueArtifactWorkProductStoredMetadataSchema = issueArtifactWorkProductMetadataFieldsSchema
+const issueArtifactWorkProductStoredMetadataSchema = issueArtifactWorkProductStoredMetadataFieldsSchema
   .strip()
   .superRefine(refineIssueArtifactWorkProductMetadata);
 

--- a/server/src/__tests__/issue-work-product-routes.test.ts
+++ b/server/src/__tests__/issue-work-product-routes.test.ts
@@ -175,4 +175,41 @@ describe("issue work product routes", () => {
     expect(res.status).toBe(200);
     expect(mockWorkProductService.update).toHaveBeenCalledWith(workProductId, { title: "Recovered title" });
   });
+
+  it("rejects artifact updates that try to patch in a filesystem contentPath and fake attachment route", async () => {
+    mockWorkProductService.getById.mockResolvedValue({
+      id: workProductId,
+      companyId,
+      issueId,
+      type: "artifact",
+      url: `/api/attachments/${attachmentId}/content`,
+      metadata: {
+        attachmentId,
+        contentPath: `/api/attachments/${attachmentId}/content`,
+        sourcePath: "deliverables/final-packet.md",
+        contentType: "text/markdown",
+        byteSize: 128,
+        originalFilename: "final-packet.md",
+      },
+      createdByRunId: runId,
+    });
+
+    const res = await request(createApp())
+      .patch(`/api/work-products/${workProductId}`)
+      .send({
+        metadata: {
+          attachmentId,
+          contentPath: "/home/node/.openclaw/workspace-ceo/ceo-config-and-runs-report.md",
+          sourcePath: "deliverables/final-packet.md",
+          contentType: "text/markdown",
+          byteSize: 128,
+          originalFilename: "ceo-config-and-runs-report.md",
+        },
+        url: "/home/node/.openclaw/workspace-ceo/ceo-config-and-runs-report.md",
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("attachment-backed metadata");
+    expect(mockWorkProductService.update).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-work-product-routes.test.ts
+++ b/server/src/__tests__/issue-work-product-routes.test.ts
@@ -212,4 +212,41 @@ describe("issue work product routes", () => {
     expect(res.body.error).toContain("attachment-backed metadata");
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
   });
+
+  it("rejects request metadata with extra keys even when PATCH omits type", async () => {
+    mockWorkProductService.getById.mockResolvedValue({
+      id: workProductId,
+      companyId,
+      issueId,
+      type: "artifact",
+      url: `/api/attachments/${attachmentId}/content`,
+      metadata: {
+        attachmentId,
+        contentPath: `/api/attachments/${attachmentId}/content`,
+        sourcePath: "deliverables/final-packet.md",
+        contentType: "text/markdown",
+        byteSize: 128,
+        originalFilename: "final-packet.md",
+      },
+      createdByRunId: runId,
+    });
+
+    const res = await request(createApp())
+      .patch(`/api/work-products/${workProductId}`)
+      .send({
+        metadata: {
+          attachmentId,
+          contentPath: `/api/attachments/${attachmentId}/content`,
+          sourcePath: "deliverables/final-packet.md",
+          contentType: "text/markdown",
+          byteSize: 128,
+          originalFilename: "final-packet.md",
+          contentBase64: "IyBGaW5hbCBwYWNrZXQK",
+        },
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("attachment-backed metadata");
+    expect(mockWorkProductService.update).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-work-product-routes.test.ts
+++ b/server/src/__tests__/issue-work-product-routes.test.ts
@@ -205,7 +205,7 @@ describe("issue work product routes", () => {
           byteSize: 128,
           originalFilename: "ceo-config-and-runs-report.md",
         },
-        url: "/home/node/.openclaw/workspace-ceo/ceo-config-and-runs-report.md",
+        url: `/api/attachments/${attachmentId}/content`,
       });
 
     expect(res.status).toBe(422);

--- a/server/src/__tests__/issue-work-product-routes.test.ts
+++ b/server/src/__tests__/issue-work-product-routes.test.ts
@@ -1,0 +1,178 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+
+const companyId = "22222222-2222-4222-8222-222222222222";
+const issueId = "11111111-1111-4111-8111-111111111111";
+const workProductId = "33333333-3333-4333-8333-333333333333";
+const runId = "44444444-4444-4444-8444-444444444444";
+const attachmentId = "55555555-5555-4555-8555-555555555555";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockWorkProductService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentTaskCompleted: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+vi.mock("../otel.js", () => ({
+  recordHumanComment: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({ canUser: vi.fn(), hasPermission: vi.fn() }),
+  agentService: () => ({ getById: vi.fn(), list: vi.fn(), resolveByReference: vi.fn() }),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+  }),
+  goalService: () => ({}),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+    getRun: vi.fn(async () => null),
+    getActiveRunForAgent: vi.fn(async () => null),
+    cancelRun: vi.fn(async () => null),
+  }),
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => [companyId]),
+  }),
+  issueApprovalService: () => ({}),
+  issueThreadInteractionService: () => ({
+    expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+    expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  }),
+  issueReferenceService: () => ({
+    deleteDocumentSource: vi.fn(async () => undefined),
+    diffIssueReferenceSummary: vi.fn(() => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    })),
+    emptySummary: vi.fn(() => ({ outbound: [], inbound: [] })),
+    listIssueReferenceSummary: vi.fn(async () => ({ outbound: [], inbound: [] })),
+    syncComment: vi.fn(async () => undefined),
+    syncDocument: vi.fn(async () => undefined),
+    syncIssue: vi.fn(async () => undefined),
+  }),
+  issueService: () => mockIssueService,
+  documentService: () => ({ upsertIssueDocument: vi.fn() }),
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => mockWorkProductService,
+  ISSUE_LIST_DEFAULT_LIMIT: 20,
+  ISSUE_LIST_MAX_LIMIT: 100,
+  clampIssueListLimit: (value: number) => value,
+}));
+
+import { issueRoutes } from "../routes/issues.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      source: "session",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {
+    provider: "local_disk",
+    putFile: vi.fn(),
+    getObject: vi.fn(),
+    headObject: vi.fn(),
+    deleteObject: vi.fn(),
+  } as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue work product routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.getById.mockResolvedValue({
+      id: issueId,
+      companyId,
+      status: "todo",
+      assigneeAgentId: null,
+      projectId: null,
+    });
+  });
+
+  it("rejects updates when the merged artifact state is still missing attachment-backed metadata", async () => {
+    mockWorkProductService.getById.mockResolvedValue({
+      id: workProductId,
+      companyId,
+      issueId,
+      type: "artifact",
+      metadata: null,
+      createdByRunId: null,
+    });
+
+    const res = await request(createApp())
+      .patch(`/api/work-products/${workProductId}`)
+      .send({ title: "Recovered title" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("attachment-backed metadata");
+    expect(mockWorkProductService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows artifact updates when the stored metadata stays attachment-backed", async () => {
+    mockWorkProductService.getById.mockResolvedValue({
+      id: workProductId,
+      companyId,
+      issueId,
+      type: "artifact",
+      metadata: {
+        attachmentId,
+        contentPath: `/api/attachments/${attachmentId}/content`,
+        sourcePath: "deliverables/final-packet.md",
+        contentType: "text/markdown",
+        byteSize: 128,
+        originalFilename: "final-packet.md",
+      },
+      createdByRunId: runId,
+    });
+    mockWorkProductService.update.mockResolvedValue({
+      id: workProductId,
+      title: "Recovered title",
+    });
+
+    const res = await request(createApp())
+      .patch(`/api/work-products/${workProductId}`)
+      .send({ title: "Recovered title" });
+
+    expect(res.status).toBe(200);
+    expect(mockWorkProductService.update).toHaveBeenCalledWith(workProductId, { title: "Recovered title" });
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -10,6 +10,7 @@ import {
   acceptIssueThreadInteractionSchema,
   createIssueAttachmentMetadataSchema,
   getIssueArtifactWorkProductValidationIssues,
+  sanitizeStoredIssueArtifactWorkProductMetadata,
   createIssueThreadInteractionSchema,
   createIssueWorkProductSchema,
   createIssueLabelSchema,
@@ -1376,7 +1377,9 @@ export function issueRoutes(
     const artifactValidationIssues = getIssueArtifactWorkProductValidationIssues({
       type: "type" in req.body ? req.body.type : existing.type,
       url: "url" in req.body ? req.body.url : existing.url,
-      metadata: "metadata" in req.body ? req.body.metadata : existing.metadata,
+      metadata: "metadata" in req.body
+        ? req.body.metadata
+        : sanitizeStoredIssueArtifactWorkProductMetadata(existing.metadata),
       createdByRunId: "createdByRunId" in req.body ? req.body.createdByRunId : existing.createdByRunId,
     });
     if (artifactValidationIssues.length > 0) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -10,6 +10,7 @@ import {
   acceptIssueThreadInteractionSchema,
   createIssueAttachmentMetadataSchema,
   getIssueArtifactWorkProductValidationIssues,
+  getStoredIssueArtifactWorkProductValidationIssues,
   sanitizeStoredIssueArtifactWorkProductMetadata,
   createIssueThreadInteractionSchema,
   createIssueWorkProductSchema,
@@ -1374,7 +1375,7 @@ export function issueRoutes(
       return;
     }
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
-    const artifactValidationIssues = getIssueArtifactWorkProductValidationIssues({
+    const artifactValidationIssues = getStoredIssueArtifactWorkProductValidationIssues({
       type: "type" in req.body ? req.body.type : existing.type,
       url: "url" in req.body ? req.body.url : existing.url,
       metadata: "metadata" in req.body

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1375,6 +1375,7 @@ export function issueRoutes(
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     const artifactValidationIssues = getIssueArtifactWorkProductValidationIssues({
       type: req.body.type ?? existing.type,
+      url: req.body.url ?? existing.url,
       metadata: req.body.metadata ?? existing.metadata,
       createdByRunId: req.body.createdByRunId ?? existing.createdByRunId,
     });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1374,10 +1374,10 @@ export function issueRoutes(
     }
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     const artifactValidationIssues = getIssueArtifactWorkProductValidationIssues({
-      type: req.body.type ?? existing.type,
-      url: req.body.url ?? existing.url,
-      metadata: req.body.metadata ?? existing.metadata,
-      createdByRunId: req.body.createdByRunId ?? existing.createdByRunId,
+      type: "type" in req.body ? req.body.type : existing.type,
+      url: "url" in req.body ? req.body.url : existing.url,
+      metadata: "metadata" in req.body ? req.body.metadata : existing.metadata,
+      createdByRunId: "createdByRunId" in req.body ? req.body.createdByRunId : existing.createdByRunId,
     });
     if (artifactValidationIssues.length > 0) {
       res.status(422).json({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9,6 +9,7 @@ import {
   addIssueCommentSchema,
   acceptIssueThreadInteractionSchema,
   createIssueAttachmentMetadataSchema,
+  getIssueArtifactWorkProductValidationIssues,
   createIssueThreadInteractionSchema,
   createIssueWorkProductSchema,
   createIssueLabelSchema,
@@ -1372,6 +1373,18 @@ export function issueRoutes(
       return;
     }
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    const artifactValidationIssues = getIssueArtifactWorkProductValidationIssues({
+      type: req.body.type ?? existing.type,
+      metadata: req.body.metadata ?? existing.metadata,
+      createdByRunId: req.body.createdByRunId ?? existing.createdByRunId,
+    });
+    if (artifactValidationIssues.length > 0) {
+      res.status(422).json({
+        error: "Artifact work products require attachment-backed metadata and createdByRunId",
+        details: artifactValidationIssues,
+      });
+      return;
+    }
     const product = await workProductsSvc.update(id, req.body);
     if (!product) {
       res.status(404).json({ error: "Work product not found" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1375,14 +1375,26 @@ export function issueRoutes(
       return;
     }
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
-    const artifactValidationIssues = getStoredIssueArtifactWorkProductValidationIssues({
-      type: "type" in req.body ? req.body.type : existing.type,
-      url: "url" in req.body ? req.body.url : existing.url,
-      metadata: "metadata" in req.body
-        ? req.body.metadata
-        : sanitizeStoredIssueArtifactWorkProductMetadata(existing.metadata),
-      createdByRunId: "createdByRunId" in req.body ? req.body.createdByRunId : existing.createdByRunId,
-    });
+    const mergedType = "type" in req.body ? req.body.type : existing.type;
+    const mergedUrl = "url" in req.body ? req.body.url : existing.url;
+    const mergedCreatedByRunId = "createdByRunId" in req.body ? req.body.createdByRunId : existing.createdByRunId;
+    const requestProvidedMetadata = "metadata" in req.body;
+    const mergedMetadata = requestProvidedMetadata
+      ? req.body.metadata
+      : sanitizeStoredIssueArtifactWorkProductMetadata(existing.metadata);
+    const artifactValidationIssues = requestProvidedMetadata
+      ? getIssueArtifactWorkProductValidationIssues({
+          type: mergedType,
+          url: mergedUrl,
+          metadata: mergedMetadata,
+          createdByRunId: mergedCreatedByRunId,
+        })
+      : getStoredIssueArtifactWorkProductValidationIssues({
+          type: mergedType,
+          url: mergedUrl,
+          metadata: mergedMetadata,
+          createdByRunId: mergedCreatedByRunId,
+        });
     if (artifactValidationIssues.length > 0) {
       res.status(422).json({
         error: "Artifact work products require attachment-backed metadata and createdByRunId",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3883,7 +3883,10 @@ export function heartbeatService(db: Db) {
         continue;
       }
 
-      const upserted = await workProductsSvc.upsertByExternalId(issueId, input.run.companyId, parsedWorkProduct.data);
+      const upserted = await workProductsSvc.upsertByExternalId(issueId, input.run.companyId, {
+        ...parsedWorkProduct.data,
+        externalId,
+      });
 
       // Re-read the authoritative state to detect a concurrent-run race where
       // another upsert overwrote our metadata after we wrote it.  If the stored

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3850,14 +3850,21 @@ export function heartbeatService(db: Db) {
         createdByRunId: input.run.id,
       });
       if (!parsedWorkProduct.success) {
-        const removedAttachment = await issuesSvc.removeAttachment(attachment.id);
-        if (removedAttachment) {
-          await storage.deleteObject(removedAttachment.companyId, removedAttachment.objectKey).catch((err) => {
-            logger.warn(
-              { err, attachmentId: removedAttachment.id, objectKey: removedAttachment.objectKey },
-              "failed to delete invalid artifact attachment object",
-            );
-          });
+        try {
+          const removedAttachment = await issuesSvc.removeAttachment(attachment.id);
+          if (removedAttachment) {
+            await storage.deleteObject(removedAttachment.companyId, removedAttachment.objectKey).catch((err) => {
+              logger.warn(
+                { err, attachmentId: removedAttachment.id, objectKey: removedAttachment.objectKey },
+                "failed to delete invalid artifact attachment object",
+              );
+            });
+          }
+        } catch (err) {
+          logger.warn(
+            { err, attachmentId: attachment.id, sourcePath: artifact.sourcePath, runId: input.run.id },
+            "failed to remove invalid artifact attachment after validation failure",
+          );
         }
         logger.warn(
           { issues: parsedWorkProduct.error.issues, sourcePath: artifact.sourcePath, runId: input.run.id },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8,6 +8,7 @@ import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
+  createIssueWorkProductSchema,
   parseIssueArtifactWorkProductMetadata,
   type BillingType,
   type EnvironmentLeaseStatus,
@@ -3848,8 +3849,7 @@ export function heartbeatService(db: Db) {
       const existing = await workProductsSvc.findByExternalIdForIssue(issueId, input.run.companyId, externalId);
       const previousMetadata = existing ? parseIssueArtifactWorkProductMetadata(existing) : null;
       const isUpdate = existing !== null;
-
-      const upserted = await workProductsSvc.upsertByExternalId(issueId, input.run.companyId, {
+      const parsedWorkProduct = createIssueWorkProductSchema.safeParse({
         projectId: issue.projectId ?? null,
         executionWorkspaceId: issue.executionWorkspaceId ?? null,
         runtimeServiceId: null,
@@ -3866,6 +3866,24 @@ export function heartbeatService(db: Db) {
         metadata,
         createdByRunId: input.run.id,
       });
+      if (!parsedWorkProduct.success) {
+        const removedAttachment = await issuesSvc.removeAttachment(attachment.id);
+        if (removedAttachment) {
+          await storage.deleteObject(removedAttachment.companyId, removedAttachment.objectKey).catch((err) => {
+            logger.warn(
+              { err, attachmentId: removedAttachment.id, objectKey: removedAttachment.objectKey },
+              "failed to delete invalid artifact attachment object",
+            );
+          });
+        }
+        logger.warn(
+          { issues: parsedWorkProduct.error.issues, sourcePath: artifact.sourcePath, runId: input.run.id },
+          "constructed artifact work product payload failed validation — skipping artifact",
+        );
+        continue;
+      }
+
+      const upserted = await workProductsSvc.upsertByExternalId(issueId, input.run.companyId, parsedWorkProduct.data);
 
       // Re-read the authoritative state to detect a concurrent-run race where
       // another upsert overwrote our metadata after we wrote it.  If the stored

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3817,23 +3817,6 @@ export function heartbeatService(db: Db) {
         createdByAgentId: input.agent.id,
       });
 
-      await logActivity(db, {
-        companyId: input.run.companyId,
-        actorType: "agent",
-        actorId: input.agent.id,
-        agentId: input.agent.id,
-        runId: input.run.id,
-        action: "issue.attachment_added",
-        entityType: "issue",
-        entityId: issueId,
-        details: {
-          attachmentId: attachment.id,
-          originalFilename: attachment.originalFilename,
-          contentType: attachment.contentType,
-          byteSize: attachment.byteSize,
-        },
-      });
-
       const metadata = {
         attachmentId: attachment.id,
         contentPath: `/api/attachments/${attachment.id}/content`,
@@ -3907,6 +3890,24 @@ export function heartbeatService(db: Db) {
           });
         }
       } else {
+        if (upserted) {
+          await logActivity(db, {
+            companyId: input.run.companyId,
+            actorType: "agent",
+            actorId: input.agent.id,
+            agentId: input.agent.id,
+            runId: input.run.id,
+            action: "issue.attachment_added",
+            entityType: "issue",
+            entityId: issueId,
+            details: {
+              attachmentId: attachment.id,
+              originalFilename: attachment.originalFilename,
+              contentType: attachment.contentType,
+              byteSize: attachment.byteSize,
+            },
+          });
+        }
         // Normal path: clean up the previous attachment if it was replaced.
         if (isUpdate && previousMetadata?.attachmentId && previousMetadata.attachmentId !== attachment.id) {
           const removed = await issuesSvc.removeAttachment(previousMetadata.attachmentId);


### PR DESCRIPTION
This pull request introduces stricter validation and improved handling for "artifact" issue work products, ensuring that artifact work products always have attachment-backed metadata and an associated `createdByRunId`. The changes add new schema validators, runtime type guards, and integrate these checks into both the shared validation logic and the server-side update and creation flows. Comprehensive tests are also included to verify the new validation behavior.

**Validation and Type Guard Enhancements**
- Added `isIssueArtifactWorkProductMetadata` type guard to check if metadata conforms to the expected structure for artifact work products (`packages/shared/src/types/work-product.ts`).
- Updated `parseIssueArtifactWorkProductMetadata` to use the new type guard, ensuring only valid metadata is parsed (`packages/shared/src/types/work-product.ts`).
- Exported `isIssueArtifactWorkProductMetadata` and related types from shared entry points for broader usage (`packages/shared/src/index.ts`, `packages/shared/src/types/index.ts`). [[1]](diffhunk://#diff-ecabfdd7e2be0565549135ce454f50ce3db926b4951903c474d35d9037790aeaL496-R499) [[2]](diffhunk://#diff-43b22797af0cdf77adb47b4b1a2145191d4007a15da3b198b5ac364bdc811c24L112-R115)

**Schema Validation Improvements**
- Introduced `issueArtifactWorkProductMetadataSchema` and related validation helpers to enforce required fields for artifact work products, including on partial updates (`packages/shared/src/validators/work-product.ts`).
- Updated `createIssueWorkProductSchema` and `updateIssueWorkProductSchema` to use stricter validation for artifact work products, ensuring attachment-backed metadata and `createdByRunId` are always present (`packages/shared/src/validators/work-product.ts`).
- Exported new validators for use in other modules (`packages/shared/src/validators/index.ts`, `packages/shared/src/index.ts`). [[1]](diffhunk://#diff-6f29232cc7139f9713bcab706850b6828ff61b8544b79738cb4aed7f38a97b50R217-R218) [[2]](diffhunk://#diff-ecabfdd7e2be0565549135ce454f50ce3db926b4951903c474d35d9037790aeaR659-R660)

**Server Integration and Enforcement**
- Integrated artifact validation into the work product update API, returning a 422 error if artifact requirements are not met (`server/src/routes/issues.ts`). [[1]](diffhunk://#diff-e80a71553f161363b7a3fc25018f288df58941381605bd46f3484e2d56099310R1376-R1387) [[2]](diffhunk://#diff-e80a71553f161363b7a3fc25018f288df58941381605bd46f3484e2d56099310R12)
- Updated the heartbeat service to validate artifact work products before upserting and to clean up invalid attachments if validation fails (`server/src/services/heartbeat.ts`). [[1]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L3851-R3852) [[2]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R3869-R3886) [[3]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R11)

**Test Coverage**
- Added comprehensive tests for artifact work product validation, including creation and update scenarios, to ensure the new requirements are enforced (`packages/shared/src/validators/work-product.test.ts`, `server/src/__tests__/issue-work-product-routes.test.ts`). [[1]](diffhunk://#diff-106fc11ecec30d7a096c1d29da13096c2502d182922caf8dc4371899ee3ae661R1-R69) [[2]](diffhunk://#diff-257fe970bf6cf04dfc50f5d93af82fa211032d87e830c8021d27514e7b3d4933R1-R178)