### PR TITLE
fix(builder): streamline builder ui and openclaw gateway flow

### DIFF
--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -5,6 +5,7 @@ import type { ServerAdapterModule } from "../adapters/index.js";
 
 const mockAgentService = vi.hoisted(() => ({
   create: vi.fn(),
+  list: vi.fn(),
   getById: vi.fn(),
   update: vi.fn(),
 }));
@@ -197,6 +198,7 @@ describe("agent routes adapter validation", () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     }));
+    mockAgentService.list.mockResolvedValue([]);
     mockAgentService.getById.mockResolvedValue(null);
     mockAgentService.update.mockImplementation(async (id: string, patch: Record<string, unknown>) => ({
       id,
@@ -346,6 +348,52 @@ describe("agent routes adapter validation", () => {
     expect(adapterConfig?.disableDeviceAuth).toBe(false);
     expect(typeof adapterConfig?.devicePrivateKeyPem).toBe("string");
     expect(String(adapterConfig?.devicePrivateKeyPem ?? "")).toContain("BEGIN PRIVATE KEY");
+  });
+
+  it("reuses OpenClaw device key from existing agent with same gateway url", async () => {
+    const sharedPem = "-----BEGIN PRIVATE KEY-----\nshared\n-----END PRIVATE KEY-----";
+    mockAgentService.list.mockResolvedValue([
+      {
+        id: "existing-1",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: "ws://citro-openclaw.internal:18789",
+          disableDeviceAuth: false,
+          devicePrivateKeyPem: sharedPem,
+        },
+      },
+    ]);
+
+    const { registerServerAdapter } = await import("../adapters/index.js");
+    registerServerAdapter({
+      type: "openclaw_gateway",
+      execute: async () => ({ exitCode: 0, signal: null, timedOut: false }),
+      testEnvironment: async () => ({
+        adapterType: "openclaw_gateway",
+        status: "pass",
+        checks: [],
+        testedAt: new Date(0).toISOString(),
+      }),
+    });
+
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/agents")
+      .send({
+        name: "CTO",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: "ws://citro-openclaw.internal:18789",
+          authToken: "gateway-token",
+          disableDeviceAuth: false,
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const adapterConfig = mockAgentService.create.mock.calls[0]?.[1]?.adapterConfig as
+      | Record<string, unknown>
+      | undefined;
+    expect(adapterConfig?.devicePrivateKeyPem).toBe(sharedPem);
   });
 
   it("persists normalized OpenClaw connection status on agent metadata", async () => {

--- a/server/src/__tests__/builder-routes.test.ts
+++ b/server/src/__tests__/builder-routes.test.ts
@@ -365,6 +365,53 @@ describe("builder routes", () => {
     });
   });
 
+  it("generates persistent OpenClaw device key for pairing mode", async () => {
+    mockBuilderService.getSettings.mockResolvedValue(null);
+    mockBuilderService.upsertSettings.mockResolvedValue({
+      companyId,
+      adapterType: "openclaw_gateway",
+      adapterConfig: {
+        url: "wss://gateway.example",
+        disableDeviceAuth: false,
+        authTokenRef: { type: "secret_ref", secretId: "secret-1", version: "latest" },
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+    });
+
+    const res = await request(app)
+      .put(`/api/companies/${companyId}/builder/settings`)
+      .send({
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: "wss://gateway.example",
+          authToken: "gateway-token",
+          disableDeviceAuth: false,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockBuilderService.upsertSettings).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({
+        adapterType: "openclaw_gateway",
+        adapterConfig: expect.objectContaining({
+          url: "wss://gateway.example",
+          disableDeviceAuth: false,
+          authTokenRef: { type: "secret_ref", secretId: "secret-1", version: "latest" },
+          devicePrivateKeyPem: expect.stringContaining("BEGIN PRIVATE KEY"),
+        }),
+      }),
+    );
+  });
+
   it("preserves stored Otto apiKeyRef when the user leaves the field blank", async () => {
     mockBuilderService.getSettings.mockResolvedValue({
       companyId,

--- a/server/src/__tests__/clickup-bridge.test.ts
+++ b/server/src/__tests__/clickup-bridge.test.ts
@@ -66,6 +66,20 @@ describe("isUserCommentForImport", () => {
     const res = isUserCommentForImport({ id: "c6", comment_text: "agent reply", user: { id: -16805283 }, date: "600" }, "bot-1", -16805283);
     expect(res).toEqual({ id: "c6", text: "agent reply", createdAt: 600 });
   });
+
+  it("falls back to rich comment array when comment_text missing", () => {
+    const res = isUserCommentForImport({
+      id: "c7",
+      comment: [
+        { text: "reviewed " },
+        { type: "tag", user: { username: "Risk" } },
+        { text: " and approved" },
+      ],
+      user: { id: -16805283 },
+      date: "700",
+    }, "bot-1", -16805283);
+    expect(res).toEqual({ id: "c7", text: "reviewed @Risk and approved", createdAt: 700 });
+  });
 });
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -46,6 +46,7 @@ import {
   companySkillService,
   budgetService,
   heartbeatService,
+  clickupBridgeService,
   ISSUE_LIST_DEFAULT_LIMIT,
   issueApprovalService,
   issueService,
@@ -754,14 +755,43 @@ export function agentRoutes(db: Db) {
     return privateKey.export({ type: "pkcs8", format: "pem" }).toString();
   }
 
-  function ensureGatewayDeviceKey(
+  function normalizeOpenClawGatewayUrl(value: unknown): string | null {
+    const raw = asNonEmptyString(value);
+    if (!raw) return null;
+    try {
+      const parsed = new URL(raw);
+      parsed.hash = "";
+      parsed.search = "";
+      parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+      return parsed.toString();
+    } catch {
+      return raw.trim();
+    }
+  }
+
+  async function ensureGatewayDeviceKey(
+    companyId: string,
     adapterType: string | null | undefined,
     adapterConfig: Record<string, unknown>,
-  ): Record<string, unknown> {
+  ): Promise<Record<string, unknown>> {
     if (adapterType !== "openclaw_gateway") return adapterConfig;
     const disableDeviceAuth = parseBooleanLike(adapterConfig.disableDeviceAuth);
     if (disableDeviceAuth !== false) return adapterConfig;
     if (asNonEmptyString(adapterConfig.devicePrivateKeyPem)) return adapterConfig;
+
+    const targetUrl = normalizeOpenClawGatewayUrl(adapterConfig.url);
+    if (targetUrl) {
+      const existingAgents = await svc.list(companyId);
+      for (const existingAgent of existingAgents) {
+        if (existingAgent.adapterType !== "openclaw_gateway") continue;
+        const existingConfig = asRecord(existingAgent.adapterConfig) ?? {};
+        if (normalizeOpenClawGatewayUrl(existingConfig.url) !== targetUrl) continue;
+        const sharedDeviceKey = asNonEmptyString(existingConfig.devicePrivateKeyPem);
+        if (!sharedDeviceKey) continue;
+        return { ...adapterConfig, devicePrivateKeyPem: sharedDeviceKey };
+      }
+    }
+
     return { ...adapterConfig, devicePrivateKeyPem: generateEd25519PrivateKeyPem() };
   }
 
@@ -780,17 +810,17 @@ export function agentRoutes(db: Db) {
       if (!hasBypassFlag) {
         next.dangerouslyBypassApprovalsAndSandbox = DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
       }
-      return ensureGatewayDeviceKey(adapterType, next);
+      return next;
     }
     if (adapterType === "gemini_local" && !asNonEmptyString(next.model)) {
       next.model = DEFAULT_GEMINI_LOCAL_MODEL;
-      return ensureGatewayDeviceKey(adapterType, next);
+      return next;
     }
     // OpenCode requires explicit model selection — no default
     if (adapterType === "cursor" && !asNonEmptyString(next.model)) {
       next.model = DEFAULT_CURSOR_LOCAL_MODEL;
     }
-    return ensureGatewayDeviceKey(adapterType, next);
+    return next;
   }
 
   async function assertAdapterConfigConstraints(
@@ -1720,9 +1750,13 @@ export function agentRoutes(db: Db) {
       req,
       (hireInput.adapterConfig ?? {}) as Record<string, unknown>,
     );
-    const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
+    const requestedAdapterConfig = await ensureGatewayDeviceKey(
+      companyId,
       hireInput.adapterType,
-      ((hireInput.adapterConfig ?? {}) as Record<string, unknown>),
+      applyCreateDefaultsByAdapterType(
+        hireInput.adapterType,
+        ((hireInput.adapterConfig ?? {}) as Record<string, unknown>),
+      ),
     );
     const persistedRequestedAdapterConfig =
       hireInput.adapterType === "openclaw_gateway"
@@ -1918,9 +1952,13 @@ export function agentRoutes(db: Db) {
       req,
       (createInput.adapterConfig ?? {}) as Record<string, unknown>,
     );
-    const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
+    const requestedAdapterConfig = await ensureGatewayDeviceKey(
+      companyId,
       createInput.adapterType,
-      ((createInput.adapterConfig ?? {}) as Record<string, unknown>),
+      applyCreateDefaultsByAdapterType(
+        createInput.adapterType,
+        ((createInput.adapterConfig ?? {}) as Record<string, unknown>),
+      ),
     );
     const persistedRequestedAdapterConfig =
       createInput.adapterType === "openclaw_gateway"
@@ -3004,6 +3042,45 @@ export function agentRoutes(db: Db) {
     }
 
     res.json(liveRuns);
+  });
+
+  router.post("/companies/:companyId/clickup-bridges/:bridgeId/retry", async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    const bridgeId = req.params.bridgeId as string;
+    assertCompanyAccess(req, companyId);
+
+    const [bridge] = await db
+      .select({ id: clickupBridges.id })
+      .from(clickupBridges)
+      .where(and(eq(clickupBridges.id, bridgeId), eq(clickupBridges.companyId, companyId)))
+      .limit(1);
+
+    if (!bridge) {
+      res.status(404).json({ error: "ClickUp bridge not found" });
+      return;
+    }
+
+    const retried = await clickupBridgeService(db).retryBridge(bridgeId);
+    if (!retried) {
+      res.status(409).json({ error: "ClickUp bridge is not failed or closed" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "clickup_bridge.retried",
+      entityType: "clickup_bridge",
+      entityId: bridgeId,
+      details: { status: retried.status },
+    });
+
+    res.json({ ok: true, bridge: retried });
   });
 
   router.get("/heartbeat-runs/:runId", async (req, res) => {

--- a/server/src/routes/builder.ts
+++ b/server/src/routes/builder.ts
@@ -1,6 +1,6 @@
 import { Router, type Request } from "express";
 import type { Db } from "@paperclipai/db";
-import { randomUUID } from "node:crypto";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
 import {
   applyBuilderProposalSchema,
   createBuilderSessionSchema,
@@ -91,6 +91,39 @@ function tokenFromAuthorizationHeader(value: string | null) {
   return match?.[1]?.trim() || value.trim() || null;
 }
 
+function parseBooleanLike(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return null;
+  }
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on") {
+    return true;
+  }
+  if (normalized === "false" || normalized === "0" || normalized === "no" || normalized === "off") {
+    return false;
+  }
+  return null;
+}
+
+function generateEd25519PrivateKeyPem(): string {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  return privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+}
+
+function ensureGatewayDeviceKey(adapterConfig: Record<string, unknown>): Record<string, unknown> {
+  const disableDeviceAuth = parseBooleanLike(adapterConfig.disableDeviceAuth);
+  if (disableDeviceAuth !== false) return adapterConfig;
+  if (asNonEmptyString(adapterConfig.devicePrivateKeyPem)) return adapterConfig;
+  return {
+    ...adapterConfig,
+    devicePrivateKeyPem: generateEd25519PrivateKeyPem(),
+  };
+}
+
 function extractOpenClawAuthToken(adapterConfig: Record<string, unknown>) {
   const explicit = asNonEmptyString(adapterConfig.authToken) ?? asNonEmptyString(adapterConfig.token);
   if (explicit) return explicit;
@@ -142,7 +175,7 @@ async function persistBuilderSecrets(params: {
 
   if (params.adapterType === "openclaw_gateway") {
     const plainToken = extractOpenClawAuthToken(params.adapterConfig);
-    const sanitized = sanitizeOpenClawAdapterConfig(params.adapterConfig);
+    const sanitized = ensureGatewayDeviceKey(sanitizeOpenClawAdapterConfig(params.adapterConfig));
     const existingRef = asRecord(params.existingSettings?.adapterConfig)?.authTokenRef;
     const requestedRef = sanitized.authTokenRef ?? existingRef;
 

--- a/server/src/services/clickup-bridge.ts
+++ b/server/src/services/clickup-bridge.ts
@@ -220,11 +220,29 @@ function buildTaskFields(body: string, cfg: ReturnType<typeof resolveConfig>): R
   return fields;
 }
 
+function renderCommentRichText(raw: unknown): string {
+  if (!Array.isArray(raw)) return "";
+  return raw
+    .map((part) => {
+      if (!part || typeof part !== "object") return "";
+      const row = part as Record<string, unknown>;
+      const directText = typeof row.text === "string" ? row.text : "";
+      if (directText) return directText;
+      const user = row.user && typeof row.user === "object" ? (row.user as Record<string, unknown>) : null;
+      const username = user ? asString(user.username) : "";
+      if (row.type === "tag") return username ? `@${username}` : "@user";
+      return "";
+    })
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export function isUserCommentForImport(raw: unknown, bridgeBotUserId: string | null, clickupAgentUserId: number | null = null): { id: string; text: string; createdAt: number } | null {
   if (!raw || typeof raw !== "object") return null;
   const row = raw as Record<string, unknown>;
   const id = asScalarString(row.id);
-  const text = asString(row.comment_text);
+  const text = asString(row.comment_text) || renderCommentRichText(row.comment);
   const author = row.user && typeof row.user === "object" ? (row.user as Record<string, unknown>) : null;
   const authorId = author ? asScalarString(author.id) : "";
   const isSystem = typeof row.comment === "object" && row.comment !== null && !Array.isArray(row.comment);

--- a/ui/src/pages/CompanyBuilder.test.tsx
+++ b/ui/src/pages/CompanyBuilder.test.tsx
@@ -320,6 +320,55 @@ describe("CompanyBuilder", () => {
     });
   });
 
+  it("selects a newly created session immediately", async () => {
+    const newSessionCreatedAt = new Date("2026-05-06T10:00:00.000Z");
+    const newSession: BuilderSession = {
+      ...sessionsState[0],
+      id: "session-2",
+      title: "Fresh plan",
+      createdAt: newSessionCreatedAt,
+      updatedAt: newSessionCreatedAt,
+    };
+    const newSessionDetail: BuilderSessionDetail = {
+      ...newSession,
+      messages: [],
+    };
+
+    mockBuilderApi.createSession.mockImplementationOnce(async () => {
+      sessionsState = [newSession, ...sessionsState];
+      return { session: newSession };
+    });
+    mockBuilderApi.getSession.mockImplementation(async (_companyId?: string, sessionId?: string) => ({
+      session: sessionId === newSession.id
+        ? { ...newSessionDetail, messages: [] }
+        : {
+            ...sessionDetailState,
+            messages: [...sessionDetailState.messages],
+          },
+    }));
+
+    const { root } = await renderCompanyBuilder(container);
+    const newButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("New"),
+    );
+    expect(newButton).not.toBeUndefined();
+
+    await act(async () => {
+      newButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+    await flushReact();
+    await flushReact();
+
+    expect(mockBuilderApi.createSession).toHaveBeenCalledWith("company-1", {});
+    expect(container.textContent).toContain("Fresh plan");
+    expect(mockBuilderApi.getSession).toHaveBeenLastCalledWith("company-1", "session-2");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("splits active and archived sessions and disables archived composer", async () => {
     sessionsState = [
       {
@@ -361,6 +410,7 @@ describe("CompanyBuilder", () => {
       (button) => button.textContent?.includes("Archived"),
     );
     expect(archivedToggle).not.toBeUndefined();
+    expect(container.querySelector('button[aria-label="Restore session"]')).toBeNull();
 
     await act(async () => {
       archivedToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -405,6 +455,16 @@ describe("CompanyBuilder", () => {
 
     expect(mockBuilderApi.archiveSession).toHaveBeenCalledWith("company-1", "session-1");
     expect(container.textContent).toContain("Archived");
+
+    const archivedToggle = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Archived"),
+    );
+    expect(archivedToggle).not.toBeUndefined();
+
+    await act(async () => {
+      archivedToggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
 
     const restoreButton = container.querySelector('button[aria-label="Restore session"]');
     expect(restoreButton).not.toBeNull();

--- a/ui/src/pages/CompanyBuilder.tsx
+++ b/ui/src/pages/CompanyBuilder.tsx
@@ -1,7 +1,6 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
-  BuilderHandoffTarget,
   BuilderMessage,
   BuilderProposal,
   BuilderSession,
@@ -766,36 +765,6 @@ function RuntimeSummaryCard({
   );
 }
 
-function WorkflowCard({
-  handoff,
-}: {
-  handoff: BuilderHandoffTarget | null;
-}) {
-  return (
-    <Card className="border-border/70">
-      <CardHeader className="pb-3">
-        <CardTitle className="text-sm">Workflow</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3 text-sm text-muted-foreground">
-        <p>
-          Start work here, then continue governed or multi-step actions in the standard surface.
-        </p>
-        <p>
-          Direct actions stay inline only when the change is local and safe.
-        </p>
-        {handoff?.href ? (
-          <Button asChild size="sm" variant="outline" className="w-full">
-            <Link to={handoff.href}>
-              {handoff.label}
-              <ArrowUpRight className="h-4 w-4" />
-            </Link>
-          </Button>
-        ) : null}
-      </CardContent>
-    </Card>
-  );
-}
-
 function SessionRowAction({
   label,
   icon,
@@ -865,6 +834,15 @@ export function CompanyBuilder() {
     },
     onSuccess: async (created) => {
       if (!created) return;
+      queryClient.setQueryData<{ sessions: BuilderSession[] } | undefined>(
+        [...QUERY_KEY, "sessions", selectedCompanyId],
+        (current) => ({
+          sessions: [
+            created.session,
+            ...(current?.sessions ?? []).filter((session) => session.id !== created.session.id),
+          ],
+        }),
+      );
       setActiveSessionId(created.session.id);
       await queryClient.invalidateQueries({
         queryKey: [...QUERY_KEY, "sessions", selectedCompanyId],
@@ -885,7 +863,6 @@ export function CompanyBuilder() {
       return builderApi.archiveSession(selectedCompanyId, sessionId);
     },
     onSuccess: async () => {
-      setArchivedSectionOpen(true);
       await queryClient.invalidateQueries({
         queryKey: [...QUERY_KEY, "sessions", selectedCompanyId],
       });
@@ -940,9 +917,11 @@ export function CompanyBuilder() {
       setActiveSessionId(null);
       return;
     }
-    if (!activeSessionId || !sessions.some((session) => session.id === activeSessionId)) {
+    if (!activeSessionId) {
       setActiveSessionId(sessions[0]?.id ?? null);
+      return;
     }
+    if (!sessions.some((session) => session.id === activeSessionId)) return;
   }, [activeSessionId, sessions]);
 
   const detail = sessionDetailQuery.data?.session ?? null;
@@ -950,16 +929,6 @@ export function CompanyBuilder() {
     sessions.find((session) => session.id === activeSessionId) ?? null;
   const effectiveRuntimeConfig =
     detail?.effectiveRuntimeConfig ?? activeSession?.effectiveRuntimeConfig ?? null;
-
-  const lastHandoff = useMemo(() => {
-    if (!detail) return null;
-    const messages = [...detail.messages].reverse();
-    for (const message of messages) {
-      const handoff = message.content.toolResult?.handoff;
-      if (handoff?.href) return handoff;
-    }
-    return null;
-  }, [detail]);
 
   if (!selectedCompanyId) {
     return (
@@ -970,8 +939,8 @@ export function CompanyBuilder() {
   }
 
   return (
-    <div className="grid h-full gap-4 lg:grid-cols-[280px_minmax(0,1fr)_320px]">
-      <Card className="overflow-hidden border-border/70">
+    <div className="grid h-full gap-4 lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
+      <Card className="overflow-hidden border-border/70 lg:min-h-0">
         <CardHeader className="border-b border-border/70 pb-3">
           <div className="flex items-center justify-between gap-3">
             <CardTitle className="text-sm">Sessions</CardTitle>
@@ -985,7 +954,7 @@ export function CompanyBuilder() {
             </Button>
           </div>
         </CardHeader>
-        <CardContent className="p-0">
+        <CardContent className="p-0 lg:max-h-[calc(100vh-14rem)] lg:overflow-y-auto">
           {sessions.length === 0 ? (
             <div className="p-4 text-sm text-muted-foreground">
               No sessions yet. Start one to plan, draft, or launch company work.
@@ -1073,29 +1042,7 @@ export function CompanyBuilder() {
         </CardContent>
       </Card>
 
-      <Card className="overflow-hidden border-border/70">
-        <CardHeader className="border-b border-border/70 pb-3">
-          <CardTitle className="text-sm">
-            {activeSession ? getSessionDisplayTitle(activeSession) : "Conversation"}
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="h-[78vh] p-4">
-          {detail ? (
-            <ConversationPane
-              companyId={selectedCompanyId}
-              session={detail}
-              onBusyChange={setSidebarBusy}
-            />
-          ) : (
-            <EmptyState
-              icon={Sparkles}
-              message="No session selected. Create one to start a Builder conversation."
-            />
-          )}
-        </CardContent>
-      </Card>
-
-      <div className="space-y-4">
+      <div className="grid gap-4 lg:min-h-0 lg:grid-rows-[auto_minmax(0,1fr)]">
         <RuntimeSummaryCard
           runtime={effectiveRuntimeConfig}
           messageCount={detail?.messages.length ?? 0}
@@ -1104,7 +1051,27 @@ export function CompanyBuilder() {
             return status === "pending" || status === "approved";
           }).length ?? 0}
         />
-        <WorkflowCard handoff={lastHandoff} />
+        <Card className="overflow-hidden border-border/70 lg:min-h-0">
+          <CardHeader className="border-b border-border/70 pb-3">
+            <CardTitle className="text-sm">
+              {activeSession ? getSessionDisplayTitle(activeSession) : "Conversation"}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-4 lg:h-[calc(100vh-22rem)]">
+            {detail ? (
+              <ConversationPane
+                companyId={selectedCompanyId}
+                session={detail}
+                onBusyChange={setSidebarBusy}
+              />
+            ) : (
+              <EmptyState
+                icon={Sparkles}
+                message="No session selected. Create one to start a Builder conversation."
+              />
+            )}
+          </CardContent>
+        </Card>
       </div>
     </div>
   );


### PR DESCRIPTION
## Thinking Path

> - Paperclip gives operators a control plane for managing agent systems and the runtimes behind them.
> - This branch touches two operator-facing surfaces in that control plane: Company AI Builder session management and OpenClaw-backed agent/runtime configuration.
> - The Builder page currently drops the operator back onto the wrong session after creating a new one and spreads key context across an awkward three-column layout.
> - The OpenClaw gateway flow also needs stronger persistence around pairing credentials and better recovery ergonomics for failed ClickUp bridge work.
> - Both issues affect day-to-day operational reliability rather than introducing new product concepts.
> - This pull request stabilizes OpenClaw credential handling and retry behavior while cleaning up the Builder session flow and layout.
> - The benefit is a more reliable OpenClaw setup path and a tighter Builder UI for active company work.

## What Changed

- Reused an existing OpenClaw device private key when creating another agent against the same normalized gateway URL, instead of generating a fresh key every time.
- Ensured Company AI Builder OpenClaw settings persist a device private key whenever pairing mode is enabled.
- Added a board-only route to retry failed or closed ClickUp bridges and logged that retry as activity.
- Improved ClickUp comment import parsing so rich-text comment arrays still round-trip into plain text when `comment_text` is missing.
- Fixed the Builder new-session flow so the newly created session stays selected immediately.
- Kept archived Builder sessions collapsed by default, moved the live runtime card above chat, reduced the page to a two-column sessions/chat layout, and removed the Workflow card copy.
- Added regression coverage for the OpenClaw device-key reuse path, Builder OpenClaw settings persistence, ClickUp rich-comment parsing, and the Builder UI session-selection/collapsed-archive behavior.

## Verification

- `pnpm vitest run ui/src/pages/CompanyBuilder.test.tsx server/src/__tests__/builder-routes.test.ts server/src/__tests__/agent-adapter-validation-routes.test.ts server/src/__tests__/clickup-bridge.test.ts`
- `pnpm -r typecheck`
- Manual Builder check: create a new session, confirm it opens immediately, confirm Archived starts collapsed, and confirm runtime renders above chat in the two-column layout
- Manual OpenClaw check: save pairing-mode Builder settings or create a second agent against the same gateway URL and confirm the generated device key is persisted/reused instead of regenerated unnecessarily

## Risks

- Medium-low risk because the branch changes both Builder UI state behavior and OpenClaw credential plumbing, but the affected code paths are covered by targeted route/UI tests and full repo typecheck.
- Reusing a device key by normalized gateway URL assumes that agents pointing at the same gateway should share the pairing identity; that matches the requested workflow but changes previous per-agent behavior.
- This is a stacked PR targeting `add-clickup-and-openai-agents`, because the current Builder work is not based directly on `bizmain`.
- UI screenshot follow-up may still be needed before merge if reviewers want explicit before/after captures.

> Checked `ROADMAP.md`; no matching planned core item was found for this Builder/OpenClaw cleanup.

## Model Used

- OpenAI Codex desktop coding agent, GPT-5-class model with repository editing, terminal execution, and test-running/tool-use capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
