### PR TITLE
feat: add audience support for deliverables and issue documents

### DIFF
--- a/packages/db/src/migrations/0072_deliverable_audience.sql
+++ b/packages/db/src/migrations/0072_deliverable_audience.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "issue_work_products"
+ADD COLUMN "audience" text NOT NULL DEFAULT 'human';--> statement-breakpoint
+
+ALTER TABLE "issue_documents"
+ADD COLUMN "audience" text NOT NULL DEFAULT 'human';--> statement-breakpoint
+
+UPDATE "issue_documents"
+SET "audience" = 'internal'
+WHERE "key" IN ('plan', 'continuation-summary');--> statement-breakpoint

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1778209428904,
       "tag": "0071_issues_open_routine_execution_awaiting_human",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1778679360000,
+      "tag": "0072_deliverable_audience",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issue_documents.ts
+++ b/packages/db/src/schema/issue_documents.ts
@@ -11,6 +11,7 @@ export const issueDocuments = pgTable(
     issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
     documentId: uuid("document_id").notNull().references(() => documents.id, { onDelete: "cascade" }),
     key: text("key").notNull(),
+    audience: text("audience").notNull().default("human"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/db/src/schema/issue_work_products.ts
+++ b/packages/db/src/schema/issue_work_products.ts
@@ -34,6 +34,7 @@ export const issueWorkProducts = pgTable(
     url: text("url"),
     status: text("status").notNull(),
     reviewState: text("review_state").notNull().default("none"),
+    audience: text("audience").notNull().default("human"),
     isPrimary: boolean("is_primary").notNull().default(false),
     healthStatus: text("health_status").notNull().default("unknown"),
     summary: text("summary"),

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -776,6 +776,7 @@ export interface WorkerToHostMethods {
       title?: string;
       format?: string;
       changeSummary?: string;
+      audience?: "human" | "internal";
     },
     result: IssueDocument,
   ];

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -620,6 +620,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
             companyId: input.companyId,
             issueId: input.issueId,
             key: input.key,
+            audience: existing?.audience ?? input.audience ?? "human",
             title: input.title ?? existing?.title ?? null,
             format: "markdown",
             latestRevisionId: randomUUID(),

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -888,6 +888,7 @@ export interface PluginIssueDocumentsClient {
     title?: string;
     format?: string;
     changeSummary?: string;
+    audience?: "human" | "internal";
   }): Promise<IssueDocument>;
 
   /**

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -775,6 +775,7 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
               title: input.title,
               format: input.format,
               changeSummary: input.changeSummary,
+              audience: input.audience,
             });
           },
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -221,6 +221,7 @@ export function getDefaultIssueDocumentAudience(key: string): DeliverableAudienc
     ? "internal"
     : "human";
 }
+
 export const ISSUE_REFERENCE_SOURCE_KINDS = ["title", "description", "comment", "document"] as const;
 export type IssueReferenceSourceKind = (typeof ISSUE_REFERENCE_SOURCE_KINDS)[number];
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -207,10 +207,19 @@ export const ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY = "continuation-summary" as
 export const SYSTEM_ISSUE_DOCUMENT_KEYS = [ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY] as const;
 export type SystemIssueDocumentKey = (typeof SYSTEM_ISSUE_DOCUMENT_KEYS)[number];
 
+export const DELIVERABLE_AUDIENCES = ["human", "internal"] as const;
+export type DeliverableAudience = (typeof DELIVERABLE_AUDIENCES)[number];
+
 const SYSTEM_ISSUE_DOCUMENT_KEY_SET = new Set<string>(SYSTEM_ISSUE_DOCUMENT_KEYS);
 
 export function isSystemIssueDocumentKey(key: string): key is SystemIssueDocumentKey {
   return SYSTEM_ISSUE_DOCUMENT_KEY_SET.has(key);
+}
+
+export function getDefaultIssueDocumentAudience(key: string): DeliverableAudience {
+  return key.trim().toLowerCase() === "plan" || isSystemIssueDocumentKey(key.trim().toLowerCase())
+    ? "internal"
+    : "human";
 }
 export const ISSUE_REFERENCE_SOURCE_KINDS = ["title", "description", "comment", "document"] as const;
 export type IssueReferenceSourceKind = (typeof ISSUE_REFERENCE_SOURCE_KINDS)[number];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -27,7 +27,9 @@ export {
   ISSUE_RELATION_TYPES,
   ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
   SYSTEM_ISSUE_DOCUMENT_KEYS,
+  DELIVERABLE_AUDIENCES,
   isSystemIssueDocumentKey,
+  getDefaultIssueDocumentAudience,
   ISSUE_REFERENCE_SOURCE_KINDS,
   ISSUE_EXECUTION_POLICY_MODES,
   ISSUE_EXECUTION_STAGE_TYPES,
@@ -129,6 +131,7 @@ export {
   type IssueOriginKind,
   type IssueRelationType,
   type SystemIssueDocumentKey,
+  type DeliverableAudience,
   type IssueReferenceSourceKind,
   type IssueExecutionPolicyMode,
   type IssueExecutionStageType,
@@ -501,6 +504,7 @@ export type {
   DeliverableDetail,
   DeliverableIssueRef,
   DeliverableListItem,
+  DeliverablePreview,
 } from "./types/index.js";
 export {
   isIssueArtifactWorkProductMetadata,

--- a/packages/shared/src/types/deliverable.ts
+++ b/packages/shared/src/types/deliverable.ts
@@ -1,3 +1,5 @@
+import type { DeliverableAudience } from "../constants.js";
+
 /**
  * Cross-issue deliverable view: a rolled-up presentation of an
  * `issue_work_products` row with `type = "artifact"`. These are downloadable
@@ -24,6 +26,12 @@ export interface DeliverableAgentRef {
   icon: string | null;
 }
 
+export interface DeliverablePreview {
+  kind: "markdown" | "text";
+  body: string;
+  truncated: boolean;
+}
+
 export interface DeliverableListItem {
   /** issue_work_products.id */
   id: string;
@@ -31,6 +39,7 @@ export interface DeliverableListItem {
   projectId: string | null;
   title: string;
   summary: string | null;
+  audience: DeliverableAudience;
   createdAt: string;
   updatedAt: string;
 
@@ -53,6 +62,7 @@ export interface DeliverableListItem {
 }
 
 export interface DeliverableDetail extends DeliverableListItem {
+  preview: DeliverablePreview | null;
   /**
    * Full ancestor chain from the immediate parent of `childIssue` up to the
    * root. Empty when the child issue has no parent. Order: nearest parent

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -118,6 +118,7 @@ export type {
   DeliverableDetail,
   DeliverableIssueRef,
   DeliverableListItem,
+  DeliverablePreview,
 } from "./deliverable.js";
 export type {
   Issue,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -1,4 +1,5 @@
 import type {
+  DeliverableAudience,
   IssueExecutionDecisionOutcome,
   IssueExecutionPolicyMode,
   IssueReferenceSourceKind,
@@ -70,6 +71,7 @@ export interface IssueDocumentSummary {
   companyId: string;
   issueId: string;
   key: string;
+  audience: DeliverableAudience;
   title: string | null;
   format: DocumentFormat;
   latestRevisionId: string | null;

--- a/packages/shared/src/types/work-product.test.ts
+++ b/packages/shared/src/types/work-product.test.ts
@@ -32,4 +32,18 @@ describe("issue artifact work product metadata types", () => {
       byteSize: 0,
     });
   });
+
+  it("drops redundant audience values from stored artifact metadata", () => {
+    expect(parseIssueArtifactWorkProductMetadata({
+      type: "artifact",
+      metadata: {
+        ...baseMetadata,
+        byteSize: 12,
+        audience: "internal",
+      },
+    })).toEqual({
+      ...baseMetadata,
+      byteSize: 12,
+    });
+  });
 });

--- a/packages/shared/src/types/work-product.ts
+++ b/packages/shared/src/types/work-product.ts
@@ -1,5 +1,3 @@
-import type { DeliverableAudience } from "../constants.js";
-
 export type IssueWorkProductType =
   | "preview_url"
   | "runtime_service"
@@ -40,7 +38,6 @@ export interface IssueArtifactWorkProductMetadata {
   contentType: string;
   byteSize: number;
   originalFilename: string | null;
-  audience?: DeliverableAudience;
 }
 
 export interface IssueWorkProduct {
@@ -145,6 +142,20 @@ export function parseIssueArtifactWorkProductMetadata(
 
   const originalFilename =
     typeof metadata.originalFilename === "string" ? metadata.originalFilename : null;
+  const {
+    attachmentId,
+    contentPath,
+    sourcePath,
+    contentType,
+    byteSize,
+  } = metadata;
 
-  return { ...(metadata as IssueArtifactWorkProductMetadata), originalFilename };
+  return {
+    attachmentId: attachmentId as string,
+    contentPath: contentPath as string,
+    sourcePath: sourcePath as string,
+    contentType: contentType as string,
+    byteSize: byteSize as number,
+    originalFilename,
+  };
 }

--- a/packages/shared/src/types/work-product.ts
+++ b/packages/shared/src/types/work-product.ts
@@ -1,3 +1,5 @@
+import type { DeliverableAudience } from "../constants.js";
+
 export type IssueWorkProductType =
   | "preview_url"
   | "runtime_service"

--- a/packages/shared/src/types/work-product.ts
+++ b/packages/shared/src/types/work-product.ts
@@ -1,3 +1,5 @@
+import type { DeliverableAudience } from "../constants.js";
+
 export type IssueWorkProductType =
   | "preview_url"
   | "runtime_service"
@@ -38,6 +40,7 @@ export interface IssueArtifactWorkProductMetadata {
   contentType: string;
   byteSize: number;
   originalFilename: string | null;
+  audience?: DeliverableAudience;
 }
 
 export interface IssueWorkProduct {
@@ -54,6 +57,7 @@ export interface IssueWorkProduct {
   url: string | null;
   status: IssueWorkProductStatus | string;
   reviewState: IssueWorkProductReviewState;
+  audience: DeliverableAudience;
   isPrimary: boolean;
   healthStatus: "unknown" | "healthy" | "unhealthy";
   summary: string | null;

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DELIVERABLE_AUDIENCES } from "../constants.js";
 import {
   ISSUE_EXECUTION_DECISION_OUTCOMES,
   ISSUE_EXECUTION_POLICY_MODES,
@@ -458,6 +459,7 @@ export const upsertIssueDocumentSchema = z.object({
   body: z.string().max(524288),
   changeSummary: z.string().trim().max(500).nullable().optional(),
   baseRevisionId: z.string().uuid().nullable().optional(),
+  audience: z.enum(DELIVERABLE_AUDIENCES).nullable().optional(),
 });
 
 export const restoreIssueDocumentRevisionSchema = z.object({});

--- a/packages/shared/src/validators/work-product.test.ts
+++ b/packages/shared/src/validators/work-product.test.ts
@@ -110,8 +110,10 @@ describe("work product validators", () => {
     const sanitized = sanitizeStoredIssueArtifactWorkProductMetadata({
       ...validArtifactMetadata,
       contentBase64: "IyBGaW5hbCBwYWNrZXQK",
+      audience: "internal",
     });
 
+    expect(sanitized).toEqual(validArtifactMetadata);
     expect(getIssueArtifactWorkProductValidationIssues({
       type: "artifact",
       url: validArtifactMetadata.contentPath,

--- a/packages/shared/src/validators/work-product.ts
+++ b/packages/shared/src/validators/work-product.ts
@@ -51,7 +51,6 @@ const issueArtifactWorkProductMetadataFieldsSchema = z.object({
   contentType: z.string().trim().min(1),
   byteSize: z.number().int().positive(),
   originalFilename: z.string().trim().min(1).nullable().optional().transform((v) => v ?? null),
-  audience: z.enum(DELIVERABLE_AUDIENCES).optional(),
 });
 
 const issueArtifactWorkProductStoredMetadataFieldsSchema = issueArtifactWorkProductMetadataFieldsSchema.extend({

--- a/packages/shared/src/validators/work-product.ts
+++ b/packages/shared/src/validators/work-product.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DELIVERABLE_AUDIENCES } from "../constants.js";
 
 export const issueWorkProductTypeSchema = z.enum([
   "preview_url",
@@ -50,6 +51,7 @@ const issueArtifactWorkProductMetadataFieldsSchema = z.object({
   contentType: z.string().trim().min(1),
   byteSize: z.number().int().positive(),
   originalFilename: z.string().trim().min(1).nullable().optional().transform((v) => v ?? null),
+  audience: z.enum(DELIVERABLE_AUDIENCES).optional(),
 });
 
 const issueArtifactWorkProductStoredMetadataFieldsSchema = issueArtifactWorkProductMetadataFieldsSchema.extend({
@@ -163,6 +165,7 @@ const issueWorkProductBaseSchema = z.object({
   url: issueWorkProductUrlSchema.optional().nullable(),
   status: issueWorkProductStatusSchema.default("active"),
   reviewState: issueWorkProductReviewStateSchema.optional().default("none"),
+  audience: z.enum(DELIVERABLE_AUDIENCES).optional().default("human"),
   isPrimary: z.boolean().optional().default(false),
   healthStatus: z.enum(["unknown", "healthy", "unhealthy"]).optional().default("unknown"),
   summary: z.string().optional().nullable(),

--- a/server/src/__tests__/documents-service.test.ts
+++ b/server/src/__tests__/documents-service.test.ts
@@ -116,4 +116,33 @@ describeEmbeddedPostgres("documentService system issue documents", () => {
       body: "# Handoff",
     }));
   });
+
+  it("preserves an existing audience when updating without an explicit audience override", async () => {
+    const { issueId } = await createIssueWithDocuments();
+    const existing = await svc.getIssueDocumentByKey(issueId, "plan");
+    const updatedToHuman = await svc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      title: "Plan for humans",
+      format: "markdown",
+      body: "# Human plan",
+      baseRevisionId: existing?.latestRevisionId ?? null,
+      audience: "human",
+    });
+
+    const updated = await svc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      title: "Plan for humans v2",
+      format: "markdown",
+      body: "# Human plan v2",
+      baseRevisionId: updatedToHuman.document.latestRevisionId,
+    });
+
+    expect(updated.created).toBe(false);
+    expect(updated.document.audience).toBe("human");
+
+    const stored = await svc.getIssueDocumentByKey(issueId, "plan");
+    expect(stored?.audience).toBe("human");
+  });
 });

--- a/server/src/__tests__/documents-service.test.ts
+++ b/server/src/__tests__/documents-service.test.ts
@@ -32,6 +32,10 @@ describeEmbeddedPostgres("documentService system issue documents", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-documents-service-");
     db = createDb(tempDb.connectionString);
+    await db.execute(`
+      alter table issue_documents
+      add column if not exists audience text not null default 'human'
+    `);
     svc = documentService(db);
   }, 20_000);
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1523,21 +1523,27 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     documentServiceSpy.mockRestore();
 
-    const promotedDocs = await db
-      .select({
-        key: issueDocuments.key,
-      })
-      .from(issueDocuments)
-      .where(eq(issueDocuments.issueId, issueId));
+    const promotedDocs = await waitForValue(async () => {
+      const rows = await db
+        .select({
+          key: issueDocuments.key,
+        })
+        .from(issueDocuments)
+        .where(eq(issueDocuments.issueId, issueId));
+      return rows.some((row) => row.key === "second-doc") ? rows : null;
+    }, 5_000);
     expect(promotedDocs).toContainEqual({ key: "second-doc" });
     expect(promotedDocs).not.toContainEqual({ key: "first-doc" });
 
-    const comments = await db
-      .select({
-        body: issueComments.body,
-      })
-      .from(issueComments)
-      .where(eq(issueComments.issueId, issueId));
+    const comments = await waitForValue(async () => {
+      const rows = await db
+        .select({
+          body: issueComments.body,
+        })
+        .from(issueComments)
+        .where(eq(issueComments.issueId, issueId));
+      return rows.length > 0 ? rows : null;
+    }, 5_000);
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("Finished both deliverables.");
     expect(comments[0]?.body).not.toContain("<issue-document");

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -416,6 +416,18 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockDocumentService.upsertIssueDocument).toHaveBeenCalled();
   });
 
+  it("rejects invalid document audiences before calling the document service", async () => {
+    const app = await createApp(boardActor());
+
+    const res = await request(app)
+      .put(`/api/issues/${issueId}/documents/plan`)
+      .send({ format: "markdown", body: "# board", audience: "admin" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Validation error");
+    expect(mockDocumentService.upsertIssueDocument).not.toHaveBeenCalled();
+  });
+
   it("allows agents with the active-checkout management grant to mutate active checkouts", async () => {
     mockAccessService.hasPermission.mockImplementation(async (
       _companyId: string,

--- a/server/src/__tests__/work-products.test.ts
+++ b/server/src/__tests__/work-products.test.ts
@@ -220,4 +220,27 @@ describe("workProductService", () => {
     expect(items[0]?.byteSize).toBe(15);
     expect(items[0]?.originalFilename).toBe("company-requirements.md");
   });
+
+  it("truncates inline document previews by UTF-8 byte length", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        createDeliverableQueryRow({
+          deliverable_source: "document",
+          metadata: null,
+          document_key: "plan",
+          document_format: "markdown",
+          document_body: `${"a".repeat((64 * 1024) - 1)}🙂`,
+          document_byte_size: (64 * 1024) + 3,
+        }),
+      ])
+      .mockResolvedValueOnce([]);
+
+    const svc = workProductService({ execute } as any);
+    const deliverable = await svc.getDeliverableById("deliverable-1");
+
+    expect(deliverable?.preview?.truncated).toBe(true);
+    expect(deliverable?.preview?.body.endsWith("🙂")).toBe(false);
+    expect(Buffer.byteLength(deliverable?.preview?.body ?? "", "utf8")).toBeLessThanOrEqual(64 * 1024);
+  });
 });

--- a/server/src/__tests__/work-products.test.ts
+++ b/server/src/__tests__/work-products.test.ts
@@ -1,4 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+const mockGetObject = vi.hoisted(() => vi.fn());
+
+vi.mock("../storage/index.js", () => ({
+  getStorageService: () => ({
+    getObject: mockGetObject,
+  }),
+}));
+
 import { escapeLikePattern, workProductService } from "../services/work-products.ts";
 
 function createWorkProductRow(overrides: Partial<Record<string, unknown>> = {}) {
@@ -242,5 +250,38 @@ describe("workProductService", () => {
     expect(deliverable?.preview?.truncated).toBe(true);
     expect(deliverable?.preview?.body.endsWith("🙂")).toBe(false);
     expect(Buffer.byteLength(deliverable?.preview?.body ?? "", "utf8")).toBeLessThanOrEqual(64 * 1024);
+  });
+
+  it("returns the deliverable when artifact preview loading fails", async () => {
+    mockGetObject.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        createDeliverableQueryRow({
+          metadata: {
+            attachmentId: "attachment-1",
+            contentPath: "/api/attachments/attachment-1/content",
+            sourcePath: "deliverables/final-report.md",
+            contentType: "text/markdown; charset=utf-8",
+            byteSize: 32,
+            originalFilename: "final-report.md",
+          },
+        }),
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          company_id: "company-1",
+          object_key: "assets/final-report.md",
+        },
+      ]);
+
+    const svc = workProductService({ execute } as any);
+    const deliverable = await svc.getDeliverableById("deliverable-1");
+
+    expect(deliverable?.id).toBe("deliverable-1");
+    expect(deliverable?.preview).toBeNull();
+    expect(mockGetObject).toHaveBeenCalledWith("company-1", "assets/final-report.md");
   });
 });

--- a/server/src/routes/deliverables.ts
+++ b/server/src/routes/deliverables.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import type { Db } from "@paperclipai/db";
+import { DELIVERABLE_AUDIENCES, type DeliverableAudience } from "@paperclipai/shared";
 import { workProductService, clampDeliverableLimit } from "../services/index.js";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
 
@@ -29,6 +30,9 @@ export function deliverableRoutes(db: Db) {
     const q = typeof req.query.q === "string" && req.query.q.trim().length > 0
       ? req.query.q.trim()
       : undefined;
+    const audience = typeof req.query.audience === "string" && DELIVERABLE_AUDIENCES.includes(req.query.audience as DeliverableAudience)
+      ? req.query.audience as DeliverableAudience
+      : undefined;
 
     const items = await workProductsSvc.listDeliverablesForCompany(companyId, {
       limit,
@@ -36,6 +40,7 @@ export function deliverableRoutes(db: Db) {
       projectId,
       agentId,
       q,
+      audience,
     });
     res.json({ items, limit, offset });
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1078,6 +1078,7 @@ export function issueRoutes(
       body: req.body.body,
       changeSummary: req.body.changeSummary ?? null,
       baseRevisionId: req.body.baseRevisionId ?? null,
+      audience: req.body.audience ?? null,
       createdByAgentId: actor.agentId ?? null,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
       createdByRunId: actor.runId ?? null,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -34,6 +34,7 @@ import {
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
   type ExecutionWorkspace,
+  type UpsertIssueDocument,
 } from "@paperclipai/shared";
 import { trackAgentTaskCompleted } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
@@ -1067,18 +1068,19 @@ export function issueRoutes(
       res.status(400).json({ error: "Invalid document key", details: keyParsed.error.issues });
       return;
     }
+    const body = upsertIssueDocumentSchema.parse(req.body) as UpsertIssueDocument;
 
     const actor = getActorInfo(req);
     const referenceSummaryBefore = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
     const result = await documentsSvc.upsertIssueDocument({
       issueId: issue.id,
       key: keyParsed.data,
-      title: req.body.title ?? null,
-      format: req.body.format,
-      body: req.body.body,
-      changeSummary: req.body.changeSummary ?? null,
-      baseRevisionId: req.body.baseRevisionId ?? null,
-      audience: req.body.audience ?? null,
+      title: body.title ?? null,
+      format: body.format,
+      body: body.body,
+      changeSummary: body.changeSummary ?? null,
+      baseRevisionId: body.baseRevisionId ?? null,
+      audience: body.audience ?? null,
       createdByAgentId: actor.agentId ?? null,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
       createdByRunId: actor.runId ?? null,

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -1,7 +1,12 @@
 import { and, asc, desc, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { documentRevisions, documents, issueDocuments, issues } from "@paperclipai/db";
-import { isSystemIssueDocumentKey, issueDocumentKeySchema } from "@paperclipai/shared";
+import {
+  getDefaultIssueDocumentAudience,
+  isSystemIssueDocumentKey,
+  issueDocumentKeySchema,
+  type DeliverableAudience,
+} from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 
 function normalizeDocumentKey(key: string) {
@@ -31,6 +36,7 @@ function mapIssueDocumentRow(
     companyId: string;
     issueId: string;
     key: string;
+    audience: string;
     title: string | null;
     format: string;
     latestBody: string;
@@ -50,6 +56,7 @@ function mapIssueDocumentRow(
     companyId: row.companyId,
     issueId: row.issueId,
     key: row.key,
+    audience: row.audience as DeliverableAudience,
     title: row.title,
     format: row.format,
     ...(includeBody ? { body: row.latestBody } : {}),
@@ -69,6 +76,7 @@ const issueDocumentSelect = {
   companyId: documents.companyId,
   issueId: issueDocuments.issueId,
   key: issueDocuments.key,
+  audience: issueDocuments.audience,
   title: documents.title,
   format: documents.format,
   latestBody: documents.latestBody,
@@ -176,11 +184,13 @@ export function documentService(db: Db) {
       body: string;
       changeSummary?: string | null;
       baseRevisionId?: string | null;
+      audience?: DeliverableAudience | null;
       createdByAgentId?: string | null;
       createdByUserId?: string | null;
       createdByRunId?: string | null;
     }) => {
       const key = normalizeDocumentKey(input.key);
+      const audience = input.audience ?? getDefaultIssueDocumentAudience(key);
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)
@@ -260,7 +270,7 @@ export function documentService(db: Db) {
 
             await tx
               .update(issueDocuments)
-              .set({ updatedAt: now })
+              .set({ audience, updatedAt: now })
               .where(eq(issueDocuments.documentId, existing.id));
 
             return {
@@ -270,6 +280,7 @@ export function documentService(db: Db) {
                 title: input.title ?? null,
                 format: input.format,
                 body: input.body,
+                audience,
                 latestRevisionId: revision.id,
                 latestRevisionNumber: nextRevisionNumber,
                 updatedByAgentId: input.createdByAgentId ?? null,
@@ -328,6 +339,7 @@ export function documentService(db: Db) {
             issueId: issue.id,
             documentId: document.id,
             key,
+            audience,
             createdAt: now,
             updatedAt: now,
           });
@@ -339,6 +351,7 @@ export function documentService(db: Db) {
               companyId: issue.companyId,
               issueId: issue.id,
               key,
+              audience,
               title: document.title,
               format: document.format,
               body: document.latestBody,

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -190,7 +190,6 @@ export function documentService(db: Db) {
       createdByRunId?: string | null;
     }) => {
       const key = normalizeDocumentKey(input.key);
-      const audience = input.audience ?? getDefaultIssueDocumentAudience(key);
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)
@@ -207,6 +206,7 @@ export function documentService(db: Db) {
               companyId: documents.companyId,
               issueId: issueDocuments.issueId,
               key: issueDocuments.key,
+              audience: issueDocuments.audience,
               title: documents.title,
               format: documents.format,
               latestBody: documents.latestBody,
@@ -235,6 +235,8 @@ export function documentService(db: Db) {
                 currentRevisionId: existing.latestRevisionId,
               });
             }
+            const audience =
+              input.audience ?? (existing.audience as DeliverableAudience | null) ?? getDefaultIssueDocumentAudience(key);
 
             const nextRevisionNumber = existing.latestRevisionNumber + 1;
             const [revision] = await tx
@@ -293,6 +295,7 @@ export function documentService(db: Db) {
           if (input.baseRevisionId) {
             throw conflict("Document does not exist yet", { key });
           }
+          const audience = input.audience ?? getDefaultIssueDocumentAudience(key);
 
           const [document] = await tx
             .insert(documents)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3934,6 +3934,7 @@ export function heartbeatService(db: Db) {
         url: metadata.contentPath,
         status: "ready_for_review",
         reviewState: "none",
+        audience: "human",
         isPrimary: index === primaryIndex,
         healthStatus: "healthy",
         summary: artifact.summary ?? null,
@@ -6546,6 +6547,7 @@ export function heartbeatService(db: Db) {
                 body: promotion.body,
                 changeSummary: "Promoted from heartbeat run summary",
                 baseRevisionId: existingDocument?.latestRevisionId ?? null,
+                audience: "internal",
                 createdByAgentId: agent.id,
                 createdByRunId: livenessRun.id,
               });

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -1560,6 +1560,7 @@ export function buildHostServices(
           title: params.title ?? null,
           format: params.format ?? "markdown",
           changeSummary: params.changeSummary ?? null,
+          audience: params.audience ?? null,
         });
         await logPluginActivity({
           companyId,

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -783,9 +783,13 @@ async function loadArtifactPreview(db: Db, row: DeliverableQueryRow): Promise<De
   const attachment = toRowArray<{ company_id: string; object_key: string }>(rows)[0];
   if (!attachment) return null;
 
-  const object = await getStorageService().getObject(attachment.company_id, attachment.object_key);
-  const body = (await readStreamToBuffer(object.stream)).toString("utf8");
-  return buildPreviewFromBody(metadata.contentType, body, metadata.byteSize);
+  try {
+    const object = await getStorageService().getObject(attachment.company_id, attachment.object_key);
+    const body = (await readStreamToBuffer(object.stream)).toString("utf8");
+    return buildPreviewFromBody(metadata.contentType, body, metadata.byteSize);
+  } catch {
+    return null;
+  }
 }
 
 async function loadAncestorChain(db: Db, startIssueId: string): Promise<DeliverableIssueRef[]> {

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -655,11 +655,23 @@ function canInlinePreview(contentType: string): boolean {
   return DELIVERABLE_PREVIEW_TYPES.has(normalizeContentType(contentType));
 }
 
+function truncateUtf8ByBytes(value: string, maxBytes: number): string {
+  let byteLength = 0;
+  let truncated = "";
+  for (const char of value) {
+    const nextByteLength = Buffer.byteLength(char, "utf8");
+    if (byteLength + nextByteLength > maxBytes) break;
+    truncated += char;
+    byteLength += nextByteLength;
+  }
+  return truncated;
+}
+
 function buildPreviewFromBody(contentType: string, body: string, byteSize: number): DeliverablePreview | null {
   if (!canInlinePreview(contentType)) return null;
   const truncated = byteSize > DELIVERABLE_PREVIEW_MAX_BYTES;
   const safeBody = truncated
-    ? body.slice(0, DELIVERABLE_PREVIEW_MAX_BYTES)
+    ? truncateUtf8ByBytes(body, DELIVERABLE_PREVIEW_MAX_BYTES)
     : body;
   return {
     kind: normalizeContentType(contentType) === "text/markdown" ? "markdown" : "text",

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -1,15 +1,19 @@
+import { Readable } from "node:stream";
 import { and, desc, eq, sql, type SQL } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { documents, documentRevisions, issueDocuments, issueWorkProducts, issues } from "@paperclipai/db";
+import { documents, issueDocuments, issueWorkProducts } from "@paperclipai/db";
 import {
   ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
   type DeliverableDetail,
   type DeliverableIssueRef,
   type DeliverableListItem,
+  type DeliverablePreview,
+  type DeliverableAudience,
   type IssueWorkProduct,
   parseIssueArtifactWorkProductMetadata,
   deriveAgentUrlKey,
 } from "@paperclipai/shared";
+import { getStorageService } from "../storage/index.js";
 
 type IssueWorkProductRow = typeof issueWorkProducts.$inferSelect;
 
@@ -28,6 +32,7 @@ function toIssueWorkProduct(row: IssueWorkProductRow): IssueWorkProduct {
     url: row.url ?? null,
     status: row.status,
     reviewState: row.reviewState as IssueWorkProduct["reviewState"],
+    audience: (row.audience as DeliverableAudience | null) ?? "human",
     isPrimary: row.isPrimary,
     healthStatus: row.healthStatus as IssueWorkProduct["healthStatus"],
     summary: row.summary ?? null,
@@ -113,6 +118,7 @@ export function workProductService(db: Db) {
               status: data.status,
               healthStatus: data.healthStatus ?? "healthy",
               reviewState: data.reviewState ?? "none",
+              audience: data.audience ?? "human",
               summary: data.summary ?? null,
               metadata: data.metadata,
               isPrimary: data.isPrimary,
@@ -218,6 +224,10 @@ export function workProductService(db: Db) {
         artifactFilters.push(sql`wp.title ILIKE ${like} ESCAPE '\\'`);
         documentFilters.push(sql`COALESCE(d.title, idoc.key) ILIKE ${like} ESCAPE '\\'`);
       }
+      if (opts.audience) {
+        artifactFilters.push(sql`wp.audience = ${opts.audience}`);
+        documentFilters.push(sql`idoc.audience = ${opts.audience}`);
+      }
       const artifactWhere = artifactFilters.length > 0 ? sql` AND ${sql.join(artifactFilters, sql` AND `)}` : sql``;
       const documentWhere = documentFilters.length > 0 ? sql` AND ${sql.join(documentFilters, sql` AND `)}` : sql``;
 
@@ -266,6 +276,7 @@ export function workProductService(db: Db) {
             wp.is_primary,
             wp.health_status,
             wp.summary,
+            wp.audience,
             wp.metadata,
             wp.created_by_run_id,
             wp.execution_workspace_id,
@@ -314,6 +325,7 @@ export function workProductService(db: Db) {
             true AS is_primary,
             'healthy'::text AS health_status,
             NULL::text AS summary,
+            idoc.audience,
             NULL::jsonb AS metadata,
             dr.created_by_run_id,
             NULL::uuid AS execution_workspace_id,
@@ -405,6 +417,7 @@ export function workProductService(db: Db) {
             wp.is_primary,
             wp.health_status,
             wp.summary,
+            wp.audience,
             wp.metadata,
             wp.created_by_run_id,
             wp.execution_workspace_id,
@@ -414,6 +427,7 @@ export function workProductService(db: Db) {
             NULL::text AS document_key,
             NULL::text AS document_format,
             NULL::text AS document_body,
+            NULL::integer AS document_byte_size,
             ci.id AS ci_id,
             ci.identifier AS ci_identifier,
             ci.title AS ci_title,
@@ -452,6 +466,7 @@ export function workProductService(db: Db) {
             true AS is_primary,
             'healthy'::text AS health_status,
             NULL::text AS summary,
+            idoc.audience,
             NULL::jsonb AS metadata,
             dr.created_by_run_id,
             NULL::uuid AS execution_workspace_id,
@@ -461,6 +476,7 @@ export function workProductService(db: Db) {
             idoc.key AS document_key,
             d.format AS document_format,
             d.latest_body AS document_body,
+            COALESCE(octet_length(d.latest_body), 0)::integer AS document_byte_size,
             ci.id AS ci_id,
             ci.identifier AS ci_identifier,
             ci.title AS ci_title,
@@ -492,7 +508,10 @@ export function workProductService(db: Db) {
       if (!base) return null;
 
       const ancestors = await loadAncestorChain(db, base.childIssue.id);
-      return { ...base, ancestors };
+      const preview = row.deliverable_source === "document"
+        ? buildPreviewFromBody(base.contentType, row.document_body ?? "", base.byteSize)
+        : await loadArtifactPreview(db, row);
+      return { ...base, ancestors, preview };
     },
 
     getDeliverableDocumentContentById: async (id: string): Promise<DeliverableDocumentContent | null> => {
@@ -550,6 +569,7 @@ export interface ListDeliverablesOptions {
   projectId?: string;
   agentId?: string;
   q?: string;
+  audience?: DeliverableAudience;
 }
 
 export function clampDeliverableLimit(value: unknown): number {
@@ -574,6 +594,7 @@ interface DeliverableQueryRow extends Record<string, unknown> {
   is_primary: boolean;
   health_status: string;
   summary: string | null;
+  audience: string | null;
   metadata: Record<string, unknown> | null;
   created_by_run_id: string | null;
   execution_workspace_id: string | null;
@@ -606,6 +627,9 @@ interface DeliverableDocumentContent {
   body: string;
 }
 
+const DELIVERABLE_PREVIEW_MAX_BYTES = 64 * 1024;
+const DELIVERABLE_PREVIEW_TYPES = new Set(["text/markdown", "text/plain", "application/json"]);
+
 function toRowArray<T>(result: unknown): T[] {
   // drizzle-orm/postgres-js returns the array directly; node-postgres returns { rows }.
   if (Array.isArray(result)) return result as T[];
@@ -621,6 +645,35 @@ function escapeLikePattern(value: string): string {
 
 function toIsoString(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function normalizeContentType(value: string): string {
+  return value.split(";")[0]!.trim().toLowerCase();
+}
+
+function canInlinePreview(contentType: string): boolean {
+  return DELIVERABLE_PREVIEW_TYPES.has(normalizeContentType(contentType));
+}
+
+function buildPreviewFromBody(contentType: string, body: string, byteSize: number): DeliverablePreview | null {
+  if (!canInlinePreview(contentType)) return null;
+  const truncated = byteSize > DELIVERABLE_PREVIEW_MAX_BYTES;
+  const safeBody = truncated
+    ? body.slice(0, DELIVERABLE_PREVIEW_MAX_BYTES)
+    : body;
+  return {
+    kind: normalizeContentType(contentType) === "text/markdown" ? "markdown" : "text",
+    body: safeBody,
+    truncated,
+  };
+}
+
+async function readStreamToBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
 }
 
 function rowToDeliverableListItem(row: DeliverableQueryRow): DeliverableListItem | null {
@@ -664,6 +717,7 @@ function rowToDeliverableListItem(row: DeliverableQueryRow): DeliverableListItem
     projectId: row.project_id,
     title: row.title,
     summary: row.summary,
+    audience: (row.audience as DeliverableAudience | null) ?? "human",
     createdAt: toIsoString(row.created_at),
     updatedAt: toIsoString(row.updated_at),
     contentPath,
@@ -691,6 +745,35 @@ function rowToDeliverableListItem(row: DeliverableQueryRow): DeliverableListItem
         : null,
     runId: row.created_by_run_id,
   };
+}
+
+async function loadArtifactPreview(db: Db, row: DeliverableQueryRow): Promise<DeliverablePreview | null> {
+  if (row.deliverable_source !== "artifact") return null;
+  const metadata = parseIssueArtifactWorkProductMetadata({
+    type: row.type as IssueWorkProduct["type"],
+    metadata: row.metadata,
+  });
+  if (!metadata || !canInlinePreview(metadata.contentType) || metadata.byteSize > DELIVERABLE_PREVIEW_MAX_BYTES) {
+    return null;
+  }
+
+  const attachmentId = metadata.attachmentId;
+  const rows = await db.execute<{
+    company_id: string;
+    object_key: string;
+  }>(sql`
+    SELECT ia.company_id, a.object_key
+    FROM issue_attachments ia
+    INNER JOIN assets a ON a.id = ia.asset_id
+    WHERE ia.id = ${attachmentId}
+    LIMIT 1
+  `);
+  const attachment = toRowArray<{ company_id: string; object_key: string }>(rows)[0];
+  if (!attachment) return null;
+
+  const object = await getStorageService().getObject(attachment.company_id, attachment.object_key);
+  const body = (await readStreamToBuffer(object.stream)).toString("utf8");
+  return buildPreviewFromBody(metadata.contentType, body, metadata.byteSize);
 }
 
 async function loadAncestorChain(db: Db, startIssueId: string): Promise<DeliverableIssueRef[]> {

--- a/ui/src/api/deliverables.test.ts
+++ b/ui/src/api/deliverables.test.ts
@@ -22,12 +22,13 @@ describe("deliverablesApi", () => {
       projectId: "project-1",
       agentId: "agent-1",
       q: "report",
+      audience: "internal",
       limit: 20,
       offset: 40,
     });
 
     expect(mockApi.get).toHaveBeenCalledWith(
-      "/companies/company-1/deliverables?limit=20&offset=40&projectId=project-1&agentId=agent-1&q=report",
+      "/companies/company-1/deliverables?limit=20&offset=40&projectId=project-1&agentId=agent-1&q=report&audience=internal",
     );
   });
 

--- a/ui/src/api/deliverables.ts
+++ b/ui/src/api/deliverables.ts
@@ -1,4 +1,4 @@
-import type { DeliverableDetail, DeliverableListItem } from "@paperclipai/shared";
+import type { DeliverableAudience, DeliverableDetail, DeliverableListItem } from "@paperclipai/shared";
 import { api } from "./client";
 
 export interface DeliverableListResponse {
@@ -13,6 +13,7 @@ export interface DeliverableListFilters {
   projectId?: string;
   agentId?: string;
   q?: string;
+  audience?: DeliverableAudience;
 }
 
 const DELIVERABLE_PAGE_LIMIT = 200;
@@ -24,6 +25,7 @@ function buildDeliverablesQuery(filters?: DeliverableListFilters) {
   if (filters?.projectId) params.set("projectId", filters.projectId);
   if (filters?.agentId) params.set("agentId", filters.agentId);
   if (filters?.q) params.set("q", filters.q);
+  if (filters?.audience) params.set("audience", filters.audience);
   return params.toString();
 }
 

--- a/ui/src/components/AudienceBadge.tsx
+++ b/ui/src/components/AudienceBadge.tsx
@@ -1,0 +1,10 @@
+import { Badge } from "@/components/ui/badge";
+import type { DeliverableAudience } from "@paperclipai/shared";
+
+export function AudienceBadge({ audience }: { audience: DeliverableAudience }) {
+  return (
+    <Badge variant={audience === "internal" ? "outline" : "secondary"}>
+      {audience === "internal" ? "Internal" : "Human"}
+    </Badge>
+  );
+}

--- a/ui/src/components/IssueContinuationHandoff.test.tsx
+++ b/ui/src/components/IssueContinuationHandoff.test.tsx
@@ -29,6 +29,7 @@ function createHandoffDocument(): IssueDocument {
     companyId: "company-1",
     issueId: "issue-1",
     key: ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
+    audience: "internal",
     title: "Continuation Summary",
     format: "markdown",
     body: "# Handoff\n\nResume from the activity tab.",

--- a/ui/src/components/IssueDocumentsSection.test.tsx
+++ b/ui/src/components/IssueDocumentsSection.test.tsx
@@ -169,6 +169,7 @@ function createIssueDocument(overrides: Partial<IssueDocument> = {}): IssueDocum
     companyId: "company-1",
     issueId: "issue-1",
     key: "plan",
+    audience: "internal",
     title: "Plan",
     format: "markdown",
     body: "",

--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -115,6 +115,7 @@ function toDocumentSummary(document: IssueDocument) {
     companyId: document.companyId,
     issueId: document.issueId,
     key: document.key,
+    audience: document.audience,
     title: document.title,
     format: document.format,
     latestRevisionId: document.latestRevisionId,

--- a/ui/src/components/IssueRunLedger.test.tsx
+++ b/ui/src/components/IssueRunLedger.test.tsx
@@ -318,6 +318,7 @@ describe("IssueRunLedger", () => {
       externalId: "openclaw_gateway:deliverables/final-packet.md",
       title: "Final packet",
       url: "/api/attachments/attachment-1/content",
+      audience: "human",
       status: "ready_for_review",
       reviewState: "none",
       isPrimary: true,

--- a/ui/src/lib/document-revisions.test.ts
+++ b/ui/src/lib/document-revisions.test.ts
@@ -8,6 +8,7 @@ function createDocument(overrides: Partial<IssueDocument> = {}): IssueDocument {
     companyId: "company-1",
     issueId: "issue-1",
     key: "plan",
+    audience: "internal",
     title: "Plan",
     format: "markdown",
     body: "# Current plan",

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -89,7 +89,7 @@ export const queryKeys = {
   deliverables: {
     list: (
       companyId: string,
-      filters?: { projectId?: string; agentId?: string; q?: string; limit?: number; offset?: number },
+      filters?: { projectId?: string; agentId?: string; q?: string; audience?: string; limit?: number; offset?: number },
     ) =>
       [
         "deliverables",
@@ -97,6 +97,7 @@ export const queryKeys = {
         filters?.projectId ?? "__all-projects__",
         filters?.agentId ?? "__all-agents__",
         filters?.q ?? "",
+        filters?.audience ?? "__all-audiences__",
         filters?.limit ?? "__no-limit__",
         filters?.offset ?? 0,
       ] as const,

--- a/ui/src/pages/DeliverableDetail.test.tsx
+++ b/ui/src/pages/DeliverableDetail.test.tsx
@@ -27,6 +27,12 @@ vi.mock("@/context/BreadcrumbContext", () => ({
   useBreadcrumbs: () => ({ setBreadcrumbs: setBreadcrumbsMock }),
 }));
 
+vi.mock("../components/MarkdownBody", () => ({
+  MarkdownBody: ({ children, className }: { children: string; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -59,6 +65,7 @@ const baseDetail = {
   projectId: null,
   title: "Final report",
   summary: "Produced for the board.",
+  audience: "human",
   createdAt: "2026-05-01T00:00:00.000Z",
   updatedAt: "2026-05-01T00:00:00.000Z",
   contentPath: "/api/attachments/abc/content",
@@ -71,6 +78,7 @@ const baseDetail = {
   ancestors: [
     { id: "root-1", identifier: "PAP-1", title: "Quarterly review", status: "in_progress" },
   ],
+  preview: null,
 };
 
 describe("DeliverableDetail page", () => {
@@ -124,6 +132,27 @@ describe("DeliverableDetail page", () => {
 
     const img = container.querySelector("img");
     expect(img?.getAttribute("src")).toBe("/api/attachments/abc/content");
+  });
+
+  it("renders markdown previews inline for text deliverables", async () => {
+    getMock.mockResolvedValue({
+      ...baseDetail,
+      audience: "internal",
+      contentType: "text/markdown; charset=utf-8",
+      originalFilename: "plan.md",
+      preview: {
+        kind: "markdown",
+        body: "# Execution Plan\n\n- Step 1",
+        truncated: false,
+      },
+    });
+
+    await renderAt(container, "/deliverables/deliverable-1");
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("Execution Plan");
+    expect(container.textContent).toContain("Internal");
   });
 
   it("hides the original-request row when the deliverable's child IS the root", async () => {

--- a/ui/src/pages/DeliverableDetail.tsx
+++ b/ui/src/pages/DeliverableDetail.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Download, Package } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Link, useParams } from "@/lib/router";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { deliverablesApi } from "../api/deliverables";
+import { AudienceBadge } from "../components/AudienceBadge";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { Button } from "@/components/ui/button";
@@ -278,13 +278,5 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
       </div>
       <div className="text-sm">{children}</div>
     </div>
-  );
-}
-
-function AudienceBadge({ audience }: { audience: DeliverableDetailType["audience"] }) {
-  return (
-    <Badge variant={audience === "internal" ? "outline" : "secondary"}>
-      {audience === "internal" ? "Internal" : "Human"}
-    </Badge>
   );
 }

--- a/ui/src/pages/DeliverableDetail.tsx
+++ b/ui/src/pages/DeliverableDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Download, Package } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Link, useParams } from "@/lib/router";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
@@ -8,6 +9,7 @@ import { deliverablesApi } from "../api/deliverables";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { Button } from "@/components/ui/button";
+import { MarkdownBody } from "../components/MarkdownBody";
 import { agentUrl, formatDateTime, issueUrl, relativeTime, formatFileSize } from "../lib/utils";
 import type { DeliverableDetail as DeliverableDetailType } from "@paperclipai/shared";
 
@@ -68,7 +70,10 @@ function DeliverableDetailView({ data }: { data: DeliverableDetailType }) {
     <div className="space-y-4">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0 space-y-1">
-          <h1 className="text-xl font-semibold text-foreground">{data.title}</h1>
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-semibold text-foreground">{data.title}</h1>
+            <AudienceBadge audience={data.audience} />
+          </div>
           {data.originalFilename ? (
             <p className="font-mono text-xs text-muted-foreground">{data.originalFilename}</p>
           ) : null}
@@ -93,7 +98,33 @@ function DeliverableDetailView({ data }: { data: DeliverableDetailType }) {
 }
 
 function ArtifactPreview({ data }: { data: DeliverableDetailType }) {
-  const { contentPath, contentType, byteSize, originalFilename, title } = data;
+  const { contentPath, contentType, byteSize, originalFilename, title, preview } = data;
+
+  if (preview?.kind === "markdown") {
+    return (
+      <div className="rounded-md border border-border bg-card p-6">
+        <MarkdownBody className="prose prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0" softBreaks={false}>
+          {preview.body}
+        </MarkdownBody>
+        {preview.truncated ? (
+          <p className="mt-4 text-xs text-muted-foreground">Preview truncated. Download the file to inspect the full content.</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (preview?.kind === "text") {
+    return (
+      <div className="rounded-md border border-border bg-card p-4">
+        <pre className="max-h-[70vh] overflow-auto whitespace-pre-wrap break-words font-mono text-xs text-foreground">
+          {preview.body}
+        </pre>
+        {preview.truncated ? (
+          <p className="mt-3 text-xs text-muted-foreground">Preview truncated. Download the file to inspect the full content.</p>
+        ) : null}
+      </div>
+    );
+  }
 
   if (isImage(contentType)) {
     return (
@@ -215,6 +246,10 @@ function DetailSidePanel({ data }: { data: DeliverableDetailType }) {
         </div>
       </DetailRow>
 
+      <DetailRow label="Audience">
+        <AudienceBadge audience={data.audience} />
+      </DetailRow>
+
       {data.ancestors.length > 1 ? (
         <DetailRow label="Issue chain">
           <ul className="space-y-1">
@@ -243,5 +278,13 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
       </div>
       <div className="text-sm">{children}</div>
     </div>
+  );
+}
+
+function AudienceBadge({ audience }: { audience: DeliverableDetailType["audience"] }) {
+  return (
+    <Badge variant={audience === "internal" ? "outline" : "secondary"}>
+      {audience === "internal" ? "Internal" : "Human"}
+    </Badge>
   );
 }

--- a/ui/src/pages/Deliverables.test.tsx
+++ b/ui/src/pages/Deliverables.test.tsx
@@ -201,6 +201,34 @@ describe("Deliverables page", () => {
     expect(container.querySelector('input[type="search"]')).toBeTruthy();
   });
 
+  it("keeps the audience filter visible when audience filtering returns zero results", async () => {
+    listMock.mockImplementation(async (_companyId: string, filters?: { audience?: string }) => {
+      if (filters?.audience === "internal") {
+        return { items: [], limit: 50, offset: 0 };
+      }
+      return { items: [sampleItem()], limit: 50, offset: 0 };
+    });
+
+    await renderDeliverables(container);
+    await flushReact();
+    await flushReact();
+
+    const select = container.querySelector('select[aria-label="Filter by audience"]') as HTMLSelectElement;
+    expect(select).toBeTruthy();
+
+    await act(async () => {
+      select.selectedIndex = 2;
+      select.value = "internal";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    await flushReact();
+    await flushReact();
+
+    expect(container.querySelector('select[aria-label="Filter by audience"]')).toBeTruthy();
+    expect((container.querySelector('select[aria-label="Filter by audience"]') as HTMLSelectElement).value).toBe("internal");
+  });
+
   it("renders an empty state when there are no deliverables", async () => {
     listMock.mockResolvedValue({ items: [], limit: 50, offset: 0 });
 

--- a/ui/src/pages/Deliverables.test.tsx
+++ b/ui/src/pages/Deliverables.test.tsx
@@ -60,6 +60,7 @@ function sampleItem(overrides: Record<string, unknown> = {}) {
     projectId: null,
     title: "Final report",
     summary: null,
+    audience: "human",
     createdAt: "2026-05-01T00:00:00.000Z",
     updatedAt: "2026-05-01T00:00:00.000Z",
     contentPath: "/api/attachments/abc/content",
@@ -90,7 +91,7 @@ describe("Deliverables page", () => {
 
   it("renders deliverables in a table with download links", async () => {
     listMock.mockResolvedValue({
-      items: [sampleItem(), sampleItem({ id: "deliverable-2", title: "Draft", originalFilename: "draft.md" })],
+      items: [sampleItem(), sampleItem({ id: "deliverable-2", title: "Draft", originalFilename: "draft.md", audience: "internal" })],
       limit: 50,
       offset: 0,
     });
@@ -107,6 +108,8 @@ describe("Deliverables page", () => {
     expect(container.textContent).toContain("from");
     expect(container.textContent).toContain("PAP-12");
     expect(container.textContent).toContain("Astro");
+    expect(container.textContent).toContain("Human");
+    expect(container.textContent).toContain("Internal");
 
     const downloadLinks = Array.from(container.querySelectorAll("a")).filter(
       (a) => a.getAttribute("href") === "/api/attachments/abc/content",
@@ -116,11 +119,11 @@ describe("Deliverables page", () => {
     expect(firstDownload.getAttribute("download")).toBe("report.pdf");
   });
 
-  it("uses server-side search query parameter", async () => {
-    listMock.mockImplementation(async (_companyId: string, filters?: { q?: string }) => {
-      if (filters?.q === "draft") {
+  it("uses server-side search query parameter and audience filter", async () => {
+    listMock.mockImplementation(async (_companyId: string, filters?: { q?: string; audience?: string }) => {
+      if (filters?.q === "draft" || filters?.audience === "internal") {
         return {
-          items: [sampleItem({ id: "deliverable-2", title: "Draft" })],
+          items: [sampleItem({ id: "deliverable-2", title: "Draft", audience: "internal" })],
           limit: 50,
           offset: 0,
         };
@@ -153,6 +156,18 @@ describe("Deliverables page", () => {
 
     expect(listMock.mock.calls.some(([, filters]) => (filters as { q?: string } | undefined)?.q === "draft")).toBe(true);
     expect(container.textContent).toContain("Draft");
+
+    const select = container.querySelector('select[aria-label="Filter by audience"]') as HTMLSelectElement;
+    await act(async () => {
+      select.selectedIndex = 2;
+      select.value = "internal";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    await flushReact();
+    await flushReact();
+
+    expect(listMock.mock.calls.some(([, filters]) => (filters as { audience?: string } | undefined)?.audience === "internal")).toBe(true);
   });
 
   it("keeps search input visible when search returns zero results", async () => {

--- a/ui/src/pages/Deliverables.tsx
+++ b/ui/src/pages/Deliverables.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Download, Package } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Link } from "@/lib/router";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -10,12 +11,19 @@ import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { Input } from "@/components/ui/input";
 import { issueUrl, agentUrl, relativeTime, formatDateTime, formatFileSize } from "../lib/utils";
-import type { DeliverableListItem } from "@paperclipai/shared";
+import type { DeliverableAudience, DeliverableListItem } from "@paperclipai/shared";
+
+const AUDIENCE_FILTERS: Array<{ value: "all" | DeliverableAudience; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "human", label: "Human" },
+  { value: "internal", label: "Internal" },
+];
 
 export function Deliverables() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const [search, setSearch] = useState("");
+  const [audience, setAudience] = useState<"all" | DeliverableAudience>("all");
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Deliverables" }]);
@@ -25,10 +33,12 @@ export function Deliverables() {
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.deliverables.list(selectedCompanyId!, {
       q: searchTerm || undefined,
+      audience: audience === "all" ? undefined : audience,
     }),
     queryFn: () =>
       deliverablesApi.list(selectedCompanyId!, {
         q: searchTerm || undefined,
+        audience: audience === "all" ? undefined : audience,
         limit: 200,
       }),
     enabled: !!selectedCompanyId,
@@ -55,7 +65,7 @@ export function Deliverables() {
           </p>
         </div>
         {items.length > 0 || searchTerm ? (
-          <div className="w-full max-w-xs">
+          <div className="flex w-full max-w-md gap-2">
             <Input
               type="search"
               placeholder="Search deliverables..."
@@ -63,6 +73,16 @@ export function Deliverables() {
               onChange={(event) => setSearch(event.target.value)}
               aria-label="Search deliverables"
             />
+            <select
+              value={audience}
+              onChange={(event) => setAudience(event.target.value as "all" | DeliverableAudience)}
+              aria-label="Filter by audience"
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            >
+              {AUDIENCE_FILTERS.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
           </div>
         ) : null}
       </div>
@@ -86,6 +106,7 @@ export function Deliverables() {
             <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
               <tr>
                 <th className="px-3 py-2 text-left font-medium">Title</th>
+                <th className="px-3 py-2 text-left font-medium">Audience</th>
                 <th className="px-3 py-2 text-left font-medium">Issue</th>
                 <th className="px-3 py-2 text-left font-medium">Agent</th>
                 <th className="px-3 py-2 text-right font-medium">Size</th>
@@ -110,7 +131,7 @@ function DeliverableRow({ item }: { item: DeliverableListItem }) {
   const showChildSeparately = item.rootIssue !== null && item.rootIssue.id !== item.childIssue.id;
 
   return (
-    <tr className="border-t border-border hover:bg-muted/30">
+    <tr className={`border-t border-border hover:bg-muted/30 ${item.audience === "internal" ? "bg-muted/10" : ""}`}>
       <td className="px-3 py-2 align-top">
         <Link
           to={`/deliverables/${item.id}`}
@@ -123,6 +144,9 @@ function DeliverableRow({ item }: { item: DeliverableListItem }) {
             {item.originalFilename}
           </div>
         ) : null}
+      </td>
+      <td className="px-3 py-2 align-top">
+        <AudienceBadge audience={item.audience} />
       </td>
       <td className="px-3 py-2 align-top">
         <Link
@@ -180,5 +204,13 @@ function DeliverableRow({ item }: { item: DeliverableListItem }) {
         </a>
       </td>
     </tr>
+  );
+}
+
+function AudienceBadge({ audience }: { audience: DeliverableAudience }) {
+  return (
+    <Badge variant={audience === "internal" ? "outline" : "secondary"}>
+      {audience === "internal" ? "Internal" : "Human"}
+    </Badge>
   );
 }

--- a/ui/src/pages/Deliverables.tsx
+++ b/ui/src/pages/Deliverables.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Download, Package } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Link } from "@/lib/router";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { deliverablesApi } from "../api/deliverables";
+import { AudienceBadge } from "../components/AudienceBadge";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { Input } from "@/components/ui/input";
@@ -64,7 +64,7 @@ export function Deliverables() {
             {items.length > 0 ? ` (${items.length})` : null}
           </p>
         </div>
-        {items.length > 0 || searchTerm ? (
+        {items.length > 0 || searchTerm || audience !== "all" ? (
           <div className="flex w-full max-w-md gap-2">
             <Input
               type="search"
@@ -204,13 +204,5 @@ function DeliverableRow({ item }: { item: DeliverableListItem }) {
         </a>
       </td>
     </tr>
-  );
-}
-
-function AudienceBadge({ audience }: { audience: DeliverableAudience }) {
-  return (
-    <Badge variant={audience === "internal" ? "outline" : "secondary"}>
-      {audience === "internal" ? "Internal" : "Human"}
-    </Badge>
   );
 }

--- a/ui/storybook/fixtures/paperclipData.ts
+++ b/ui/storybook/fixtures/paperclipData.ts
@@ -899,6 +899,7 @@ export const storybookIssueDocuments: IssueDocument[] = [
     companyId: "company-storybook",
     issueId: "issue-storybook-1",
     key: "plan",
+    audience: "internal",
     title: "Plan",
     format: "markdown",
     body: [
@@ -922,6 +923,7 @@ export const storybookIssueDocuments: IssueDocument[] = [
     companyId: "company-storybook",
     issueId: "issue-storybook-1",
     key: "notes",
+    audience: "human",
     title: "Review Notes",
     format: "markdown",
     body: [
@@ -947,6 +949,7 @@ export const storybookContinuationHandoff: IssueDocument = {
   companyId: "company-storybook",
   issueId: "issue-storybook-1",
   key: "continuation_summary",
+  audience: "internal",
   title: "Continuation handoff",
   format: "markdown",
   body: [


### PR DESCRIPTION
This pull request introduces the concept of "audience" to deliverables and issue documents, allowing them to be categorized as either "human" or "internal." The update includes schema changes, type definitions, API adjustments, and validation logic to support this new property throughout the stack.

**Database and Schema Changes:**

- Added a new `audience` column (defaulting to `"human"`) to both the `issue_work_products` and `issue_documents` tables, and updated existing "plan" and "continuation-summary" documents to have an `"internal"` audience.
- Reflected these changes in the corresponding TypeScript schema definitions for `issueWorkProducts` and `issueDocuments`. [[1]](diffhunk://#diff-7f62b55339d0e8969a1716a960941cb91d5f63c976fa967f9a9225ac5cb9363cR37) [[2]](diffhunk://#diff-2c89f86f167b267e98c596b392ab741ee39492abb75b9593285298ccd3095cefR14)

**Type System and Constants:**

- Introduced `DeliverableAudience` and related constants/types, making `audience` a first-class property in deliverable, work product, and document types. [[1]](diffhunk://#diff-1d536cd3a832ab8cf6a670a23882cb3d64e3defef66e7bb26847f21d26ddf748R210-R223) [[2]](diffhunk://#diff-1e79cbf8869a3f7fb154e90b4df712b634683f6973ad227355db0e3520705697R29-R42) [[3]](diffhunk://#diff-1e79cbf8869a3f7fb154e90b4df712b634683f6973ad227355db0e3520705697R65) [[4]](diffhunk://#diff-8c33de2f97107743f44fcc7cbaa63904702e696818365f35ecebcd8272832e68R43) [[5]](diffhunk://#diff-8c33de2f97107743f44fcc7cbaa63904702e696818365f35ecebcd8272832e68R60) [[6]](diffhunk://#diff-e04b861e7d25216490d941dd4c267e0061ac9a0be8b8a57136ba4a158d72958fR2) [[7]](diffhunk://#diff-e04b861e7d25216490d941dd4c267e0061ac9a0be8b8a57136ba4a158d72958fR74)
- Added a utility function `getDefaultIssueDocumentAudience` to determine the default audience based on document key.

**API and Validation Updates:**

- Extended APIs and validation schemas to accept and propagate the new `audience` property for deliverables and issue documents, including query parameters and request bodies. [[1]](diffhunk://#diff-aa8ea7f3b92828eb92ad2d16c256cd265c22979cd57b5633973f6ccecf2759c3R33-R43) [[2]](diffhunk://#diff-e80a71553f161363b7a3fc25018f288df58941381605bd46f3484e2d56099310R1081) [[3]](diffhunk://#diff-be1822c6d17a3c9abfe9d6f815fe09e8712a04f64aab5cc13d45f8824dc09410R462) [[4]](diffhunk://#diff-63062cfedb0b20361d7121e8bb20c5d8439010670f09d102a86aa12b50316b0eR54) [[5]](diffhunk://#diff-63062cfedb0b20361d7121e8bb20c5d8439010670f09d102a86aa12b50316b0eR168)
- Updated SDK interfaces and protocol methods to include the `audience` field. [[1]](diffhunk://#diff-74af42edd3651729049963945ec1332085a9a12b5a143ca186a2e3f694152cf7R779) [[2]](diffhunk://#diff-5cbbd55c8ba9cdcf64755911c461e490b129e94eadfe56889a2706273f0d5d31R891) [[3]](diffhunk://#diff-b90ab8e75e48125bdc966f2d8602a2fb1bddf708a683edea544c62c5b85c840fR778) [[4]](diffhunk://#diff-590690cda58df67c601e236031580b99f2b1fb4fb0a5387edd0e2cadd3854158R623)

**Service and Logic Adjustments:**

- Modified the document service to use the provided `audience` or fall back to a default based on the document key.
- Ensured the new property is handled in mapping, selection, and service logic for documents and deliverables. [[1]](diffhunk://#diff-88258f385c73d20867ee0c28f98b8daed4d146479f43f763cd167e3f60f56399R39) [[2]](diffhunk://#diff-88258f385c73d20867ee0c28f98b8daed4d146479f43f763cd167e3f60f56399R59) [[3]](diffhunk://#diff-88258f385c73d20867ee0c28f98b8daed4d146479f43f763cd167e3f60f56399R79)

**Miscellaneous:**

- Updated test harness and test setup to support the new `audience` column. [[1]](diffhunk://#diff-590690cda58df67c601e236031580b99f2b1fb4fb0a5387edd0e2cadd3854158R623) [[2]](diffhunk://#diff-bf972858b5decfe62bfb96ffd406e353a382268c7ffa173f07152e9a8be09634R35-R38)
- Exported new types and constants as part of the shared module API. [[1]](diffhunk://#diff-ecabfdd7e2be0565549135ce454f50ce3db926b4951903c474d35d9037790aeaR30-R32) [[2]](diffhunk://#diff-ecabfdd7e2be0565549135ce454f50ce3db926b4951903c474d35d9037790aeaR134) [[3]](diffhunk://#diff-ecabfdd7e2be0565549135ce454f50ce3db926b4951903c474d35d9037790aeaR507) [[4]](diffhunk://#diff-43b22797af0cdf77adb47b4b1a2145191d4007a15da3b198b5ac364bdc811c24R121)

These changes collectively enable audience-based filtering, categorization, and processing of deliverables and documents throughout the system.