### PR TITLE
fix(server): mount builder under company routes

### DIFF
--- a/server/src/__tests__/company-builder-mount.test.ts
+++ b/server/src/__tests__/company-builder-mount.test.ts
@@ -1,0 +1,158 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const companyId = "22222222-2222-4222-8222-222222222222";
+
+const mockCompanyService = vi.hoisted(() => ({
+  list: vi.fn(),
+  stats: vi.fn(),
+  getById: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  archive: vi.fn(),
+  remove: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  ensureMembership: vi.fn(),
+}));
+
+const mockBudgetService = vi.hoisted(() => ({
+  upsertPolicy: vi.fn(),
+}));
+
+const mockCompanyPortabilityService = vi.hoisted(() => ({
+  exportBundle: vi.fn(),
+  previewExport: vi.fn(),
+  previewImport: vi.fn(),
+  importBundle: vi.fn(),
+}));
+
+const mockFeedbackService = vi.hoisted(() => ({
+  listFeedbackTraces: vi.fn(),
+}));
+
+const mockBuilderService = vi.hoisted(() => ({
+  listSessions: vi.fn(),
+  getSessionDetail: vi.fn(),
+  createSession: vi.fn(),
+  abortSession: vi.fn(),
+  archiveSession: vi.fn(),
+  restoreSession: vi.fn(),
+  sendMessage: vi.fn(),
+  getSettings: vi.fn(),
+  upsertSettings: vi.fn(),
+  getToolCatalog: vi.fn(),
+  listProposals: vi.fn(),
+  getProposal: vi.fn(),
+  applyProposal: vi.fn(),
+  rejectProposal: vi.fn(),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  getExperimental: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockSecretService = vi.hoisted(() => ({
+  create: vi.fn(),
+  rotate: vi.fn(),
+  normalizeSecretRefBindingForPersistence: vi.fn(),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../routes/authz.js", async () => vi.importActual("../routes/authz.js"));
+  vi.doMock("../services/builder/index.js", () => ({
+    builderService: () => mockBuilderService,
+  }));
+  vi.doMock("../services/instance-settings.js", () => ({
+    instanceSettingsService: () => mockInstanceSettingsService,
+  }));
+  vi.doMock("../services/activity-log.js", () => ({
+    logActivity: mockLogActivity,
+  }));
+  vi.doMock("../services/secrets.js", () => ({
+    secretService: () => mockSecretService,
+  }));
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => mockAccessService,
+    agentService: () => mockAgentService,
+    budgetService: () => mockBudgetService,
+    companyPortabilityService: () => mockCompanyPortabilityService,
+    companyService: () => mockCompanyService,
+    feedbackService: () => mockFeedbackService,
+    logActivity: mockLogActivity,
+  }));
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ companyRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/companies.js")>("../routes/companies.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { actor: typeof actor }).actor = actor;
+    next();
+  });
+  app.use("/api/companies", companyRoutes({} as never));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("company routes builder mount", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../services/builder/index.js");
+    vi.doUnmock("../services/instance-settings.js");
+    vi.doUnmock("../services/activity-log.js");
+    vi.doUnmock("../services/secrets.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../routes/companies.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.resetAllMocks();
+
+    mockInstanceSettingsService.getExperimental.mockResolvedValue({
+      enableIsolatedWorkspaces: false,
+      autoRestartDevServerWhenIdle: false,
+      builderEnabled: true,
+    });
+    mockBuilderService.listSessions.mockResolvedValue([
+      {
+        id: "session-1",
+        companyId,
+        title: "Builder chat",
+      },
+    ]);
+  });
+
+  it("serves builder endpoints through companyRoutes", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app).get(`/api/companies/${companyId}/builder/sessions`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sessions).toEqual([
+      {
+        id: "session-1",
+        companyId,
+        title: "Builder chat",
+      },
+    ]);
+    expect(mockBuilderService.listSessions).toHaveBeenCalledWith(companyId, { includeArchived: false });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -35,7 +35,6 @@ import {
   type InstanceDatabaseBackupService,
 } from "./routes/instance-database-backups.js";
 import { llmRoutes } from "./routes/llms.js";
-import { builderRoutes } from "./routes/builder.js";
 import { authRoutes } from "./routes/auth.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
@@ -207,7 +206,6 @@ export async function createApp(
   api.use(inboxDismissalRoutes(db));
   api.use(instanceSettingsRoutes(db));
   api.use(emergencyStopRoutes(db));
-  api.use(builderRoutes(db));
   if (opts.databaseBackupService) {
     api.use(instanceDatabaseBackupRoutes(opts.databaseBackupService));
   }

--- a/server/src/routes/builder.ts
+++ b/server/src/routes/builder.ts
@@ -252,14 +252,24 @@ async function persistBuilderSecrets(params: {
 }
 
 export function builderRoutes(db: Db) {
-  const router = Router();
+  return createBuilderRoutes(db);
+}
+
+export function companyBuilderRoutes(db: Db) {
+  return createBuilderRoutes(db, { scopedToCompany: true });
+}
+
+function createBuilderRoutes(db: Db, options?: { scopedToCompany?: boolean }) {
+  const router = Router(options?.scopedToCompany ? { mergeParams: true } : undefined);
   const svc = builderService(db);
+  const route = (path: string) =>
+    options?.scopedToCompany ? path : `/companies/:companyId/builder${path}`;
 
   // ------------------------------------------------------------------------
   // Provider settings
   // ------------------------------------------------------------------------
 
-  router.get("/companies/:companyId/builder/settings", async (req, res) => {
+  router.get(route("/settings"), async (req, res) => {
     await assertBuilderEnabled(db);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -269,7 +279,7 @@ export function builderRoutes(db: Db) {
   });
 
   router.put(
-    "/companies/:companyId/builder/settings",
+    route("/settings"),
     validate(updateBuilderProviderSettingsSchema),
     async (req, res) => {
       await assertBuilderEnabled(db);
@@ -315,7 +325,7 @@ export function builderRoutes(db: Db) {
   // Tool catalog
   // ------------------------------------------------------------------------
 
-  router.get("/companies/:companyId/builder/tools", async (req, res) => {
+  router.get(route("/tools"), async (req, res) => {
     await assertBuilderEnabled(db);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -327,7 +337,7 @@ export function builderRoutes(db: Db) {
   // Sessions
   // ------------------------------------------------------------------------
 
-  router.get("/companies/:companyId/builder/sessions", async (req, res) => {
+  router.get(route("/sessions"), async (req, res) => {
     await assertBuilderEnabled(db);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -338,7 +348,7 @@ export function builderRoutes(db: Db) {
   });
 
   router.post(
-    "/companies/:companyId/builder/sessions",
+    route("/sessions"),
     validate(createBuilderSessionSchema),
     async (req, res) => {
       await assertBuilderEnabled(db);
@@ -370,7 +380,7 @@ export function builderRoutes(db: Db) {
     },
   );
 
-  router.get("/companies/:companyId/builder/sessions/:sessionId", async (req, res) => {
+  router.get(route("/sessions/:sessionId"), async (req, res) => {
     await assertBuilderEnabled(db);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -381,7 +391,7 @@ export function builderRoutes(db: Db) {
   });
 
   router.post(
-    "/companies/:companyId/builder/sessions/:sessionId/messages",
+    route("/sessions/:sessionId/messages"),
     validate(sendBuilderMessageSchema),
     async (req, res) => {
       await assertBuilderEnabled(db);
@@ -427,7 +437,7 @@ export function builderRoutes(db: Db) {
   );
 
   router.post(
-    "/companies/:companyId/builder/sessions/:sessionId/abort",
+    route("/sessions/:sessionId/abort"),
     async (req, res) => {
       await assertBuilderEnabled(db);
       const companyId = req.params.companyId as string;
@@ -456,7 +466,7 @@ export function builderRoutes(db: Db) {
   );
 
   router.post(
-    "/companies/:companyId/builder/sessions/:sessionId/archive",
+    route("/sessions/:sessionId/archive"),
     async (req, res) => {
       await assertBuilderEnabled(db);
       const companyId = req.params.companyId as string;
@@ -484,7 +494,7 @@ export function builderRoutes(db: Db) {
   );
 
   router.post(
-    "/companies/:companyId/builder/sessions/:sessionId/restore",
+    route("/sessions/:sessionId/restore"),
     async (req, res) => {
       await assertBuilderEnabled(db);
       const companyId = req.params.companyId as string;
@@ -520,7 +530,7 @@ export function builderRoutes(db: Db) {
   // start using the API now and gain incremental updates later transparently.
 
   router.post(
-    "/companies/:companyId/builder/sessions/:sessionId/messages/stream",
+    route("/sessions/:sessionId/messages/stream"),
     validate(sendBuilderMessageSchema),
     async (req, res) => {
       await assertBuilderEnabled(db);
@@ -603,7 +613,7 @@ export function builderRoutes(db: Db) {
   // Proposals (Phases 1 + 2)
   // ------------------------------------------------------------------------
 
-  router.get("/companies/:companyId/builder/proposals", async (req, res) => {
+  router.get(route("/proposals"), async (req, res) => {
     await assertBuilderEnabled(db);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -624,7 +634,7 @@ export function builderRoutes(db: Db) {
   });
 
   router.get(
-    "/companies/:companyId/builder/proposals/:proposalId",
+    route("/proposals/:proposalId"),
     async (req, res) => {
       await assertBuilderEnabled(db);
       const companyId = req.params.companyId as string;
@@ -638,7 +648,7 @@ export function builderRoutes(db: Db) {
   );
 
   router.post(
-    "/companies/:companyId/builder/proposals/:proposalId/apply",
+    route("/proposals/:proposalId/apply"),
     validate(applyBuilderProposalSchema),
     async (req, res) => {
       await assertBuilderEnabled(db);
@@ -653,7 +663,7 @@ export function builderRoutes(db: Db) {
   );
 
   router.post(
-    "/companies/:companyId/builder/proposals/:proposalId/reject",
+    route("/proposals/:proposalId/reject"),
     validate(rejectBuilderProposalSchema),
     async (req, res) => {
       await assertBuilderEnabled(db);

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -14,6 +14,7 @@ import {
 } from "@paperclipai/shared";
 import { badRequest, forbidden } from "../errors.js";
 import { validate } from "../middleware/validate.js";
+import { companyBuilderRoutes } from "./builder.js";
 import {
   accessService,
   agentService,
@@ -34,6 +35,8 @@ export function companyRoutes(db: Db, storage?: StorageService) {
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);
+
+  router.use("/:companyId/builder", companyBuilderRoutes(db));
 
   function parseBooleanQuery(value: unknown) {
     return value === true || value === "true" || value === "1";


### PR DESCRIPTION
## Thinking Path

> - Bizbox is the control plane for autonomous AI companies, so API surfaces should follow company boundaries rather than hang off the instance root.
> - The Builder feature is a company-scoped tool with company-owned settings, sessions, tools, and proposals.
> - The documented Builder API shape in the Builder plan is `/api/companies/:companyId/builder/*`.
> - The server was still mounting `builderRoutes` directly in `createApp`, which made the feature feel detached from the rest of the company route tree.
> - That split routing made the ownership model less clear and made it easier for future company-route changes to miss Builder.
> - This pull request moves Builder mounting into `companyRoutes` and keeps the handlers reusable by supporting both top-level and nested route construction.
> - The benefit is a cleaner company-scoped route tree plus a regression test that proves Builder is served through the company router.

## What Changed

- Moved Builder route mounting from `server/src/app.ts` into `server/src/routes/companies.ts` under `/:companyId/builder`.
- Refactored `server/src/routes/builder.ts` so the same handler set can be created either as legacy absolute paths or as company-nested routes with `mergeParams`.
- Added `server/src/__tests__/company-builder-mount.test.ts` to verify `/api/companies/:companyId/builder/sessions` is served through `companyRoutes`.

## Verification

- `pnpm vitest run server/src/__tests__/company-builder-mount.test.ts server/src/__tests__/builder-routes.test.ts`

## Risks

- Low risk. This changes only Builder route registration, but any untested caller depending on the old top-level mount shape would break if it bypassed the documented company-scoped path.

## Model Used

- OpenAI Codex desktop coding agent, GPT-5-based model family (exact internal model ID not exposed by the app), tool-enabled with terminal/git/test execution, high-reasoning workflow.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
