### PR TITLE
Add toggle for showing archived routines and update view state

### DIFF
--- a/server/src/__tests__/heartbeat-openclaw-artifacts.test.ts
+++ b/server/src/__tests__/heartbeat-openclaw-artifacts.test.ts
@@ -359,7 +359,8 @@ describeEmbeddedPostgres("heartbeat issue-backed artifact persistence", () => {
       return (
         persisted?.status === "succeeded" &&
         products.length === 1 &&
-        products[0]?.createdByRunId === secondRun!.id
+        products[0]?.createdByRunId === secondRun!.id &&
+        mockStorage.deleteObject.mock.calls.length === 1
       );
     });
 

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Routines, buildRoutineGroups } from "./Routines";
 
 let currentSearch = "";
+let container: HTMLDivElement;
 
 const navigateMock = vi.fn();
 const routinesListMock = vi.fn<(companyId: string) => Promise<RoutineListItem[]>>();
@@ -17,6 +18,19 @@ const issuesListRenderMock = vi.fn(({ issues }: { issues: Issue[] }) => (
 ));
 
 vi.mock("@/lib/router", () => ({
+  Link: ({
+    to,
+    children,
+    ...props
+  }: {
+    to: string;
+    children: unknown;
+    [key: string]: unknown;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
   useNavigate: () => navigateMock,
   useLocation: () => ({ pathname: "/routines", search: currentSearch ? `?${currentSearch}` : "", hash: "" }),
   useSearchParams: () => [new URLSearchParams(currentSearch), vi.fn()],
@@ -207,6 +221,28 @@ vi.mock("../components/AgentIconPicker", () => ({
   AgentIcon: () => <span data-testid="agent-icon" />,
 }));
 
+vi.mock("@/components/ui/toggle-switch", () => ({
+  ToggleSwitch: ({
+    checked,
+    onCheckedChange,
+    "aria-label": ariaLabel,
+  }: {
+    checked: boolean;
+    onCheckedChange: (checked: boolean) => void;
+    "aria-label"?: string;
+  }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={() => onCheckedChange(!checked)}
+    >
+      {checked ? "on" : "off"}
+    </button>
+  ),
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -291,11 +327,39 @@ async function flush() {
   await Promise.resolve();
   await Promise.resolve();
   await new Promise((resolve) => window.setTimeout(resolve, 0));
+  await Promise.resolve();
+  await new Promise((resolve) => window.setTimeout(resolve, 10));
+}
+
+async function renderRoutines() {
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <Routines />
+      </QueryClientProvider>,
+    );
+    await flush();
+    await flush();
+  });
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    if (container.textContent?.trim()) break;
+    await act(async () => {
+      await flush();
+    });
+  }
+
+  return root;
 }
 
 describe("Routines page", () => {
-  let container: HTMLDivElement;
-
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -342,23 +406,129 @@ describe("Routines page", () => {
       createIssue({ id: "issue-2", title: "Routine execution B", identifier: "PAP-1001", issueNumber: 1001 }),
     ]);
 
-    const root = createRoot(container);
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-      },
-    });
+    const root = await renderRoutines();
+
+    expect(issuesListMock).toHaveBeenCalledWith("company-1", { originKind: "routine_execution" });
 
     await act(async () => {
-      root.render(
-        <QueryClientProvider client={queryClient}>
-          <Routines />
-        </QueryClientProvider>,
-      );
+      root.unmount();
+    });
+  });
+
+  it("hides archived routines by default and shows filtered count copy", async () => {
+    routinesListMock.mockResolvedValue([
+      createRoutine({ id: "routine-1", title: "Active routine", status: "active" }),
+      createRoutine({ id: "routine-2", title: "Archived routine", status: "archived" }),
+    ]);
+    issuesListMock.mockResolvedValue([]);
+
+    const root = await renderRoutines();
+
+    expect(container.textContent).toContain("Active routine");
+    expect(container.textContent).not.toContain("Archived routine");
+    expect(container.textContent).toContain("1 routine");
+    expect(container.textContent).toContain("1 archived hidden");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("reveals archived routines when the show archived toggle is enabled", async () => {
+    routinesListMock.mockResolvedValue([
+      createRoutine({ id: "routine-1", title: "Active routine", status: "active" }),
+      createRoutine({ id: "routine-2", title: "Archived routine", status: "archived" }),
+    ]);
+    issuesListMock.mockResolvedValue([]);
+
+    const root = await renderRoutines();
+    const toggle = container.querySelector('[aria-label="Show archived routines"]');
+    expect(toggle).not.toBeNull();
+
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       await flush();
     });
 
-    expect(issuesListMock).toHaveBeenCalledWith("company-1", { originKind: "routine_execution" });
+    expect(container.textContent).toContain("Active routine");
+    expect(container.textContent).toContain("Archived routine");
+    expect(container.textContent).toContain("2 routines");
+    expect(container.textContent).not.toContain("archived hidden");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("rehides archived routines when the toggle is turned back off", async () => {
+    routinesListMock.mockResolvedValue([
+      createRoutine({ id: "routine-1", title: "Active routine", status: "active" }),
+      createRoutine({ id: "routine-2", title: "Archived routine", status: "archived" }),
+    ]);
+    issuesListMock.mockResolvedValue([]);
+
+    const root = await renderRoutines();
+    const toggle = container.querySelector('[aria-label="Show archived routines"]');
+    expect(toggle).not.toBeNull();
+
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flush();
+    });
+
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flush();
+    });
+
+    expect(container.textContent).toContain("Active routine");
+    expect(container.textContent).not.toContain("Archived routine");
+    expect(container.textContent).toContain("1 archived hidden");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("restores the persisted show archived preference for the same company", async () => {
+    localStorage.setItem(
+      "paperclip:routines-view:company-1",
+      JSON.stringify({ groupBy: "none", collapsedGroups: [], showArchived: true }),
+    );
+    routinesListMock.mockResolvedValue([
+      createRoutine({ id: "routine-1", title: "Active routine", status: "active" }),
+      createRoutine({ id: "routine-2", title: "Archived routine", status: "archived" }),
+    ]);
+    issuesListMock.mockResolvedValue([]);
+
+    const root = await renderRoutines();
+
+    expect(container.textContent).toContain("Archived routine");
+    const toggle = container.querySelector('[aria-label="Show archived routines"]');
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("keeps archived routines out of grouped sections while hidden", async () => {
+    localStorage.setItem(
+      "paperclip:routines-view:company-1",
+      JSON.stringify({ groupBy: "project", collapsedGroups: [], showArchived: false }),
+    );
+    routinesListMock.mockResolvedValue([
+      createRoutine({ id: "routine-1", title: "Visible project routine", projectId: "project-1", status: "active" }),
+      createRoutine({ id: "routine-2", title: "Hidden archived routine", projectId: "project-2", status: "archived" }),
+    ]);
+    issuesListMock.mockResolvedValue([]);
+
+    const root = await renderRoutines();
+
+    expect(container.textContent).toContain("Project Alpha");
+    expect(container.textContent).toContain("Visible project routine");
+    expect(container.textContent).not.toContain("Project Beta");
+    expect(container.textContent).not.toContain("Hidden archived routine");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act } from "react";
+import { act, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, RoutineListItem } from "@paperclipai/shared";
@@ -24,7 +24,7 @@ vi.mock("@/lib/router", () => ({
     ...props
   }: {
     to: string;
-    children: unknown;
+    children?: ReactNode;
     [key: string]: unknown;
   }) => (
     <a href={to} {...props}>

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -614,14 +614,14 @@ export function Routines() {
               ) : null}
             </div>
             <div className="flex items-center gap-3">
-              <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <ToggleSwitch
                   checked={routineViewState.showArchived}
                   onCheckedChange={(showArchived) => updateRoutineView({ showArchived })}
                   aria-label="Show archived routines"
                 />
                 <span>Show archived</span>
-              </label>
+              </div>
               <Popover>
                 <PopoverTrigger asChild>
                   <Button variant="ghost" size="sm" className="text-xs">

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -84,6 +84,7 @@ type RoutineGroupBy = "none" | "project" | "assignee";
 type RoutineViewState = {
   groupBy: RoutineGroupBy;
   collapsedGroups: string[];
+  showArchived: boolean;
 };
 
 type RoutineGroup = {
@@ -95,6 +96,7 @@ type RoutineGroup = {
 const defaultRoutineViewState: RoutineViewState = {
   groupBy: "none",
   collapsedGroups: [],
+  showArchived: false,
 };
 
 function getRoutineViewState(key: string): RoutineViewState {
@@ -492,6 +494,14 @@ export function Routines() {
     () => new Map((projects ?? []).map((project) => [project.id, project])),
     [projects],
   );
+  const visibleRoutines = useMemo(
+    () => (routines ?? []).filter((routine) => routineViewState.showArchived || routine.status !== "archived"),
+    [routineViewState.showArchived, routines],
+  );
+  const archivedRoutineCount = useMemo(
+    () => (routines ?? []).filter((routine) => routine.status === "archived").length,
+    [routines],
+  );
   const liveIssueIds = useMemo(() => {
     const ids = new Set<string>();
     for (const run of liveRuns ?? []) {
@@ -500,8 +510,8 @@ export function Routines() {
     return ids;
   }, [liveRuns]);
   const routineGroups = useMemo(
-    () => buildRoutineGroups(routines ?? [], routineViewState.groupBy, projectById, agentById),
-    [agentById, projectById, routineViewState.groupBy, routines],
+    () => buildRoutineGroups(visibleRoutines, routineViewState.groupBy, projectById, agentById),
+    [agentById, projectById, routineViewState.groupBy, visibleRoutines],
   );
   const recentRunsIssueLinkState = useMemo(
     () =>
@@ -593,39 +603,56 @@ export function Routines() {
         />
         <TabsContent value="routines" className="space-y-4">
           <div className="flex items-center justify-between gap-3">
-            <p className="text-sm text-muted-foreground">
-              {(routines ?? []).length} routine{(routines ?? []).length === 1 ? "" : "s"}
-            </p>
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button variant="ghost" size="sm" className="text-xs">
-                  <Layers className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
-                  <span className="hidden sm:inline">Group</span>
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent align="end" className="w-44 p-0">
-                <div className="p-2 space-y-0.5">
-                  {([
-                    ["project", "Project"],
-                    ["assignee", "Agent"],
-                    ["none", "None"],
-                  ] as const).map(([value, label]) => (
-                    <button
-                      key={value}
-                      className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm ${
-                        routineViewState.groupBy === value
-                          ? "bg-accent/50 text-foreground"
-                          : "text-muted-foreground hover:bg-accent/50"
-                      }`}
-                      onClick={() => updateRoutineView({ groupBy: value, collapsedGroups: [] })}
-                    >
-                      <span>{label}</span>
-                      {routineViewState.groupBy === value ? <Check className="h-3.5 w-3.5" /> : null}
-                    </button>
-                  ))}
-                </div>
-              </PopoverContent>
-            </Popover>
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">
+                {visibleRoutines.length} routine{visibleRoutines.length === 1 ? "" : "s"}
+              </p>
+              {!routineViewState.showArchived && archivedRoutineCount > 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  {archivedRoutineCount} archived hidden
+                </p>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                <ToggleSwitch
+                  checked={routineViewState.showArchived}
+                  onCheckedChange={(showArchived) => updateRoutineView({ showArchived })}
+                  aria-label="Show archived routines"
+                />
+                <span>Show archived</span>
+              </label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button variant="ghost" size="sm" className="text-xs">
+                    <Layers className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
+                    <span className="hidden sm:inline">Group</span>
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align="end" className="w-44 p-0">
+                  <div className="p-2 space-y-0.5">
+                    {([
+                      ["project", "Project"],
+                      ["assignee", "Agent"],
+                      ["none", "None"],
+                    ] as const).map(([value, label]) => (
+                      <button
+                        key={value}
+                        className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm ${
+                          routineViewState.groupBy === value
+                            ? "bg-accent/50 text-foreground"
+                            : "text-muted-foreground hover:bg-accent/50"
+                        }`}
+                        onClick={() => updateRoutineView({ groupBy: value, collapsedGroups: [] })}
+                      >
+                        <span>{label}</span>
+                        {routineViewState.groupBy === value ? <Check className="h-3.5 w-3.5" /> : null}
+                      </button>
+                    ))}
+                  </div>
+                </PopoverContent>
+              </Popover>
+            </div>
           </div>
         </TabsContent>
         <TabsContent value="runs">
@@ -907,11 +934,15 @@ export function Routines() {
 
       {activeTab === "routines" ? (
         <div>
-          {(routines ?? []).length === 0 ? (
+          {visibleRoutines.length === 0 ? (
             <div className="py-12">
               <EmptyState
                 icon={Repeat}
-                message="No routines yet. Use Create routine to define the first recurring workflow."
+                message={
+                  archivedRoutineCount > 0 && !routineViewState.showArchived
+                    ? "All routines are archived. Turn on Show archived to view them."
+                    : "No routines yet. Use Create routine to define the first recurring workflow."
+                }
               />
             </div>
           ) : (


### PR DESCRIPTION
This pull request adds support for showing and hiding archived routines on the Routines page, along with a toggle to control this preference. It also introduces tests to verify the new behavior and persists the user's preference per company. The implementation ensures that archived routines are excluded from routine groups and counts when hidden, and provides clear messaging in the UI.

**Feature: Show/hide archived routines**
- Added a `showArchived` property to the routine view state, with persistence in localStorage and a default of `false`. [[1]](diffhunk://#diff-b8aace95b9bc9d5c4397e4b933a9d854e54947c42f91980a14debfc03e1eb436R87) [[2]](diffhunk://#diff-b8aace95b9bc9d5c4397e4b933a9d854e54947c42f91980a14debfc03e1eb436R99)
- Added a toggle switch to the UI to control visibility of archived routines, updated the routines count and message accordingly, and excluded archived routines from groups and counts when hidden. [[1]](diffhunk://#diff-b8aace95b9bc9d5c4397e4b933a9d854e54947c42f91980a14debfc03e1eb436R497-R504) [[2]](diffhunk://#diff-b8aace95b9bc9d5c4397e4b933a9d854e54947c42f91980a14debfc03e1eb436L503-R514) [[3]](diffhunk://#diff-b8aace95b9bc9d5c4397e4b933a9d854e54947c42f91980a14debfc03e1eb436R606-R624) [[4]](diffhunk://#diff-b8aace95b9bc9d5c4397e4b933a9d854e54947c42f91980a14debfc03e1eb436R656) [[5]](diffhunk://#diff-b8aace95b9bc9d5c4397e4b933a9d854e54947c42f91980a14debfc03e1eb436L910-R945)

**Testing improvements**
- Refactored the test setup for the Routines page and added comprehensive tests to verify toggling, persistence, and correct UI behavior for archived routines. [[1]](diffhunk://#diff-5a350b297d7a1a530ee20fccc2e194e38c52efffda1bcacf9e9c45c1ebaef4c0R330-R362) [[2]](diffhunk://#diff-5a350b297d7a1a530ee20fccc2e194e38c52efffda1bcacf9e9c45c1ebaef4c0L345-R531)
- Mocked the `ToggleSwitch` component for testing, ensuring toggle behavior is simulated accurately.
- Added a mock for the `Link` component from the router library for improved test isolation.
- Small test setup improvement: moved `container` initialization to the appropriate scope.