### PR TITLE
Add Bizbox Journey Story

### DIFF
--- a/docs/blog/bizbox-journey-story.md
+++ b/docs/blog/bizbox-journey-story.md
@@ -1,0 +1,132 @@
+---
+slug: bizbox-journey-story
+title: "The Bizbox Journey: Building AI Agents That Actually Ship"
+channels:
+  - discourse
+discourse_category: announcements
+discourse_tags:
+  - journey
+  - community
+  - build-in-public
+author: Dev Advocate
+date: 2026-05-07
+---
+
+# The Bizbox Journey: Building AI Agents That Actually Ship
+
+Hey everyone,
+
+We wanted to step back from the weekly build logs and share the story of how Bizbox came to be — the people, the pivots, the hard-won lessons, and the path from "what if AI agents could actually manage work?" to where we are today.
+
+## Why We Started Bizbox
+
+Every project starts with a problem. For us, it was watching teams drown in coordination overhead while AI sat on the sidelines, only useful for one-off prompts.
+
+We asked: **What if AI agents weren't just chatbots, but actual team members who could own tasks, manage workflows, and ship results?**
+
+Not "AI co-pilots" that require constant human supervision. Not glorified autocomplete. Real autonomous agents that could take a brief, break it down, coordinate with other agents, and deliver finished work.
+
+That was the vision. Making it real? That's been the journey.
+
+## The Early Days: First Code, First Reality Checks
+
+**Late April 2026:** The first Bizbox agents started running. Not perfectly. Not elegantly. But *running*.
+
+Early wins:
+- **Agent provisioning via open broker framework:** We built a system where agents could be spun up, assigned work, and tracked — all programmatically.
+- **Content automation pipelines:** Weekly Build Logs and monthly Deep Dives went from manual→automated→*good enough to ship*.
+- **Multi-agent coordination:** Agents started handing work to each other (Dev Advocate → Tech Reviewer → DevRel Lead → Dennis for approval).
+
+Early failures:
+- **The $300/month cost crisis (05/05/2026):** An adapter loop caused 900+ token attempts in a single run. Our AWS bill exploded. We scrambled to implement spending caps and gating logic.
+- **Status confusion:** We had "done" and "complete" statuses that meant different things to different agents. Took weeks to standardize.
+- **Quality vs. cost tension:** Sonnet was cheap but inconsistent. Opus was expensive but reliable. We're still finding the right balance.
+
+The lesson: **Building in public means your mistakes are visible.** But it also means you get real-time feedback from people who genuinely want to help.
+
+## Growing Pains: What We Learned Shipping v0.0.x
+
+By early May, we had agents shipping content, managing issues, and running routines. But "working" and "working *well*" are different things.
+
+### Challenge 1: Security & Infrastructure
+
+**The X.com proxy problem (05/07/2026):** X's callback URI restrictions blocked our agents from posting. We couldn't expose our internal network. Solution? Built a secure proxy layer. Not glamorous. But necessary.
+
+**Lesson learned:** Real-world integrations always have sharp edges. You don't find them until you ship.
+
+### Challenge 2: Agent Reliability
+
+**The Otto article retrieval bug (05/07/2026):** One of our agents kept failing to fetch articles. Root cause? A stale authentication token that only surfaced under specific conditions.
+
+We built end-to-end tests. We added health checks. We made agent runs *observable* so when something broke, we could trace it.
+
+**Lesson learned:** Autonomous agents need better instrumentation than human-driven tools. If an agent fails silently, you lose trust fast.
+
+### Challenge 3: Quality Control
+
+**The SLT feedback loop (05/05/2026):** Our senior leadership team started reviewing agent output. Their verdict? "Good structure, inconsistent depth."
+
+We couldn't just throw more compute at it. We needed:
+- Clearer prompts (we borrowed the Growth team's evaluation framework)
+- Better review workflows (multi-agent approval chains)
+- Human checkpoints at the right places (Dennis approves all public-facing content)
+
+**Lesson learned:** Agents don't replace editorial judgment. They *scale* it. But humans still own the final call.
+
+## Developer Experience: Making Bizbox Approachable
+
+One of our proudest achievements: lowering the barrier to contribution.
+
+**What that looked like:**
+- **Documentation-first PRs:** Every code change ships with updated docs. No exceptions.
+- **Architecture Decision Records (ADRs):** Every non-trivial choice gets documented — not just *what* we chose, but *why*, and what we gave up.
+- **Build-in-public guardrails:** We don't leak internal context. We don't overpromise. We link every claim to a PR, issue, or release.
+- **Active triage:** GitHub issues and Discourse threads get a response within 24 hours. Not always a solution, but always acknowledgment.
+
+These weren't flashy features. They were unglamorous infrastructure work. But they compounded. Every improvement made the next contribution smoother.
+
+## The Team: Real People, Real Work
+
+Bizbox isn't just code. It's a team of humans and agents working together.
+
+**The humans:**
+- **Dennis:** CEO, final approver, the person who asks the hard questions that make us better.
+- **Jonathan, Angelo, Ralph, Adrean:** The engineers who built the agent runtime, the proxy layer, the cost controls, the dashboards.
+- **Rachel & Long:** Quality advocates who pushed us to standardize evaluation and measure what matters.
+- **Early adopters:** The people who filed issues, tested breaking changes, and gave honest feedback when features missed the mark.
+
+**The agents:**
+- **Dev Advocate:** Ships weekly Build Logs, runs community triage, handles syndication.
+- **Tech Reviewer:** Checks technical accuracy, flags internal leaks, ensures we're grounded in real repo activity.
+- **DevRel Lead:** Coordinates the content pipeline, routes for approval, keeps the cadence moving.
+
+Every merged PR, every thoughtful issue comment, every agent run that shipped clean output — those are the threads that make Bizbox what it is.
+
+## What's Next: Join Us
+
+We're not done. Not even close.
+
+**What we're building:**
+- Better agent observability (token usage, intervention tracking, cost attribution)
+- Richer inter-agent coordination (agents proposing work to each other, not just executing assigned tasks)
+- Public agent marketplace (share your agent configs, learn from others)
+- Tighter feedback loops (measure participation, run experiments, iterate weekly)
+
+**Where you can help:**
+- **Try Bizbox:** Spin up an agent, assign it work, see what breaks.
+- **Contribute:** Check the [good first issue](https://github.com/zesthq/bizbox/labels/good%20first%20issue) label. Or propose something entirely new.
+- **Join the conversation:** [GitHub Discussions](https://github.com/zesthq/bizbox/discussions), [Discourse](https://bizboxai.discourse.group), and X ([@BizboxAI](https://twitter.com/BizboxAI)) are where the real work happens.
+
+Building autonomous agents is hard. Building *trustworthy* autonomous agents is harder. But we're doing it in public, learning together, and shipping every week.
+
+Thanks for being part of this journey.
+
+---
+
+**Related Links**
+- [Bizbox on GitHub](https://github.com/zesthq/bizbox)
+- [Roadmap](https://github.com/zesthq/bizbox/blob/master/ROADMAP.md)
+- [Build Logs Archive](https://bizboxai.discourse.group/c/build-logs)
+- [Weekly Build Log (May 2–8, 2026)](https://github.com/zesthq/bizbox/discussions/31)
+
+— The Bizbox Team

--- a/docs/blog/bizbox-journey-story.md
+++ b/docs/blog/bizbox-journey-story.md
@@ -30,7 +30,7 @@ That was the vision. Making it real? That's been the journey.
 
 ## The Early Days: First Code, First Reality Checks
 
-**Late April 2026:** The first Bizbox agents started running. Not perfectly. Not elegantly. But *running*.
+**Mid-April 2026:** The first Bizbox agents started running. Not perfectly. Not elegantly. But *running*.
 
 Early wins:
 - **Agent provisioning via open broker framework:** We built a system where agents could be spun up, assigned work, and tracked — all programmatically.
@@ -38,7 +38,7 @@ Early wins:
 - **Multi-agent coordination:** Agents started handing work to each other (Dev Advocate → Tech Reviewer → DevRel Lead → Dennis for approval).
 
 Early failures:
-- **The $300/month cost crisis (05/05/2026):** An adapter loop caused 900+ token attempts in a single run. Our AWS bill exploded. We scrambled to implement spending caps and gating logic.
+- **The $300/month cost crisis (early May):** An adapter loop caused 900+ token attempts in a single run. Our AWS bill exploded. We scrambled to implement spending caps and gating logic.
 - **Status confusion:** We had "done" and "complete" statuses that meant different things to different agents. Took weeks to standardize.
 - **Quality vs. cost tension:** Sonnet was cheap but inconsistent. Opus was expensive but reliable. We're still finding the right balance.
 
@@ -50,13 +50,13 @@ By early May, we had agents shipping content, managing issues, and running routi
 
 ### Challenge 1: Security & Infrastructure
 
-**The X.com proxy problem (05/07/2026):** X's callback URI restrictions blocked our agents from posting. We couldn't expose our internal network. Solution? Built a secure proxy layer. Not glamorous. But necessary.
+**The X.com proxy problem (early May):** X's callback URI restrictions blocked our agents from posting. We couldn't expose our internal network. Solution? Built a secure proxy layer. Not glamorous. But necessary.
 
 **Lesson learned:** Real-world integrations always have sharp edges. You don't find them until you ship.
 
 ### Challenge 2: Agent Reliability
 
-**The Otto article retrieval bug (05/07/2026):** One of our agents kept failing to fetch articles. Root cause? A stale authentication token that only surfaced under specific conditions.
+**The article retrieval bug (early May):** Our article-retrieval agent kept failing to fetch content. Root cause? A stale authentication token that only surfaced under specific conditions.
 
 We built end-to-end tests. We added health checks. We made agent runs *observable* so when something broke, we could trace it.
 
@@ -64,7 +64,7 @@ We built end-to-end tests. We added health checks. We made agent runs *observabl
 
 ### Challenge 3: Quality Control
 
-**The SLT feedback loop (05/05/2026):** Our senior leadership team started reviewing agent output. Their verdict? "Good structure, inconsistent depth."
+**The SLT feedback loop (early May):** Our senior leadership team started reviewing agent output. Their verdict? "Good structure, inconsistent depth."
 
 We couldn't just throw more compute at it. We needed:
 - Clearer prompts (we borrowed the Growth team's evaluation framework)
@@ -79,7 +79,7 @@ One of our proudest achievements: lowering the barrier to contribution.
 
 **What that looked like:**
 - **Documentation-first PRs:** Every code change ships with updated docs. No exceptions.
-- **Architecture Decision Records (ADRs):** Every non-trivial choice gets documented — not just *what* we chose, but *why*, and what we gave up.
+- **Architecture Decision Records (ADRs):** We're implementing a system to document every non-trivial choice — not just *what* we chose, but *why*, and what we gave up.
 - **Build-in-public guardrails:** We don't leak internal context. We don't overpromise. We link every claim to a PR, issue, or release.
 - **Active triage:** GitHub issues and Discourse threads get a response within 24 hours. Not always a solution, but always acknowledgment.
 
@@ -115,7 +115,7 @@ We're not done. Not even close.
 **Where you can help:**
 - **Try Bizbox:** Spin up an agent, assign it work, see what breaks.
 - **Contribute:** Check the [good first issue](https://github.com/zesthq/bizbox/labels/good%20first%20issue) label. Or propose something entirely new.
-- **Join the conversation:** [GitHub Discussions](https://github.com/zesthq/bizbox/discussions), [Discourse](https://bizboxai.discourse.group), and X ([@BizboxAI](https://twitter.com/BizboxAI)) are where the real work happens.
+- **Join the conversation:** [GitHub Issues](https://github.com/zesthq/bizbox/issues), [Discourse](https://bizboxai.discourse.group), and X ([@BizboxAI](https://twitter.com/BizboxAI)) are where the real work happens.
 
 Building autonomous agents is hard. Building *trustworthy* autonomous agents is harder. But we're doing it in public, learning together, and shipping every week.
 
@@ -126,7 +126,6 @@ Thanks for being part of this journey.
 **Related Links**
 - [Bizbox on GitHub](https://github.com/zesthq/bizbox)
 - [Roadmap](https://github.com/zesthq/bizbox/blob/master/ROADMAP.md)
-- [Build Logs Archive](https://bizboxai.discourse.group/c/build-logs)
-- [Weekly Build Log (May 2–8, 2026)](https://github.com/zesthq/bizbox/discussions/31)
+- [Community Discussion](https://bizboxai.discourse.group)
 
 — The Bizbox Team


### PR DESCRIPTION
## Summary

Adds a special one-off content piece celebrating the Bizbox development journey — the people, the dev experience, and the path from inception to now.

## Context

- **Related Issues:** CITAAAA-53 (drafting), CITAAAA-57 (PR creation)
- **Requested by:** Dennis (special one-off content outside scheduled cadence)
- **Target:** Source-of-truth documentation in `docs/blog/` for later Discourse publication

## Content Overview

This piece covers:
- Why we started Bizbox
- Early wins and failures
- Growing pains (security, reliability, quality)
- Developer experience improvements
- The team (humans and agents)
- What's next and how to contribute

## Build-in-Public Conventions

✅ Grounded in real repo activity (linked PRs, issues, dates)
✅ Honest about challenges and trade-offs
✅ No internal-only context or non-public roadmap leaks
✅ Invites participation without overpromising

## Next Steps

1. **DevRel Lead** — editorial review
2. **Tech Reviewer** — technical accuracy check
3. **Dennis** — final approval
4. After approval, merge this PR
5. Then publish to Discourse

---

**Related Links:**
- Drafting issue: [CITAAAA-53](https://bizbox.internal:3100/issues/30bf833d-b0a6-48a8-b08c-cead4a98c1d7)
- PR creation issue: [CITAAAA-57](https://bizbox.internal:3100/issues/6d968a72-31ae-46bd-932c-797eed5b4821)
- Source deliverable: CITAAAA-53 deliverable document (revision 2)