### PR TITLE
fix(agent-thread): refresh wake context and collapse runtime settings

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -416,7 +416,7 @@ describe("renderPaperclipWakePrompt", () => {
         },
       ],
       threadMessageWindow: {
-        requestedCount: 1,
+        totalCount: 1,
         includedCount: 1,
         missingCount: 0,
       },

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -612,20 +612,20 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     threadMessageIds,
     latestThreadMessageId: asString(payload.latestThreadMessageId, "").trim() || null,
     threadMessages,
-    requestedCount: asNumber(
-      commentWindow.requestedCount,
-      asNumber(
-        threadMessageWindow.totalCount,
-        asNumber(
-          threadMessageWindow.requestedCount,
-          comments.length || commentIds.length || threadMessages.length || threadMessageIds.length,
-        ),
-      ),
-    ),
-    includedCount: asNumber(
-      commentWindow.includedCount,
-      asNumber(threadMessageWindow.includedCount, comments.length || threadMessages.length),
-    ),
+    requestedCount:
+      comments.length > 0 || commentIds.length > 0
+        ? asNumber(commentWindow.requestedCount, comments.length || commentIds.length)
+        : asNumber(
+            threadMessageWindow.totalCount,
+            asNumber(
+              threadMessageWindow.requestedCount,
+              threadMessages.length || threadMessageIds.length,
+            ),
+          ),
+    includedCount:
+      comments.length > 0 || commentIds.length > 0
+        ? asNumber(commentWindow.includedCount, comments.length)
+        : asNumber(threadMessageWindow.includedCount, threadMessages.length),
     missingCount: asNumber(
       commentWindow.missingCount,
       asNumber(threadMessageWindow.missingCount, 0),

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -614,7 +614,13 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     threadMessages,
     requestedCount: asNumber(
       commentWindow.requestedCount,
-      asNumber(threadMessageWindow.requestedCount, comments.length || commentIds.length || threadMessages.length || threadMessageIds.length),
+      asNumber(
+        threadMessageWindow.totalCount,
+        asNumber(
+          threadMessageWindow.requestedCount,
+          comments.length || commentIds.length || threadMessages.length || threadMessageIds.length,
+        ),
+      ),
     ),
     includedCount: asNumber(
       commentWindow.includedCount,

--- a/server/src/__tests__/agent-thread-routes.test.ts
+++ b/server/src/__tests__/agent-thread-routes.test.ts
@@ -331,6 +331,7 @@ describe("agent thread routes", () => {
         agentThreadMessageId: messageId,
         agentThreadMessageBody: "hello from board",
         wakeReason: "agent_thread_message",
+        forceFreshSession: true,
       }),
     }));
     expect(res.body).toEqual({

--- a/server/src/__tests__/heartbeat-agent-thread-payload.test.ts
+++ b/server/src/__tests__/heartbeat-agent-thread-payload.test.ts
@@ -53,35 +53,7 @@ describeEmbeddedPostgres("buildPaperclipWakePayload agent thread", () => {
     const thirdMessageId = randomUUID();
     const now = new Date("2026-05-04T09:00:00.000Z");
 
-    await db.insert(companies).values({
-      id: companyId,
-      name: "Paperclip",
-      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
-      requireBoardApprovalForNewAgents: false,
-    });
-
-    await db.insert(agents).values({
-      id: agentId,
-      companyId,
-      name: "CTO",
-      role: "cto",
-      status: "active",
-      adapterType: "codex_local",
-      adapterConfig: {},
-      runtimeConfig: {},
-      permissions: {},
-    });
-
-    await db.insert(agentThreads).values({
-      id: threadId,
-      companyId,
-      agentId,
-      status: "active",
-      archivedAt: null,
-      lastActivityAt: now,
-      createdAt: now,
-      updatedAt: now,
-    });
+    await seedAgentThread({ db, companyId, agentId, threadId, now });
 
     await db.insert(agentThreadMessages).values({
       id: firstMessageId,
@@ -160,14 +132,146 @@ describeEmbeddedPostgres("buildPaperclipWakePayload agent thread", () => {
         },
       ],
       threadMessageWindow: {
-        requestedCount: 3,
+        totalCount: 3,
         includedCount: 3,
         missingCount: 0,
       },
       fallbackFetchNeeded: false,
     });
   });
+
+  it("marks older thread messages missing when the inline window hits the message limit", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const threadId = randomUUID();
+    const now = new Date("2026-05-04T09:00:00.000Z");
+
+    await seedAgentThread({ db, companyId, agentId, threadId, now });
+
+    const messageIds: string[] = [];
+    for (let index = 0; index < 9; index += 1) {
+      const messageId = randomUUID();
+      messageIds.push(messageId);
+      await db.insert(agentThreadMessages).values({
+        id: messageId,
+        threadId,
+        companyId,
+        role: index % 2 === 0 ? "user" : "assistant",
+        authorUserId: index % 2 === 0 ? "user-1" : null,
+        authorAgentId: index % 2 === 0 ? null : agentId,
+        producingHeartbeatRunId: null,
+        body: `message ${index + 1}`,
+        createdAt: new Date(now.getTime() + index * 60_000),
+        updatedAt: new Date(now.getTime() + index * 60_000),
+      });
+    }
+
+    const payload = await buildPaperclipWakePayload({
+      db,
+      companyId,
+      contextSnapshot: {
+        wakeReason: "agent_thread_message",
+        agentThreadId: threadId,
+        agentThreadMessageId: messageIds[8],
+      },
+    });
+
+    expect(payload?.threadMessageIds).toEqual(messageIds.slice(1));
+    expect(payload?.threadMessageWindow).toMatchObject({
+      totalCount: 9,
+      includedCount: 8,
+      missingCount: 1,
+    });
+    expect(payload?.fallbackFetchNeeded).toBe(true);
+  });
+
+  it("marks thread messages missing when the inline char budget is exhausted", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const threadId = randomUUID();
+    const now = new Date("2026-05-04T09:00:00.000Z");
+
+    await seedAgentThread({ db, companyId, agentId, threadId, now });
+
+    const messageIds = Array.from({ length: 4 }, () => randomUUID());
+    const budgetSizedBody = "a".repeat(4_000);
+
+    for (const [index, messageId] of messageIds.entries()) {
+      await db.insert(agentThreadMessages).values({
+        id: messageId,
+        threadId,
+        companyId,
+        role: index % 2 === 0 ? "user" : "assistant",
+        authorUserId: index % 2 === 0 ? "user-1" : null,
+        authorAgentId: index % 2 === 0 ? null : agentId,
+        producingHeartbeatRunId: null,
+        body: budgetSizedBody,
+        createdAt: new Date(now.getTime() + index * 60_000),
+        updatedAt: new Date(now.getTime() + index * 60_000),
+      });
+    }
+
+    const payload = await buildPaperclipWakePayload({
+      db,
+      companyId,
+      contextSnapshot: {
+        wakeReason: "agent_thread_message",
+        agentThreadId: threadId,
+        agentThreadMessageId: messageIds[3],
+      },
+    });
+
+    expect(payload?.threadMessages).toHaveLength(3);
+    expect(payload?.threadMessages[0]).toMatchObject({
+      id: messageIds[0],
+      bodyTruncated: false,
+    });
+    expect(payload?.threadMessageWindow).toMatchObject({
+      totalCount: 4,
+      includedCount: 3,
+      missingCount: 1,
+    });
+    expect(payload?.fallbackFetchNeeded).toBe(true);
+  });
 });
+
+async function seedAgentThread(input: {
+  db: ReturnType<typeof createDb>;
+  companyId: string;
+  agentId: string;
+  threadId: string;
+  now: Date;
+}) {
+  await input.db.insert(companies).values({
+    id: input.companyId,
+    name: "Paperclip",
+    issuePrefix: `T${input.companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+    requireBoardApprovalForNewAgents: false,
+  });
+
+  await input.db.insert(agents).values({
+    id: input.agentId,
+    companyId: input.companyId,
+    name: "CTO",
+    role: "cto",
+    status: "active",
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    permissions: {},
+  });
+
+  await input.db.insert(agentThreads).values({
+    id: input.threadId,
+    companyId: input.companyId,
+    agentId: input.agentId,
+    status: "active",
+    archivedAt: null,
+    lastActivityAt: input.now,
+    createdAt: input.now,
+    updatedAt: input.now,
+  });
+}
 
 async function ensureAgentThreadTables(db: ReturnType<typeof createDb>) {
   await db.execute(sql.raw(`

--- a/server/src/__tests__/heartbeat-agent-thread-payload.test.ts
+++ b/server/src/__tests__/heartbeat-agent-thread-payload.test.ts
@@ -48,7 +48,9 @@ describeEmbeddedPostgres("buildPaperclipWakePayload agent thread", () => {
     const companyId = randomUUID();
     const agentId = randomUUID();
     const threadId = randomUUID();
-    const messageId = randomUUID();
+    const firstMessageId = randomUUID();
+    const secondMessageId = randomUUID();
+    const thirdMessageId = randomUUID();
     const now = new Date("2026-05-04T09:00:00.000Z");
 
     await db.insert(companies).values({
@@ -82,7 +84,31 @@ describeEmbeddedPostgres("buildPaperclipWakePayload agent thread", () => {
     });
 
     await db.insert(agentThreadMessages).values({
-      id: messageId,
+      id: firstMessageId,
+      threadId,
+      companyId,
+      role: "user",
+      authorUserId: "user-1",
+      authorAgentId: null,
+      producingHeartbeatRunId: null,
+      body: "first ask",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(agentThreadMessages).values({
+      id: secondMessageId,
+      threadId,
+      companyId,
+      role: "assistant",
+      authorUserId: null,
+      authorAgentId: agentId,
+      producingHeartbeatRunId: null,
+      body: "first reply",
+      createdAt: new Date("2026-05-04T09:01:00.000Z"),
+      updatedAt: new Date("2026-05-04T09:01:00.000Z"),
+    });
+    await db.insert(agentThreadMessages).values({
+      id: thirdMessageId,
       threadId,
       companyId,
       role: "user",
@@ -90,8 +116,8 @@ describeEmbeddedPostgres("buildPaperclipWakePayload agent thread", () => {
       authorAgentId: null,
       producingHeartbeatRunId: null,
       body: "make 3 follow-up issues",
-      createdAt: now,
-      updatedAt: now,
+      createdAt: new Date("2026-05-04T09:02:00.000Z"),
+      updatedAt: new Date("2026-05-04T09:02:00.000Z"),
     });
 
     const payload = await buildPaperclipWakePayload({
@@ -100,7 +126,7 @@ describeEmbeddedPostgres("buildPaperclipWakePayload agent thread", () => {
       contextSnapshot: {
         wakeReason: "agent_thread_message",
         agentThreadId: threadId,
-        agentThreadMessageId: messageId,
+        agentThreadMessageId: thirdMessageId,
       },
     });
 
@@ -111,16 +137,33 @@ describeEmbeddedPostgres("buildPaperclipWakePayload agent thread", () => {
         agentId,
         agentName: "CTO",
       },
-      threadMessageIds: [messageId],
-      latestThreadMessageId: messageId,
+      threadMessageIds: [firstMessageId, secondMessageId, thirdMessageId],
+      latestThreadMessageId: thirdMessageId,
       threadMessages: [
         {
-          id: messageId,
+          id: firstMessageId,
+          threadId,
+          role: "user",
+          body: "first ask",
+        },
+        {
+          id: secondMessageId,
+          threadId,
+          role: "assistant",
+          body: "first reply",
+        },
+        {
+          id: thirdMessageId,
           threadId,
           role: "user",
           body: "make 3 follow-up issues",
         },
       ],
+      threadMessageWindow: {
+        requestedCount: 3,
+        includedCount: 3,
+        missingCount: 0,
+      },
       fallbackFetchNeeded: false,
     });
   });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2679,7 +2679,7 @@ export function agentRoutes(db: Db) {
           agentThreadMessageId: result.message.id,
           agentThreadMessageBody: result.message.body,
           taskKey: `agent-thread:${result.thread.id}`,
-          forceFreshSession: false,
+          forceFreshSession: true,
         },
       });
     } catch (err) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
-import { and, asc, count, desc, eq, getTableColumns, gt, inArray, isNull, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lte, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -1669,6 +1669,7 @@ export async function buildPaperclipWakePayload(input: {
             authorAgentId: agentThreadMessages.authorAgentId,
             authorUserId: agentThreadMessages.authorUserId,
             createdAt: agentThreadMessages.createdAt,
+            totalCount: sql<number>`count(*) over ()`,
           })
           .from(agentThreadMessages)
           .where(
@@ -1683,19 +1684,9 @@ export async function buildPaperclipWakePayload(input: {
   const threadMessageIds = threadMessageRows.map((message) => message.id);
   const latestThreadMessageId =
     threadMessageIds[threadMessageIds.length - 1] ?? agentThreadMessageId ?? null;
-  const threadMessageTotalCount =
-    !agentThreadId
-      ? 0
-      : await input.db
-          .select({ count: count() })
-          .from(agentThreadMessages)
-          .where(
-            and(
-              eq(agentThreadMessages.companyId, input.companyId),
-              eq(agentThreadMessages.threadId, agentThreadId),
-            ),
-          )
-          .then((rows) => rows[0]?.count ?? 0);
+  const threadMessageTotalCount = threadMessageRows[0]
+    ? Number(threadMessageRows[0].totalCount)
+    : 0;
   const threadMessages: Array<Record<string, unknown>> = [];
   let remainingThreadBodyChars = MAX_INLINE_WAKE_THREAD_MESSAGE_BODY_TOTAL_CHARS;
   let missingThreadMessageCount = 0;
@@ -1816,7 +1807,7 @@ export async function buildPaperclipWakePayload(input: {
     latestThreadMessageId,
     threadMessages,
     threadMessageWindow: {
-      requestedCount: threadMessageTotalCount,
+      totalCount: threadMessageTotalCount,
       includedCount: threadMessages.length,
       missingCount: missingThreadMessageCount,
     },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, getTableColumns, gt, inArray, isNull, lte, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -148,6 +148,9 @@ const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
+const MAX_INLINE_WAKE_THREAD_MESSAGES = 8;
+const MAX_INLINE_WAKE_THREAD_MESSAGE_BODY_CHARS = 4_000;
+const MAX_INLINE_WAKE_THREAD_MESSAGE_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -1654,9 +1657,8 @@ export async function buildPaperclipWakePayload(input: {
     });
   }
 
-  const threadMessageIds = agentThreadMessageId ? [agentThreadMessageId] : [];
   const threadMessageRows =
-    threadMessageIds.length === 0
+    !agentThreadId
       ? []
       : await input.db
           .select({
@@ -1672,27 +1674,58 @@ export async function buildPaperclipWakePayload(input: {
           .where(
             and(
               eq(agentThreadMessages.companyId, input.companyId),
-              inArray(agentThreadMessages.id, threadMessageIds),
+              eq(agentThreadMessages.threadId, agentThreadId),
             ),
-          );
-
-  const threadMessagesById = new Map(threadMessageRows.map((message) => [message.id, message]));
+          )
+          .orderBy(desc(agentThreadMessages.createdAt), desc(agentThreadMessages.id))
+          .limit(MAX_INLINE_WAKE_THREAD_MESSAGES)
+          .then((rows) => [...rows].reverse());
+  const threadMessageIds = threadMessageRows.map((message) => message.id);
+  const latestThreadMessageId =
+    threadMessageIds[threadMessageIds.length - 1] ?? agentThreadMessageId ?? null;
+  const threadMessageTotalCount =
+    !agentThreadId
+      ? 0
+      : await input.db
+          .select({ count: count() })
+          .from(agentThreadMessages)
+          .where(
+            and(
+              eq(agentThreadMessages.companyId, input.companyId),
+              eq(agentThreadMessages.threadId, agentThreadId),
+            ),
+          )
+          .then((rows) => rows[0]?.count ?? 0);
   const threadMessages: Array<Record<string, unknown>> = [];
+  let remainingThreadBodyChars = MAX_INLINE_WAKE_THREAD_MESSAGE_BODY_TOTAL_CHARS;
   let missingThreadMessageCount = 0;
+  if (threadMessageTotalCount > threadMessageRows.length) {
+    missingThreadMessageCount += threadMessageTotalCount - threadMessageRows.length;
+    truncated = true;
+  }
 
-  for (const threadMessageId of threadMessageIds) {
-    const row = threadMessagesById.get(threadMessageId);
-    if (!row) {
+  for (const row of threadMessageRows) {
+    const allowedBodyChars = Math.min(
+      MAX_INLINE_WAKE_THREAD_MESSAGE_BODY_CHARS,
+      remainingThreadBodyChars,
+    );
+    if (allowedBodyChars <= 0) {
       missingThreadMessageCount += 1;
+      truncated = true;
       continue;
     }
+
+    const body = row.body.length > allowedBodyChars ? row.body.slice(0, allowedBodyChars) : row.body;
+    const bodyTruncated = body.length < row.body.length;
+    if (bodyTruncated) truncated = true;
+    remainingThreadBodyChars -= body.length;
 
     threadMessages.push({
       id: row.id,
       threadId: row.threadId,
       role: row.role,
-      body: row.body,
-      bodyTruncated: false,
+      body,
+      bodyTruncated,
       createdAt: row.createdAt.toISOString(),
       author: row.authorAgentId
         ? { type: "agent", id: row.authorAgentId }
@@ -1704,12 +1737,12 @@ export async function buildPaperclipWakePayload(input: {
 
   if (
     threadMessages.length === 0 &&
-    threadMessageIds.length > 0 &&
+    latestThreadMessageId &&
     typeof input.contextSnapshot.agentThreadMessageBody === "string" &&
     input.contextSnapshot.agentThreadMessageBody.trim().length > 0
   ) {
     threadMessages.push({
-      id: agentThreadMessageId,
+      id: latestThreadMessageId,
       threadId: agentThreadId,
       role: "user",
       body: input.contextSnapshot.agentThreadMessageBody,
@@ -1780,10 +1813,10 @@ export async function buildPaperclipWakePayload(input: {
     latestCommentId: commentIds[commentIds.length - 1] ?? null,
     comments,
     threadMessageIds,
-    latestThreadMessageId: threadMessageIds[threadMessageIds.length - 1] ?? null,
+    latestThreadMessageId,
     threadMessages,
     threadMessageWindow: {
-      requestedCount: threadMessageIds.length,
+      requestedCount: threadMessageTotalCount,
       includedCount: threadMessages.length,
       missingCount: missingThreadMessageCount,
     },

--- a/ui/src/pages/ExecutionWorkspaceDetail.tsx
+++ b/ui/src/pages/ExecutionWorkspaceDetail.tsx
@@ -707,77 +707,75 @@ export function ExecutionWorkspaceDetail() {
 
                 <Separator />
 
-                <div className="space-y-4">
-                  <div className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Runtime config</div>
-                  <div className="rounded-md border border-dashed border-border/70 bg-background px-4 py-3">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
-                      <div className="space-y-1">
-                        <div className="text-sm font-medium text-foreground">
-                          Runtime config source
-                        </div>
-                        <p className="text-sm text-muted-foreground">
-                          {runtimeConfigSource === "execution_workspace"
-                            ? "This execution workspace currently overrides the project workspace runtime config."
-                            : runtimeConfigSource === "project_workspace"
-                              ? "This execution workspace is inheriting the project workspace runtime config."
-                              : "No runtime config is currently defined on this execution workspace or its project workspace."}
-                        </p>
-                      </div>
-                      <Button
-                        variant="outline"
-                        className="w-full sm:w-auto"
-                        size="sm"
-                        disabled={!linkedProjectWorkspace?.runtimeConfig?.workspaceRuntime}
-                        onClick={() =>
-                          setForm((current) => current ? {
-                            ...current,
-                            inheritRuntime: true,
-                            workspaceRuntime: "",
-                          } : current)
-                        }
-                      >
-                        Reset to inherit
-                      </Button>
-                    </div>
-                  </div>
+                <details className="rounded-md border border-dashed border-border/70 bg-background px-4 py-3">
+                  <summary className="cursor-pointer text-sm font-medium">Runtime settings</summary>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Collapse this unless you need to inspect or override the workspace command model for this execution workspace.
+                  </p>
 
-                  <details className="rounded-md border border-dashed border-border/70 bg-background px-4 py-3">
-                    <summary className="cursor-pointer text-sm font-medium">Advanced runtime JSON</summary>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Override the inherited workspace command model only when this execution workspace truly needs different service or job behavior.
-                    </p>
-                    <div className="mt-3">
-                      <Field label="Workspace commands JSON" hint="Legacy `services` arrays still work, but `commands` supports both services and jobs.">
-                        <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
-                          <input
-                            id="inherit-runtime-config"
-                            type="checkbox"
-                            className="rounded border-border"
-                            checked={form.inheritRuntime}
-                            onChange={(event) => {
-                              const checked = event.target.checked;
-                              setForm((current) => {
-                                if (!current) return current;
-                                if (!checked && !current.workspaceRuntime.trim() && inheritedRuntimeConfig) {
-                                  return { ...current, inheritRuntime: checked, workspaceRuntime: formatJson(inheritedRuntimeConfig) };
-                                }
-                                return { ...current, inheritRuntime: checked };
-                              });
-                            }}
-                          />
-                          <label htmlFor="inherit-runtime-config">Inherit project workspace runtime config</label>
+                  <div className="mt-3 space-y-4">
+                    <div className="rounded-md border border-dashed border-border/70 bg-background px-4 py-3">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+                        <div className="space-y-1">
+                          <div className="text-sm font-medium text-foreground">
+                            Runtime config source
+                          </div>
+                          <p className="text-sm text-muted-foreground">
+                            {runtimeConfigSource === "execution_workspace"
+                              ? "This execution workspace currently overrides the project workspace runtime config."
+                              : runtimeConfigSource === "project_workspace"
+                                ? "This execution workspace is inheriting the project workspace runtime config."
+                                : "No runtime config is currently defined on this execution workspace or its project workspace."}
+                          </p>
                         </div>
-                        <Textarea
-                          className="min-h-64 font-mono sm:min-h-96"
-                          value={form.workspaceRuntime}
-                          onChange={(event) => setForm((current) => current ? { ...current, workspaceRuntime: event.target.value } : current)}
-                          disabled={form.inheritRuntime}
-                          placeholder={'{\n  "commands": [\n    {\n      "id": "web",\n      "name": "web",\n      "kind": "service",\n      "command": "pnpm dev",\n      "cwd": ".",\n      "port": { "type": "auto" }\n    },\n    {\n      "id": "db-migrate",\n      "name": "db:migrate",\n      "kind": "job",\n      "command": "pnpm db:migrate",\n      "cwd": "."\n    }\n  ]\n}'}
-                        />
-                      </Field>
+                        <Button
+                          variant="outline"
+                          className="w-full sm:w-auto"
+                          size="sm"
+                          disabled={!linkedProjectWorkspace?.runtimeConfig?.workspaceRuntime}
+                          onClick={() =>
+                            setForm((current) => current ? {
+                              ...current,
+                              inheritRuntime: true,
+                              workspaceRuntime: "",
+                            } : current)
+                          }
+                        >
+                          Reset to inherit
+                        </Button>
+                      </div>
                     </div>
-                  </details>
-                </div>
+
+                    <Field label="Workspace commands JSON" hint="Legacy `services` arrays still work, but `commands` supports both services and jobs.">
+                      <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+                        <input
+                          id="inherit-runtime-config"
+                          type="checkbox"
+                          className="rounded border-border"
+                          checked={form.inheritRuntime}
+                          onChange={(event) => {
+                            const checked = event.target.checked;
+                            setForm((current) => {
+                              if (!current) return current;
+                              if (!checked && !current.workspaceRuntime.trim() && inheritedRuntimeConfig) {
+                                return { ...current, inheritRuntime: checked, workspaceRuntime: formatJson(inheritedRuntimeConfig) };
+                              }
+                              return { ...current, inheritRuntime: checked };
+                            });
+                          }}
+                        />
+                        <label htmlFor="inherit-runtime-config">Inherit project workspace runtime config</label>
+                      </div>
+                      <Textarea
+                        className="min-h-64 font-mono sm:min-h-96"
+                        value={form.workspaceRuntime}
+                        onChange={(event) => setForm((current) => current ? { ...current, workspaceRuntime: event.target.value } : current)}
+                        disabled={form.inheritRuntime}
+                        placeholder={'{\n  "commands": [\n    {\n      "id": "web",\n      "name": "web",\n      "kind": "service",\n      "command": "pnpm dev",\n      "cwd": ".",\n      "port": { "type": "auto" }\n    },\n    {\n      "id": "db-migrate",\n      "name": "db:migrate",\n      "kind": "job",\n      "command": "pnpm db:migrate",\n      "cwd": "."\n    }\n  ]\n}'}
+                      />
+                    </Field>
+                  </div>
+                </details>
               </div>
 
               <div className="mt-6 flex flex-col items-stretch gap-3 sm:flex-row sm:flex-wrap sm:items-center">

--- a/ui/src/pages/ProjectWorkspaceDetail.tsx
+++ b/ui/src/pages/ProjectWorkspaceDetail.tsx
@@ -546,9 +546,9 @@ export function ProjectWorkspaceDetail() {
               </div>
 
               <details className="rounded-xl border border-dashed border-border/70 bg-background px-3 py-3">
-                <summary className="cursor-pointer text-sm font-medium">Advanced runtime JSON</summary>
+                <summary className="cursor-pointer text-sm font-medium">Runtime settings</summary>
                 <p className="mt-2 text-sm text-muted-foreground">
-                  Paperclip derives Services and Jobs from this JSON. Prefer editing named commands first; use raw JSON for advanced lifecycle, port, readiness, or environment settings.
+                  Collapse this unless you need to inspect or edit the raw workspace command model. Paperclip derives Services and Jobs from this JSON.
                 </p>
                 <div className="mt-3">
                   <Field label="Workspace commands JSON" hint="Execution workspaces inherit this config unless they override it. Legacy `services` arrays still work, but `commands` supports both services and jobs.">


### PR DESCRIPTION
## Thinking Path

> - Bizbox is the control plane for autonomous AI companies, and direct board-to-agent communication now runs through first-class `agent thread` objects.
> - That means the heartbeat wake path for agent-thread messages has to represent the live conversation accurately, not just fire a generic run.
> - After PR #44, agent-thread wakes were scoped to the thread but still reused session state and only carried the single triggering message into the wake payload.
> - In practice that let direct-chat replies stay anchored to stale earlier context, which made new thread messages feel like they were being answered from the first turn instead of the current thread state.
> - The workspace detail pages also surfaced the runtime JSON block too aggressively, which made the settings UI feel noisy for a control that is only needed occasionally.
> - This pull request makes agent-thread wakes fresh and transcript-aware, and tucks the runtime JSON/settings area behind an explicit disclosure.
> - The benefit is more reliable direct agent-thread responses and a cleaner workspace settings surface.

## What Changed

- Forced direct `agent_thread_message` wakes to start a fresh session instead of resuming the prior thread-scoped session.
- Expanded the agent-thread wake payload to include the recent thread transcript window, message counts, and truncation/fallback metadata instead of only the single triggering message.
- Updated server tests to cover the fresh-session wake behavior and the multi-message agent-thread payload.
- Renamed the raw runtime JSON disclosure to `Runtime settings` and made the noisy execution/project workspace runtime block explicitly collapsible.

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-agent-thread-payload.test.ts server/src/__tests__/agent-thread-routes.test.ts ui/src/components/WorkspaceRuntimeControls.test.tsx`
- `pnpm -r typecheck`
- Manual spot-check:
  - Open an agent chat thread.
  - Send a follow-up after an earlier exchange.
  - Confirm the next response reflects the latest thread messages rather than behaving like the first turn is still the active prompt.
  - Open execution/project workspace detail pages and confirm the runtime JSON/settings area is collapsed behind `Runtime settings` by default.

## Risks

- Medium-low risk: direct agent-thread wakes now force a fresh session, which trades some conversation continuity for more reliable grounding on the latest thread state.
- Medium-low risk: the wake payload now includes a recent thread window rather than only the triggering message; if a workflow depended on the narrower payload shape semantically, behavior may shift, though tests cover the intended server-side contract.
- Low risk: the UI change is limited to disclosure structure and labeling for runtime settings.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent in the Codex desktop app (exact in-app model ID not exposed), using tool-assisted code editing, shell execution, and test/typecheck verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
