### PR TITLE
feat(otel): add more metrics

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -518,6 +518,7 @@ Bizbox also emits traces via OpenTelemetry when OTel is enabled.
 | `bizbox.issues.human_intervened.count` | Counter | `company_id`, `project_id`, `issue_status`, `intervention_kind`, `intervener_id`, `assignee_agent_id` | Incremented once per issue (first human intervention only). Human intervention currently includes posting a comment as a user or assigning an agent as a user. |
 | `bizbox.issues.status_changed` | Counter | `company_id`, `project_id`, `from_status`, `to_status`, `actor_type`, `actor_id` | Incremented each time an existing issue transitions from one status to another. Creation is not counted. |
 | `bizbox.issues.count` | Gauge | `company_id`, `project_id`, `issue_status` | Current number of non-hidden issues per status for each company+project slice. Status values are sourced from `ISSUE_STATUSES` in `@paperclipai/shared` (not hardcoded in OTel instrumentation). Reconciled at server startup and then every 60 seconds. |
+| `bizbox.runs.status` | Counter | `company_id`, `agent_id`, `status`, `invocation_source`, `trigger_detail` | Incremented when a run transitions from non-terminal to terminal status (`succeeded`, `failed`, `timed_out`, `cancelled`). Each terminal attempt is counted. Status values are normalized to `cancelled` (including `canceled`). |
 
 ### Traces emitted
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -513,6 +513,7 @@ Bizbox also emits traces via OpenTelemetry when OTel is enabled.
 
 | Metric name | Type | Attributes | Description |
 |---|---|---|---|
+| `bizbox.issues.created` | Counter | `company_id`, `project_id`, `actor_type`, `actor_id`, `initial_status`, `assignee_agent_id`, `assignee_user_id`, `origin_kind` | Incremented each time an issue is created. |
 | `bizbox.issues.comments` | Counter | `company_id`, `project_id`, `issue_status`, `actor_type`, `commenter_id`, `assignee_agent_id`, `assignee_user_id` | Incremented each time a user (human) or agent posts a comment on an issue. A rising user comments value relative to agent comment volume signals human steering / intervention. |
 | `bizbox.issues.human_intervened.count` | Counter | `company_id`, `project_id`, `issue_status`, `intervention_kind`, `intervener_id`, `assignee_agent_id` | Incremented once per issue (first human intervention only). Human intervention currently includes posting a comment as a user or assigning an agent as a user. |
 | `bizbox.issues.status_changed` | Counter | `company_id`, `project_id`, `from_status`, `to_status`, `actor_type`, `actor_id` | Incremented each time an existing issue transitions from one status to another. Creation is not counted. |

--- a/server/src/__tests__/issue-work-product-routes.test.ts
+++ b/server/src/__tests__/issue-work-product-routes.test.ts
@@ -30,7 +30,14 @@ vi.mock("../telemetry.js", () => ({
 }));
 
 vi.mock("../otel.js", () => ({
-  recordHumanComment: vi.fn(),
+  recordComment: vi.fn(),
+  recordHumanIntervened: vi.fn(),
+  recordIssueCreated: vi.fn(),
+  recordIssueStatusChanged: vi.fn(),
+  recordIssueStatusCounts: vi.fn(),
+  clearIssueStatusCountsForCompany: vi.fn(),
+  traceHumanCommentPosted: vi.fn(),
+  recordRunStatus: vi.fn(),
 }));
 
 vi.mock("../services/index.js", () => ({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -33,7 +33,7 @@ vi.mock("../otel.js", () => ({
 
 import { instanceSettingsService } from "../services/instance-settings.ts";
 import { clampIssueListLimit, ISSUE_LIST_MAX_LIMIT, issueService } from "../services/issues.ts";
-import { recordHumanIntervened } from "../otel.js";
+import { recordHumanIntervened, recordIssueCreated } from "../otel.js";
 import { buildProjectMentionHref } from "@paperclipai/shared";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -249,6 +249,17 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       priority: "medium",
       createdByUserId: userId,
     });
+
+    expect(recordIssueCreated).toHaveBeenCalledWith(expect.objectContaining({
+      company_id: companyId,
+      project_id: undefined,
+      actor_type: "user",
+      actor_id: userId,
+      initial_status: "todo",
+      assignee_agent_id: undefined,
+      assignee_user_id: undefined,
+      origin_kind: "manual",
+    }));
 
     await svc.addComment(created.id, "human comment", { userId });
     await svc.update(created.id, {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 vi.mock("../otel.js", () => ({
   recordHumanIntervened: vi.fn(),
+  recordIssueCreated: vi.fn(),
   recordIssueStatusChanged: vi.fn(),
   recordIssueStatusCounts: vi.fn(),
   clearIssueStatusCountsForCompany: vi.fn(),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -23,6 +23,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 vi.mock("../otel.js", () => ({
+  recordComment: vi.fn(),
   recordHumanIntervened: vi.fn(),
   recordIssueCreated: vi.fn(),
   recordIssueStatusChanged: vi.fn(),

--- a/server/src/otel.ts
+++ b/server/src/otel.ts
@@ -36,6 +36,7 @@ let _commentsCounter: Counter | null = null;
 let _humanIntervenedCounter: Counter | null = null;
 let _issuesCreatedCounter: Counter | null = null;
 let _issuesStatusChangedCounter: Counter | null = null;
+let _runsStatusCounter: Counter | null = null;
 let _issuesCountByStatusGauge: ObservableGauge | null = null;
 const _issuesCountByStatusByCompanyAndProject = new Map<string, Map<string, Map<string, number>>>();
 
@@ -114,6 +115,7 @@ export async function shutdownOtel(): Promise<void> {
     _humanIntervenedCounter = null;
     _issuesCreatedCounter = null;
     _issuesStatusChangedCounter = null;
+    _runsStatusCounter = null;
     _issuesCountByStatusGauge = null;
     _issuesCountByStatusByCompanyAndProject.clear();
   }
@@ -167,6 +169,21 @@ function getIssuesStatusChangedCounter(): Counter {
     });
   }
   return _issuesStatusChangedCounter;
+}
+
+function getRunsStatusCounter(): Counter {
+  if (!_runsStatusCounter) {
+    const meter = metrics.getMeter("bizbox");
+    _runsStatusCounter = meter.createCounter("bizbox.runs.status", {
+      description: "Total number of run terminal status events.",
+      unit: "{run}",
+    });
+  }
+  return _runsStatusCounter;
+}
+
+function normalizeRunStatus(status: string): string {
+  return status === "canceled" ? "cancelled" : status;
 }
 
 /**
@@ -230,6 +247,22 @@ export function recordIssueStatusChanged(attributes: {
   actor_id: string;
 }): void {
   getIssuesStatusChangedCounter().add(1, attributes);
+}
+
+/**
+ * Increment `bizbox.runs.status`.
+ */
+export function recordRunStatus(attributes: {
+  company_id: string;
+  agent_id: string;
+  status: string;
+  invocation_source: string;
+  trigger_detail: string | undefined;
+}): void {
+  getRunsStatusCounter().add(1, {
+    ...attributes,
+    status: normalizeRunStatus(attributes.status),
+  });
 }
 
 /**

--- a/server/src/otel.ts
+++ b/server/src/otel.ts
@@ -34,6 +34,7 @@ let _tracerProvider: NodeTracerProvider | null = null;
 // time without worrying about init order.
 let _commentsCounter: Counter | null = null;
 let _humanIntervenedCounter: Counter | null = null;
+let _issuesCreatedCounter: Counter | null = null;
 let _issuesStatusChangedCounter: Counter | null = null;
 let _issuesCountByStatusGauge: ObservableGauge | null = null;
 const _issuesCountByStatusByCompanyAndProject = new Map<string, Map<string, Map<string, number>>>();
@@ -111,6 +112,7 @@ export async function shutdownOtel(): Promise<void> {
     _tracerProvider = null;
     _commentsCounter = null;
     _humanIntervenedCounter = null;
+    _issuesCreatedCounter = null;
     _issuesStatusChangedCounter = null;
     _issuesCountByStatusGauge = null;
     _issuesCountByStatusByCompanyAndProject.clear();
@@ -143,6 +145,17 @@ function getHumanIntervenedCounter(): Counter {
     });
   }
   return _humanIntervenedCounter;
+}
+
+function getIssuesCreatedCounter(): Counter {
+  if (!_issuesCreatedCounter) {
+    const meter = metrics.getMeter("bizbox");
+    _issuesCreatedCounter = meter.createCounter("bizbox.issues.created", {
+      description: "Total number of created issues.",
+      unit: "{issue}",
+    });
+  }
+  return _issuesCreatedCounter;
 }
 
 function getIssuesStatusChangedCounter(): Counter {
@@ -187,6 +200,22 @@ export function recordHumanIntervened(attributes: {
   assignee_agent_id: string | undefined;
 }): void {
   getHumanIntervenedCounter().add(1, attributes);
+}
+
+/**
+ * Increment `bizbox.issues.created`.
+ */
+export function recordIssueCreated(attributes: {
+  company_id: string;
+  project_id: string | undefined;
+  actor_type: string;
+  actor_id: string;
+  initial_status: string;
+  assignee_agent_id: string | undefined;
+  assignee_user_id: string | undefined;
+  origin_kind: string;
+}): void {
+  getIssuesCreatedCounter().add(1, attributes);
 }
 
 /**

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
 import { z } from "zod";
-import { recordComment, traceHumanCommentPosted } from "../otel.js";
 import type { Db } from "@paperclipai/db";
 import { issueExecutionDecisions } from "@paperclipai/db";
 import {
@@ -3215,32 +3214,6 @@ export function issueRoutes(
       commentReferenceSummaryBefore,
       commentReferenceSummaryAfter,
     );
-
-    // Emit OTel metric for all comments.
-    recordComment({
-      company_id: currentIssue.companyId,
-      project_id: currentIssue.projectId ?? undefined,
-      issue_status: currentIssue.status,
-      actor_type: actor.actorType,
-      commenter_id: actor.actorId,
-      assignee_agent_id: currentIssue.assigneeAgentId ?? undefined,
-      assignee_user_id: currentIssue.assigneeUserId ?? undefined,
-    });
-
-    if (actor.actorType === "user") {
-      traceHumanCommentPosted({
-        company_id: currentIssue.companyId,
-        project_id: currentIssue.projectId ?? undefined,
-        issue_id: currentIssue.id,
-        issue_identifier: currentIssue.identifier ?? undefined,
-        issue_status: currentIssue.status,
-        comment_id: comment.id,
-        commenter_id: actor.actorId,
-        assignee_agent_id: currentIssue.assigneeAgentId ?? undefined,
-        assignee_user_id: currentIssue.assigneeUserId ?? undefined,
-        body_length: comment.body.length,
-      });
-    }
 
     if (actor.runId) {
       await heartbeat.reportRunActivity(actor.runId).catch((err) =>

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -86,6 +86,7 @@ import {
 import { issueService } from "./issues.js";
 import { agentThreadService } from "./agent-threads.js";
 import { workProductService } from "./work-products.js";
+import { recordRunStatus } from "../otel.js";
 import {
   getIssueContinuationSummaryDocument,
   refreshIssueContinuationSummary,
@@ -151,6 +152,8 @@ const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_r
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
+type HeartbeatRunTerminalStatus = (typeof HEARTBEAT_RUN_TERMINAL_STATUSES)[number];
+const HEARTBEAT_RUN_TERMINAL_STATUS_SET = new Set<string>(HEARTBEAT_RUN_TERMINAL_STATUSES);
 export const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS = [
   2 * 60 * 1000,
   10 * 60 * 1000,
@@ -2625,6 +2628,13 @@ export function heartbeatService(db: Db) {
     status: string,
     patch?: Partial<typeof heartbeatRuns.$inferInsert>,
   ) {
+    const previous = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    if (!previous) return null;
+
     const updated = await db
       .update(heartbeatRuns)
       .set({ status, ...patch, updatedAt: new Date() })
@@ -2649,6 +2659,18 @@ export function heartbeatService(db: Db) {
         },
       });
       publishRunLifecyclePluginEvent(updated);
+
+      const wasTerminal = HEARTBEAT_RUN_TERMINAL_STATUS_SET.has(previous.status as HeartbeatRunTerminalStatus);
+      const nowTerminal = HEARTBEAT_RUN_TERMINAL_STATUS_SET.has(updated.status as HeartbeatRunTerminalStatus);
+      if (!wasTerminal && nowTerminal) {
+        recordRunStatus({
+          company_id: updated.companyId,
+          agent_id: updated.agentId,
+          status: updated.status,
+          invocation_source: updated.invocationSource,
+          trigger_detail: updated.triggerDetail ?? undefined,
+        });
+      }
     }
 
     return updated;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2628,19 +2628,41 @@ export function heartbeatService(db: Db) {
     status: string,
     patch?: Partial<typeof heartbeatRuns.$inferInsert>,
   ) {
-    const previous = await db
-      .select({ status: heartbeatRuns.status })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, runId))
-      .then((rows) => rows[0] ?? null);
-    if (!previous) return null;
+    const transition = await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${runId} for update`,
+      );
 
-    const updated = await db
-      .update(heartbeatRuns)
-      .set({ status, ...patch, updatedAt: new Date() })
-      .where(eq(heartbeatRuns.id, runId))
-      .returning()
-      .then((rows) => rows[0] ?? null);
+      const previous = await tx
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      if (!previous) {
+        return { updated: null as typeof heartbeatRuns.$inferSelect | null, shouldEmitTerminalMetric: false };
+      }
+
+      const updated = await tx
+        .update(heartbeatRuns)
+        .set({ status, ...patch, updatedAt: new Date() })
+        .where(eq(heartbeatRuns.id, runId))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+
+      if (!updated) {
+        return { updated: null as typeof heartbeatRuns.$inferSelect | null, shouldEmitTerminalMetric: false };
+      }
+
+      const wasTerminal = HEARTBEAT_RUN_TERMINAL_STATUS_SET.has(previous.status as HeartbeatRunTerminalStatus);
+      const nowTerminal = HEARTBEAT_RUN_TERMINAL_STATUS_SET.has(updated.status as HeartbeatRunTerminalStatus);
+
+      return {
+        updated,
+        shouldEmitTerminalMetric: !wasTerminal && nowTerminal,
+      };
+    });
+
+    const updated = transition.updated;
 
     if (updated) {
       publishLiveEvent({
@@ -2660,9 +2682,7 @@ export function heartbeatService(db: Db) {
       });
       publishRunLifecyclePluginEvent(updated);
 
-      const wasTerminal = HEARTBEAT_RUN_TERMINAL_STATUS_SET.has(previous.status as HeartbeatRunTerminalStatus);
-      const nowTerminal = HEARTBEAT_RUN_TERMINAL_STATUS_SET.has(updated.status as HeartbeatRunTerminalStatus);
-      if (!wasTerminal && nowTerminal) {
+      if (transition.shouldEmitTerminalMetric) {
         recordRunStatus({
           company_id: updated.companyId,
           agent_id: updated.agentId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -29,6 +29,7 @@ import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   clearIssueStatusCountsForCompany,
   recordHumanIntervened,
+  recordIssueCreated,
   recordIssueStatusChanged,
   recordIssueStatusCounts,
 } from "../otel.js";
@@ -2069,6 +2070,16 @@ export function issueService(db: Db) {
         }
 
         const [issue] = await tx.insert(issues).values(values).returning();
+        recordIssueCreated({
+          company_id: issue.companyId,
+          project_id: issue.projectId ?? undefined,
+          actor_type: issue.createdByUserId ? "user" : issue.createdByAgentId ? "agent" : "system",
+          actor_id: issue.createdByUserId ?? issue.createdByAgentId ?? "system",
+          initial_status: issue.status,
+          assignee_agent_id: issue.assigneeAgentId ?? undefined,
+          assignee_user_id: issue.assigneeUserId ?? undefined,
+          origin_kind: issue.originKind,
+        });
         if (issue.createdByUserId && issue.assigneeAgentId) {
           await markHumanIntervened({
             issueId: issue.id,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1941,7 +1941,7 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
-      return db.transaction(async (tx) => {
+      const created = await db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;
@@ -2100,20 +2100,24 @@ export function issueService(db: Db) {
           );
         }
 
-        recordIssueCreated({
-          company_id: issue.companyId,
-          project_id: issue.projectId ?? undefined,
-          actor_type: issue.createdByUserId ? "user" : issue.createdByAgentId ? "agent" : "system",
-          actor_id: issue.createdByUserId ?? issue.createdByAgentId ?? "system",
-          initial_status: issue.status,
-          assignee_agent_id: issue.assigneeAgentId ?? undefined,
-          assignee_user_id: issue.assigneeUserId ?? undefined,
-          origin_kind: issue.originKind,
-        });
-
         const [enriched] = await withIssueLabels(tx, [issue]);
-        return enriched;
+        return {
+          enriched,
+          metricAttributes: {
+            company_id: issue.companyId,
+            project_id: issue.projectId ?? undefined,
+            actor_type: issue.createdByUserId ? "user" : issue.createdByAgentId ? "agent" : "system",
+            actor_id: issue.createdByUserId ?? issue.createdByAgentId ?? "system",
+            initial_status: issue.status,
+            assignee_agent_id: issue.assigneeAgentId ?? undefined,
+            assignee_user_id: issue.assigneeUserId ?? undefined,
+            origin_kind: issue.originKind,
+          },
+        };
       });
+
+      recordIssueCreated(created.metricAttributes);
+      return created.enriched;
     },
 
     update: async (

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -28,10 +28,12 @@ import { ISSUE_STATUSES, extractAgentMentionIds, extractProjectMentionIds, isUui
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   clearIssueStatusCountsForCompany,
+  recordComment,
   recordHumanIntervened,
   recordIssueCreated,
   recordIssueStatusChanged,
   recordIssueStatusCounts,
+  traceHumanCommentPosted,
 } from "../otel.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -2791,6 +2793,7 @@ export function issueService(db: Db) {
         .select({
           companyId: issues.companyId,
           projectId: issues.projectId,
+          identifier: issues.identifier,
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
@@ -2822,6 +2825,33 @@ export function issueService(db: Db) {
         .update(issues)
         .set({ updatedAt: new Date() })
         .where(eq(issues.id, issueId));
+
+      const actorType = actor.userId ? "user" : actor.agentId ? "agent" : "system";
+      const commenterId = actor.userId ?? actor.agentId ?? actor.runId ?? "system";
+      recordComment({
+        company_id: issue.companyId,
+        project_id: issue.projectId ?? undefined,
+        issue_status: issue.status,
+        actor_type: actorType,
+        commenter_id: commenterId,
+        assignee_agent_id: issue.assigneeAgentId ?? undefined,
+        assignee_user_id: issue.assigneeUserId ?? undefined,
+      });
+
+      if (actor.userId) {
+        traceHumanCommentPosted({
+          company_id: issue.companyId,
+          project_id: issue.projectId ?? undefined,
+          issue_id: issueId,
+          issue_identifier: issue.identifier ?? undefined,
+          issue_status: issue.status,
+          comment_id: comment.id,
+          commenter_id: actor.userId,
+          assignee_agent_id: issue.assigneeAgentId ?? undefined,
+          assignee_user_id: issue.assigneeUserId ?? undefined,
+          body_length: comment.body.length,
+        });
+      }
 
       if (actor.userId) {
         // Track human intervention only for agent-managed issues.

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2070,16 +2070,6 @@ export function issueService(db: Db) {
         }
 
         const [issue] = await tx.insert(issues).values(values).returning();
-        recordIssueCreated({
-          company_id: issue.companyId,
-          project_id: issue.projectId ?? undefined,
-          actor_type: issue.createdByUserId ? "user" : issue.createdByAgentId ? "agent" : "system",
-          actor_id: issue.createdByUserId ?? issue.createdByAgentId ?? "system",
-          initial_status: issue.status,
-          assignee_agent_id: issue.assigneeAgentId ?? undefined,
-          assignee_user_id: issue.assigneeUserId ?? undefined,
-          origin_kind: issue.originKind,
-        });
         if (issue.createdByUserId && issue.assigneeAgentId) {
           await markHumanIntervened({
             issueId: issue.id,
@@ -2107,6 +2097,18 @@ export function issueService(db: Db) {
             tx,
           );
         }
+
+        recordIssueCreated({
+          company_id: issue.companyId,
+          project_id: issue.projectId ?? undefined,
+          actor_type: issue.createdByUserId ? "user" : issue.createdByAgentId ? "agent" : "system",
+          actor_id: issue.createdByUserId ?? issue.createdByAgentId ?? "system",
+          initial_status: issue.status,
+          assignee_agent_id: issue.assigneeAgentId ?? undefined,
+          assignee_user_id: issue.assigneeUserId ?? undefined,
+          origin_kind: issue.originKind,
+        });
+
         const [enriched] = await withIssueLabels(tx, [issue]);
         return enriched;
       });


### PR DESCRIPTION
adds a metric for issues created. adds a metric for run statuses as well. improves logic around comment metrics, should now record all comments by AI.

| Metric name | Type | Attributes | Description |
|---|---|---|---|
| `bizbox.issues.created` | Counter | `company_id`, `project_id`, `actor_type`, `actor_id`, `initial_status`, `assignee_agent_id`, `assignee_user_id`, `origin_kind` | Incremented each time an issue is created. |