### PR TITLE
bug fix, have deliverables created on heartbeat

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -82,6 +82,7 @@ export const DEFAULT_BIZBOX_AGENT_PROMPT_TEMPLATE = [
   "Execution contract:",
   "- Start actionable work in this heartbeat; do not stop at a plan unless the issue asks for planning.",
   "- Leave durable progress in comments, documents, or work products with a clear next action.",
+  "- When the issue asks for a durable text deliverable, write it as an issue document; if you must return it inline in the final summary, wrap it in <issue-document key=\"...\" title=\"...\">...</issue-document> so Paperclip can promote it into Deliverables.",
   "- Use child issues for parallel or long delegated work instead of polling agents, sessions, or processes.",
   "- If woken by a human comment on a dependency-blocked issue, respond or triage the comment without treating the blocked deliverable work as unblocked.",
   "- Create child issues directly when you know what needs to be done; use issue-thread interactions when the board/user must choose suggested tasks, answer structured questions, or confirm a proposal.",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1540,6 +1540,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("Finished both deliverables.");
+    expect(comments[0]?.body).not.toContain("<issue-document");
   });
 
   it("blocks stranded in-progress work after the continuation retry was already used", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -44,6 +44,17 @@ vi.mock("../telemetry.ts", () => ({
   getTelemetryClient: () => mockTelemetryClient,
 }));
 
+vi.mock("../otel.ts", () => ({
+  clearIssueStatusCountsForCompany: vi.fn(),
+  recordComment: vi.fn(),
+  recordHumanIntervened: vi.fn(),
+  recordIssueCreated: vi.fn(),
+  recordIssueStatusChanged: vi.fn(),
+  recordIssueStatusCounts: vi.fn(),
+  recordRunStatus: vi.fn(),
+  traceHumanCommentPosted: vi.fn(),
+}));
+
 vi.mock("@paperclipai/shared/telemetry", async () => {
   const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
     "@paperclipai/shared/telemetry",
@@ -67,6 +78,7 @@ vi.mock("../adapters/index.ts", async () => {
 
 import { heartbeatService } from "../services/heartbeat.ts";
 import { issueService } from "../services/issues.ts";
+import * as documentsModule from "../services/documents.ts";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
@@ -1416,6 +1428,120 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const wakes = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
     expect(wakes.some((row) => row.reason === "run_liveness_continuation")).toBe(false);
   });
+
+  it("continues promoting later documents and posts the run comment when one promotion fails", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Promote deliverables from heartbeat summary",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    mockAdapterExecute.mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: [
+        "## Summary",
+        "",
+        "Finished both deliverables.",
+        "",
+        "<issue-document key=\"first-doc\" title=\"First Doc\">",
+        "First body",
+        "</issue-document>",
+        "",
+        "<issue-document key=\"second-doc\" title=\"Second Doc\">",
+        "Second body",
+        "</issue-document>",
+      ].join("\n"),
+      provider: "test",
+      model: "test-model",
+    });
+
+    const baseDocumentService = documentsModule.documentService;
+    const documentServiceSpy = vi.spyOn(documentsModule, "documentService").mockImplementation((serviceDb) => {
+      const svc = baseDocumentService(serviceDb);
+      return {
+        ...svc,
+        async upsertIssueDocument(params) {
+          if (params.key === "first-doc") {
+            throw new Error("synthetic promotion failure");
+          }
+          return svc.upsertIssueDocument(params);
+        },
+      };
+    });
+
+    const heartbeat = heartbeatService(db);
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+    expect(wake?.id).toBeTruthy();
+    if (wake?.id) {
+      await waitForRunToSettle(heartbeat, wake.id, 5_000);
+    }
+
+    documentServiceSpy.mockRestore();
+
+    const promotedDocs = await db
+      .select({
+        key: issueDocuments.key,
+      })
+      .from(issueDocuments)
+      .where(eq(issueDocuments.issueId, issueId));
+    expect(promotedDocs).toContainEqual({ key: "second-doc" });
+    expect(promotedDocs).not.toContainEqual({ key: "first-doc" });
+
+    const comments = await db
+      .select({
+        body: issueComments.body,
+      })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("Finished both deliverables.");
+  });
+
   it("blocks stranded in-progress work after the continuation retry was already used", async () => {
     const { issueId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   summarizeHeartbeatRunResultJson,
   buildHeartbeatRunIssueComment,
+  extractHeartbeatRunIssueDocumentPromotions,
   mergeHeartbeatRunResultJson,
 } from "../services/heartbeat-run-summary.js";
 
@@ -62,6 +63,51 @@ describe("buildHeartbeatRunIssueComment", () => {
 
   it("returns null when there is no usable final text", () => {
     expect(buildHeartbeatRunIssueComment({ costUsd: 1.2 })).toBeNull();
+  });
+});
+
+describe("extractHeartbeatRunIssueDocumentPromotions", () => {
+  it("extracts tagged issue documents from the final summary", () => {
+    const promotions = extractHeartbeatRunIssueDocumentPromotions({
+      summary: [
+        "## Summary",
+        "",
+        "<issue-document key=\"competitive-landscape\" title=\"Competitive Landscape\">",
+        "# Competitive Landscape",
+        "",
+        "- Acme",
+        "- Umbra",
+        "</issue-document>",
+      ].join("\n"),
+    });
+
+    expect(promotions).toEqual([{
+      key: "competitive-landscape",
+      title: "Competitive Landscape",
+      body: "# Competitive Landscape\n\n- Acme\n- Umbra",
+    }]);
+  });
+
+  it("falls back to a legacy Deliverable section", () => {
+    const promotions = extractHeartbeatRunIssueDocumentPromotions({
+      summary: [
+        "## Summary",
+        "",
+        "- Research complete",
+        "",
+        "## Deliverable: Market Map",
+        "",
+        "# Market Map",
+        "",
+        "- Segment A",
+      ].join("\n"),
+    });
+
+    expect(promotions).toEqual([{
+      key: "market-map",
+      title: "Market Map",
+      body: "# Market Map\n\n- Segment A",
+    }]);
   });
 });
 

--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -109,6 +109,28 @@ describe("extractHeartbeatRunIssueDocumentPromotions", () => {
       body: "# Market Map\n\n- Segment A",
     }]);
   });
+
+  it("keeps tagged issue documents when a legacy Deliverable section resolves to the same key", () => {
+    const promotions = extractHeartbeatRunIssueDocumentPromotions({
+      summary: [
+        "## Summary",
+        "",
+        "<issue-document title=\"Deliverable\">",
+        "Tagged body",
+        "</issue-document>",
+        "",
+        "## Deliverable",
+        "",
+        "Legacy body",
+      ].join("\n"),
+    });
+
+    expect(promotions).toEqual([{
+      key: "deliverable",
+      title: "Deliverable",
+      body: "Tagged body",
+    }]);
+  });
 });
 
 describe("mergeHeartbeatRunResultJson", () => {

--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -56,6 +56,24 @@ describe("buildHeartbeatRunIssueComment", () => {
     expect(comment).not.toContain("Run summary");
   });
 
+  it("strips tagged issue documents from the posted issue comment", () => {
+    const comment = buildHeartbeatRunIssueComment({
+      summary: [
+        "## Summary",
+        "",
+        "Finished both deliverables.",
+        "",
+        "<issue-document key=\"first-doc\" title=\"First Doc\">",
+        "Hidden promoted content",
+        "</issue-document>",
+      ].join("\n"),
+    });
+
+    expect(comment).toBe("## Summary\n\nFinished both deliverables.");
+    expect(comment).not.toContain("<issue-document");
+    expect(comment).not.toContain("Hidden promoted content");
+  });
+
   it("falls back to result or message when summary is missing", () => {
     expect(buildHeartbeatRunIssueComment({ result: "done" })).toBe("done");
     expect(buildHeartbeatRunIssueComment({ message: "completed" })).toBe("completed");

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -2,6 +2,12 @@ export const HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS = 500;
 export const HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS = 4_096;
 export const HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES = 64 * 1024;
 
+export interface HeartbeatRunIssueDocumentPromotion {
+  key: string;
+  title: string | null;
+  body: string;
+}
+
 function truncateSummaryText(value: unknown, maxLength = HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS) {
   if (typeof value !== "string") return null;
   return value.length > maxLength ? value.slice(0, maxLength) : value;
@@ -15,6 +21,67 @@ function readCommentText(value: unknown) {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function slugifyDocumentKey(value: string) {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "deliverable";
+}
+
+function normalizeDocumentTitle(value: string | null | undefined) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function dedupePromotions(
+  promotions: HeartbeatRunIssueDocumentPromotion[],
+): HeartbeatRunIssueDocumentPromotion[] {
+  const byKey = new Map<string, HeartbeatRunIssueDocumentPromotion>();
+  for (const promotion of promotions) {
+    byKey.set(promotion.key, promotion);
+  }
+  return [...byKey.values()];
+}
+
+function extractTaggedIssueDocuments(summary: string): HeartbeatRunIssueDocumentPromotion[] {
+  const matches = [...summary.matchAll(/<issue-document\b([^>]*)>([\s\S]*?)<\/issue-document>/gi)];
+  if (matches.length === 0) return [];
+
+  const promotions: HeartbeatRunIssueDocumentPromotion[] = [];
+  for (const match of matches) {
+    const attrs = match[1] ?? "";
+    const body = readCommentText(match[2]);
+    if (!body) continue;
+    const keyAttr = /(?:^|\s)key="([^"]+)"/i.exec(attrs)?.[1] ?? null;
+    const titleAttr = /(?:^|\s)title="([^"]+)"/i.exec(attrs)?.[1] ?? null;
+    const title = normalizeDocumentTitle(titleAttr);
+    const key = slugifyDocumentKey(keyAttr ?? title ?? "deliverable");
+    promotions.push({ key, title, body });
+  }
+  return promotions;
+}
+
+function extractLegacyDeliverableSection(summary: string): HeartbeatRunIssueDocumentPromotion[] {
+  const headingMatch = /^##\s+Deliverable(?:s)?(?:\s*[:\-]\s*(.+))?\s*$/im.exec(summary);
+  if (!headingMatch || headingMatch.index == null) return [];
+
+  const start = headingMatch.index + headingMatch[0].length;
+  const after = summary.slice(start);
+  const nextHeadingIndex = after.search(/\n##\s+/);
+  const body = readCommentText(nextHeadingIndex >= 0 ? after.slice(0, nextHeadingIndex) : after);
+  if (!body) return [];
+
+  const title = normalizeDocumentTitle(headingMatch[1] ?? null);
+  return [{
+    key: slugifyDocumentKey(title ?? "deliverable"),
+    title,
+    body,
+  }];
 }
 
 export function mergeHeartbeatRunResultJson(
@@ -105,4 +172,20 @@ export function buildHeartbeatRunIssueComment(
     ?? readCommentText(resultJson.message)
     ?? null
   );
+}
+
+export function extractHeartbeatRunIssueDocumentPromotions(
+  resultJson: Record<string, unknown> | null | undefined,
+): HeartbeatRunIssueDocumentPromotion[] {
+  if (!resultJson || typeof resultJson !== "object" || Array.isArray(resultJson)) {
+    return [];
+  }
+
+  const summary = readCommentText(resultJson.summary);
+  if (!summary) return [];
+
+  return dedupePromotions([
+    ...extractTaggedIssueDocuments(summary),
+    ...extractLegacyDeliverableSection(summary),
+  ]);
 }

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -86,6 +86,10 @@ function extractLegacyDeliverableSection(summary: string): HeartbeatRunIssueDocu
   }];
 }
 
+function stripTaggedIssueDocuments(summary: string) {
+  return summary.replace(/<issue-document\b[^>]*>[\s\S]*?<\/issue-document>/gi, "").trim();
+}
+
 export function mergeHeartbeatRunResultJson(
   resultJson: Record<string, unknown> | null | undefined,
   summary: string | null | undefined,
@@ -168,12 +172,17 @@ export function buildHeartbeatRunIssueComment(
     return null;
   }
 
-  return (
+  const comment =
     readCommentText(resultJson.summary)
     ?? readCommentText(resultJson.result)
     ?? readCommentText(resultJson.message)
-    ?? null
-  );
+    ?? null;
+
+  if (!comment) {
+    return null;
+  }
+
+  return readCommentText(stripTaggedIssueDocuments(comment));
 }
 
 export function extractHeartbeatRunIssueDocumentPromotions(

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -43,7 +43,9 @@ function dedupePromotions(
 ): HeartbeatRunIssueDocumentPromotion[] {
   const byKey = new Map<string, HeartbeatRunIssueDocumentPromotion>();
   for (const promotion of promotions) {
-    byKey.set(promotion.key, promotion);
+    if (!byKey.has(promotion.key)) {
+      byKey.set(promotion.key, promotion);
+    }
   }
   return [...byKey.values()];
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -55,6 +55,7 @@ import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import {
   buildHeartbeatRunIssueComment,
+  extractHeartbeatRunIssueDocumentPromotions,
   HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS,
   HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS,
   HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES,
@@ -88,6 +89,7 @@ import {
 } from "./workspace-runtime.js";
 import { issueService } from "./issues.js";
 import { agentThreadService } from "./agent-threads.js";
+import { documentService } from "./documents.js";
 import { workProductService } from "./work-products.js";
 import { recordRunStatus } from "../otel.js";
 import {
@@ -2007,6 +2009,7 @@ export function heartbeatService(db: Db) {
   const secretsSvc = secretService(db);
   const companySkills = companySkillService(db);
   const issuesSvc = issueService(db);
+  const documentsSvc = documentService(db);
   const workProductsSvc = workProductService(db);
   const agentThreadsSvc = agentThreadService(db);
   const executionWorkspacesSvc = executionWorkspaceService(db);
@@ -6533,6 +6536,38 @@ export function heartbeatService(db: Db) {
         await refreshContinuationSummaryForRun(livenessRun, agent);
         if (issueId && outcome === "succeeded") {
           try {
+            for (const promotion of extractHeartbeatRunIssueDocumentPromotions(persistedResultJson)) {
+              const existingDocument = await documentsSvc.getIssueDocumentByKey(issueId, promotion.key);
+              const result = await documentsSvc.upsertIssueDocument({
+                issueId,
+                key: promotion.key,
+                title: promotion.title,
+                format: "markdown",
+                body: promotion.body,
+                changeSummary: "Promoted from heartbeat run summary",
+                baseRevisionId: existingDocument?.latestRevisionId ?? null,
+                createdByAgentId: agent.id,
+                createdByRunId: livenessRun.id,
+              });
+              await logActivity(db, {
+                companyId: livenessRun.companyId,
+                actorType: "agent",
+                actorId: agent.id,
+                agentId: agent.id,
+                runId: livenessRun.id,
+                action: result.created ? "issue.document_created" : "issue.document_updated",
+                entityType: "issue",
+                entityId: issueId,
+                details: {
+                  key: result.document.key,
+                  documentId: result.document.id,
+                  title: result.document.title,
+                  format: result.document.format,
+                  revisionNumber: result.document.latestRevisionNumber,
+                  source: "heartbeat_run_summary_promotion",
+                },
+              });
+            }
             const existingRunComment = await findRunIssueComment(livenessRun.id, livenessRun.companyId, issueId);
             if (!existingRunComment) {
               const issueComment = buildHeartbeatRunIssueComment(persistedResultJson);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6535,8 +6535,8 @@ export function heartbeatService(db: Db) {
         const livenessRun = finalizedRun;
         await refreshContinuationSummaryForRun(livenessRun, agent);
         if (issueId && outcome === "succeeded") {
-          try {
-            for (const promotion of extractHeartbeatRunIssueDocumentPromotions(persistedResultJson)) {
+          for (const promotion of extractHeartbeatRunIssueDocumentPromotions(persistedResultJson)) {
+            try {
               const existingDocument = await documentsSvc.getIssueDocumentByKey(issueId, promotion.key);
               const result = await documentsSvc.upsertIssueDocument({
                 issueId,
@@ -6567,7 +6567,14 @@ export function heartbeatService(db: Db) {
                   source: "heartbeat_run_summary_promotion",
                 },
               });
+            } catch (err) {
+              await onLog(
+                "stderr",
+                `[paperclip] Failed to promote heartbeat run summary document "${promotion.key}": ${err instanceof Error ? err.message : String(err)}\n`,
+              );
             }
+          }
+          try {
             const existingRunComment = await findRunIssueComment(livenessRun.id, livenessRun.companyId, issueId);
             if (!existingRunComment) {
               const issueComment = buildHeartbeatRunIssueComment(persistedResultJson);


### PR DESCRIPTION
This pull request introduces a new mechanism to promote durable text deliverables from heartbeat run summaries into issue documents, enhancing the workflow for handling structured deliverables. It adds a system for extracting both explicitly tagged documents and legacy deliverable sections from summary text, and ensures these are upserted as documents linked to issues. The changes also include comprehensive tests for the extraction logic.

**Promotion of Durable Deliverables from Heartbeat Summaries:**

* Added support in the agent prompt template for wrapping deliverables in `<issue-document>` tags, enabling structured extraction and promotion of these sections into issue documents.
* Implemented `extractHeartbeatRunIssueDocumentPromotions` and supporting helpers in `heartbeat-run-summary.ts` to extract both tagged and legacy deliverable sections from summary text, returning them as normalized promotion objects. [[1]](diffhunk://#diff-fc471192b6f2da8e297c05b0291ce3c5bf92fe99cfde6c7e1e9e958a5b94c09bR5-R10) [[2]](diffhunk://#diff-fc471192b6f2da8e297c05b0291ce3c5bf92fe99cfde6c7e1e9e958a5b94c09bR26-R86) [[3]](diffhunk://#diff-fc471192b6f2da8e297c05b0291ce3c5bf92fe99cfde6c7e1e9e958a5b94c09bR176-R191)
* Updated the heartbeat service to, upon successful run completion, extract and upsert promoted documents for the relevant issue, logging creation or update activities. [[1]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R2012) [[2]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R6539-R6570) [[3]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R58) [[4]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R92)

**Testing and Validation:**

* Added comprehensive tests for the document promotion extraction logic, covering both tagged and legacy deliverable formats. [[1]](diffhunk://#diff-95fb6a68862f921f3382db38062b895738fdef8b52ed22d66b9b7900ee2a2d04R5) [[2]](diffhunk://#diff-95fb6a68862f921f3382db38062b895738fdef8b52ed22d66b9b7900ee2a2d04R69-R113)