### PR TITLE
feat: add confirmation notifications in the inbox

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -339,6 +339,8 @@ export type {
   IssueExecutionStagePrincipal,
   IssueExecutionDecision,
   IssueComment,
+  PendingHumanInboxInteraction,
+  PendingHumanInboxInteractionIssue,
   IssueThreadInteractionActorFields,
   SuggestedTaskDraft,
   SuggestTasksPayload,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -134,6 +134,8 @@ export type {
   IssueExecutionStagePrincipal,
   IssueExecutionDecision,
   IssueComment,
+  PendingHumanInboxInteraction,
+  PendingHumanInboxInteractionIssue,
   IssueThreadInteractionActorFields,
   SuggestedTaskDraft,
   SuggestTasksPayload,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -268,6 +268,25 @@ export interface IssueComment {
   updatedAt: Date;
 }
 
+export interface PendingHumanInboxInteractionIssue {
+  id: string;
+  identifier: string | null;
+  title: string;
+}
+
+export interface PendingHumanInboxInteraction {
+  id: string;
+  companyId: string;
+  issueId: string;
+  kind: "ask_user_questions" | "request_confirmation";
+  title: string | null;
+  summary: string | null;
+  previewText: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  issue: PendingHumanInboxInteractionIssue;
+}
+
 export interface IssueThreadInteractionActorFields {
   createdByAgentId?: string | null;
   createdByUserId?: string | null;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -813,6 +813,15 @@ export function issueRoutes(
     res.json(result);
   });
 
+  router.get("/companies/:companyId/inbox-interactions", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    assertBoard(req);
+    const interactions = await issueThreadInteractionService(db)
+      .listPendingHumanInboxInteractionsForCompany(companyId);
+    res.json(interactions);
+  });
+
   router.post("/companies/:companyId/labels", validate(createIssueLabelSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   documents,
@@ -15,6 +15,7 @@ import type {
   AskUserQuestionsInteraction,
   CreateIssueThreadInteraction,
   IssueThreadInteraction,
+  PendingHumanInboxInteraction,
   RequestConfirmationInteraction,
   RequestConfirmationTarget,
   RejectIssueThreadInteraction,
@@ -141,6 +142,48 @@ function hydrateInteraction(
     default:
       throw unprocessable(`Unknown interaction kind: ${row.kind}`);
   }
+}
+
+function firstNonEmptyString(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return null;
+}
+
+function buildPendingInteractionPreview(args: {
+  kind: "ask_user_questions" | "request_confirmation";
+  payload: unknown;
+  title: string | null;
+  summary: string | null;
+}): string | null {
+  if (args.kind === "request_confirmation") {
+    const payload = requestConfirmationPayloadSchema.safeParse(args.payload);
+    if (payload.success) {
+      return firstNonEmptyString(
+        payload.data.prompt,
+        payload.data.detailsMarkdown ?? null,
+        args.summary,
+        args.title,
+      );
+    }
+    return firstNonEmptyString(args.summary, args.title);
+  }
+
+  const payload = askUserQuestionsPayloadSchema.safeParse(args.payload);
+  if (payload.success) {
+    const firstQuestion = payload.data.questions.find((question) => question.prompt.trim().length > 0);
+    return firstNonEmptyString(
+      payload.data.title ?? null,
+      firstQuestion?.prompt,
+      args.summary,
+      args.title,
+    );
+  }
+
+  return firstNonEmptyString(args.summary, args.title);
 }
 
 function buildAwaitingHumanInteraction<TKind extends AwaitingHumanInteractionKind>(
@@ -654,6 +697,56 @@ export function issueThreadInteractionService(db: Db) {
   }
 
   return {
+    listPendingHumanInboxInteractionsForCompany: async (
+      companyId: string,
+    ): Promise<PendingHumanInboxInteraction[]> => {
+      const rows = await db
+        .select({
+          id: issueThreadInteractions.id,
+          companyId: issueThreadInteractions.companyId,
+          issueId: issueThreadInteractions.issueId,
+          kind: issueThreadInteractions.kind,
+          title: issueThreadInteractions.title,
+          summary: issueThreadInteractions.summary,
+          payload: issueThreadInteractions.payload,
+          createdAt: issueThreadInteractions.createdAt,
+          updatedAt: issueThreadInteractions.updatedAt,
+          issueIdentifier: issues.identifier,
+          issueTitle: issues.title,
+        })
+        .from(issueThreadInteractions)
+        .innerJoin(issues, eq(issueThreadInteractions.issueId, issues.id))
+        .where(and(
+          eq(issueThreadInteractions.companyId, companyId),
+          eq(issueThreadInteractions.status, "pending"),
+          inArray(issueThreadInteractions.kind, ["request_confirmation", "ask_user_questions"]),
+          isNull(issues.hiddenAt),
+        ))
+        .orderBy(asc(issueThreadInteractions.createdAt), asc(issueThreadInteractions.id));
+
+      return rows.map((row) => ({
+        id: row.id,
+        companyId: row.companyId,
+        issueId: row.issueId,
+        kind: row.kind as "ask_user_questions" | "request_confirmation",
+        title: row.title ?? null,
+        summary: row.summary ?? null,
+        previewText: buildPendingInteractionPreview({
+          kind: row.kind as "ask_user_questions" | "request_confirmation",
+          payload: row.payload,
+          title: row.title ?? null,
+          summary: row.summary ?? null,
+        }),
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        issue: {
+          id: row.issueId,
+          identifier: row.issueIdentifier ?? null,
+          title: row.issueTitle,
+        },
+      }));
+    },
+
     listForIssue: async (issueId: string) => {
       const rows = await db
         .select()

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -11,6 +11,7 @@ import type {
   IssueDocument,
   IssueLabel,
   IssueThreadInteraction,
+  PendingHumanInboxInteraction,
   IssueWorkProduct,
   UpsertIssueDocument,
 } from "@paperclipai/shared";
@@ -65,6 +66,8 @@ export const issuesApi = {
     return api.get<Issue[]>(`/companies/${companyId}/issues${qs ? `?${qs}` : ""}`);
   },
   listLabels: (companyId: string) => api.get<IssueLabel[]>(`/companies/${companyId}/labels`),
+  listPendingInboxInteractions: (companyId: string) =>
+    api.get<PendingHumanInboxInteraction[]>(`/companies/${companyId}/inbox-interactions`),
   createLabel: (companyId: string, data: { name: string; color: string }) =>
     api.post<IssueLabel>(`/companies/${companyId}/labels`, data),
   deleteLabel: (id: string) => api.delete<IssueLabel>(`/labels/${id}`),

--- a/ui/src/components/IssueLinkQuicklook.tsx
+++ b/ui/src/components/IssueLinkQuicklook.tsx
@@ -33,13 +33,18 @@ export function IssueQuicklookCard({
   linkTo,
   linkState,
   compact = false,
+  descriptionOverride = null,
 }: {
   issue: Issue;
   linkTo: RouterDom.To;
   linkState?: unknown;
   compact?: boolean;
+  descriptionOverride?: string | null;
 }) {
-  const description = useMemo(() => summarizeIssueDescription(issue.description), [issue.description]);
+  const description = useMemo(
+    () => summarizeIssueDescription(descriptionOverride ?? issue.description),
+    [descriptionOverride, issue.description],
+  );
 
   return (
     <div className={cn("space-y-2", compact && "space-y-1.5")}>
@@ -75,6 +80,7 @@ export const IssueLinkQuicklook = React.forwardRef<
     issuePathId: string;
     disableIssueQuicklook?: boolean;
     issuePrefetch?: Issue | null;
+    issueQuicklookDescriptionOverride?: string | null;
   }
 >(function IssueLinkQuicklookImpl(
   {
@@ -85,6 +91,7 @@ export const IssueLinkQuicklook = React.forwardRef<
     state,
     disableIssueQuicklook = false,
     issuePrefetch = null,
+    issueQuicklookDescriptionOverride = null,
     onClick,
     onClickCapture,
     onMouseEnter,
@@ -164,7 +171,13 @@ export const IssueLinkQuicklook = React.forwardRef<
         onOpenAutoFocus={(event) => event.preventDefault()}
       >
         {data ? (
-          <IssueQuicklookCard issue={data} linkTo={detailPath} linkState={prefetchedState} compact />
+          <IssueQuicklookCard
+            issue={data}
+            linkTo={detailPath}
+            linkState={prefetchedState}
+            compact
+            descriptionOverride={issueQuicklookDescriptionOverride}
+          />
         ) : (
           <div className="space-y-2">
             <div className="h-4 w-24 rounded bg-accent/50" />

--- a/ui/src/hooks/useInboxBadge.ts
+++ b/ui/src/hooks/useInboxBadge.ts
@@ -152,6 +152,12 @@ export function useInboxBadge(companyId: string | null | undefined) {
     enabled: !!companyId,
   });
 
+  const { data: pendingInboxInteractions = [] } = useQuery({
+    queryKey: queryKeys.issues.pendingInboxInteractions(companyId!),
+    queryFn: () => issuesApi.listPendingInboxInteractions(companyId!),
+    enabled: !!companyId,
+  });
+
   const { data: joinRequests = [] } = useQuery({
     queryKey: queryKeys.access.joinRequests(companyId!),
     queryFn: async () => {
@@ -199,6 +205,7 @@ export function useInboxBadge(companyId: string | null | undefined) {
     () =>
       computeInboxBadgeData({
         approvals,
+        pendingInboxInteractions,
         joinRequests,
         dashboard,
         heartbeatRuns,
@@ -207,6 +214,16 @@ export function useInboxBadge(companyId: string | null | undefined) {
         dismissedAtByKey,
         currentUserId,
       }),
-    [approvals, joinRequests, dashboard, heartbeatRuns, mineIssues, dismissedAlerts, dismissedAtByKey, currentUserId],
+    [
+      approvals,
+      pendingInboxInteractions,
+      joinRequests,
+      dashboard,
+      heartbeatRuns,
+      mineIssues,
+      dismissedAlerts,
+      dismissedAtByKey,
+      currentUserId,
+    ],
   );
 }

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -310,6 +310,7 @@ describe("inbox helpers", () => {
         { ...makeApproval("pending"), requestedByUserId: "user-1" },
         { ...makeApproval("approved"), requestedByUserId: "user-2" },
       ],
+      pendingInboxInteractions: [],
       joinRequests: [makeJoinRequest("join-1")],
       dashboard,
       heartbeatRuns: [
@@ -336,6 +337,7 @@ describe("inbox helpers", () => {
   it("drops dismissed runs and alerts from the computed badge", () => {
     const result = computeInboxBadgeData({
       approvals: [],
+      pendingInboxInteractions: [],
       joinRequests: [],
       dashboard,
       heartbeatRuns: [makeRun("run-1", "failed", "2026-03-11T00:00:00.000Z")],
@@ -358,6 +360,7 @@ describe("inbox helpers", () => {
   it("excludes read mine issues from the inbox badge count", () => {
     const result = computeInboxBadgeData({
       approvals: [],
+      pendingInboxInteractions: [],
       joinRequests: [],
       dashboard,
       heartbeatRuns: [],
@@ -461,6 +464,7 @@ describe("inbox helpers", () => {
 
     const result = computeInboxBadgeData({
       approvals,
+      pendingInboxInteractions: [],
       joinRequests: [],
       dashboard,
       heartbeatRuns: [],
@@ -476,6 +480,7 @@ describe("inbox helpers", () => {
   it("does not count company-wide alerts in the personal inbox badge", () => {
     const result = computeInboxBadgeData({
       approvals: [],
+      pendingInboxInteractions: [],
       joinRequests: [],
       dashboard,
       heartbeatRuns: [],
@@ -509,6 +514,7 @@ describe("inbox helpers", () => {
       }).map((item) => {
         if (item.kind === "issue") return `issue:${item.issue.id}`;
         if (item.kind === "approval") return `approval:${item.approval.id}`;
+        if (item.kind === "interaction") return `interaction:${item.interaction.id}`;
         if (item.kind === "join_request") return `join:${item.joinRequest.id}`;
         return `run:${item.run.id}`;
       }),
@@ -552,6 +558,7 @@ describe("inbox helpers", () => {
       }).map((item) => {
         if (item.kind === "issue") return `issue:${item.issue.id}`;
         if (item.kind === "approval") return `approval:${item.approval.id}`;
+        if (item.kind === "interaction") return `interaction:${item.interaction.id}`;
         if (item.kind === "join_request") return `join:${item.joinRequest.id}`;
         return `run:${item.run.id}`;
       }),

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -5,6 +5,7 @@ import type {
   InboxDismissal,
   Issue,
   JoinRequest,
+  PendingHumanInboxInteraction,
 } from "@paperclipai/shared";
 import {
   applyIssueFilters,
@@ -61,6 +62,11 @@ export type InboxWorkItem =
       kind: "approval";
       timestamp: number;
       approval: Approval;
+    }
+  | {
+      kind: "interaction";
+      timestamp: number;
+      interaction: PendingHumanInboxInteraction;
     }
   | {
       kind: "failed_run";
@@ -742,14 +748,24 @@ export function approvalActivityTimestamp(approval: Approval): number {
   return normalizeTimestamp(approval.createdAt);
 }
 
+export function pendingInteractionActivityTimestamp(
+  interaction: PendingHumanInboxInteraction,
+): number {
+  const updatedAt = normalizeTimestamp(interaction.updatedAt);
+  if (updatedAt > 0) return updatedAt;
+  return normalizeTimestamp(interaction.createdAt);
+}
+
 export function getInboxWorkItems({
   issues,
   approvals,
+  interactions = [],
   failedRuns = [],
   joinRequests = [],
 }: {
   issues: Issue[];
   approvals: Approval[];
+  interactions?: PendingHumanInboxInteraction[];
   failedRuns?: HeartbeatRun[];
   joinRequests?: JoinRequest[];
 }): InboxWorkItem[] {
@@ -763,6 +779,11 @@ export function getInboxWorkItems({
       kind: "approval" as const,
       timestamp: approvalActivityTimestamp(approval),
       approval,
+    })),
+    ...interactions.map((interaction) => ({
+      kind: "interaction" as const,
+      timestamp: pendingInteractionActivityTimestamp(interaction),
+      interaction,
     })),
     ...failedRuns.map((run) => ({
       kind: "failed_run" as const,
@@ -784,6 +805,10 @@ export function getInboxWorkItems({
     if (a.kind === "approval" && b.kind === "approval") {
       return approvalActivityTimestamp(b.approval) - approvalActivityTimestamp(a.approval);
     }
+    if (a.kind === "interaction" && b.kind === "interaction") {
+      return pendingInteractionActivityTimestamp(b.interaction)
+        - pendingInteractionActivityTimestamp(a.interaction);
+    }
 
     return a.kind === "approval" ? -1 : 1;
   });
@@ -792,6 +817,7 @@ export function getInboxWorkItems({
 const inboxWorkItemKindOrder: InboxWorkItem["kind"][] = [
   "issue",
   "approval",
+  "interaction",
   "failed_run",
   "join_request",
 ];
@@ -799,6 +825,7 @@ const inboxWorkItemKindOrder: InboxWorkItem["kind"][] = [
 const inboxWorkItemKindLabels: Record<InboxWorkItem["kind"], string> = {
   issue: "Issues",
   approval: "Approvals",
+  interaction: "Approvals",
   failed_run: "Failed runs",
   join_request: "Join requests",
 };
@@ -960,6 +987,7 @@ export function buildGroupedInboxSections(
 export function getInboxWorkItemKey(item: InboxWorkItem): string {
   if (item.kind === "issue") return `issue:${item.issue.id}`;
   if (item.kind === "approval") return `approval:${item.approval.id}`;
+  if (item.kind === "interaction") return `interaction:${item.interaction.id}`;
   if (item.kind === "failed_run") return `run:${item.run.id}`;
   return `join:${item.joinRequest.id}`;
 }
@@ -1032,6 +1060,7 @@ export function shouldShowInboxSection({
 
 export function computeInboxBadgeData({
   approvals,
+  pendingInboxInteractions,
   joinRequests,
   dashboard,
   heartbeatRuns,
@@ -1041,6 +1070,7 @@ export function computeInboxBadgeData({
   currentUserId,
 }: {
   approvals: Approval[];
+  pendingInboxInteractions: PendingHumanInboxInteraction[];
   joinRequests: JoinRequest[];
   dashboard: DashboardSummary | undefined;
   heartbeatRuns: HeartbeatRun[];
@@ -1062,6 +1092,14 @@ export function computeInboxBadgeData({
     (jr) => !isInboxEntityDismissed(dismissedAtByKey, `join:${jr.id}`, jr.updatedAt ?? jr.createdAt),
   ).length;
   const visibleMineIssues = mineIssues.filter((issue) => issue.isUnreadForMe).length;
+  const actionableInteractions = pendingInboxInteractions.filter(
+    (interaction) =>
+      !isInboxEntityDismissed(
+        dismissedAtByKey,
+        `interaction:${interaction.id}`,
+        interaction.updatedAt,
+      ),
+  ).length;
   const agentErrorCount = dashboard?.agents.error ?? 0;
   const monthBudgetCents = dashboard?.costs.monthBudgetCents ?? 0;
   const monthUtilizationPercent = dashboard?.costs.monthUtilizationPercent ?? 0;
@@ -1077,8 +1115,8 @@ export function computeInboxBadgeData({
 
   return {
     // The inbox badge reflects personal/actionable work, not company-wide health alerts.
-    inbox: actionableApprovals + visibleJoinRequests + failedRuns + visibleMineIssues,
-    approvals: actionableApprovals,
+    inbox: actionableApprovals + actionableInteractions + visibleJoinRequests + failedRuns + visibleMineIssues,
+    approvals: actionableApprovals + actionableInteractions,
     failedRuns,
     joinRequests: visibleJoinRequests,
     mineIssues: visibleMineIssues,

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -756,6 +756,26 @@ export function pendingInteractionActivityTimestamp(
   return normalizeTimestamp(interaction.createdAt);
 }
 
+function inboxWorkItemSortRank(kind: InboxWorkItem["kind"]): number {
+  switch (kind) {
+    case "issue":
+      return 0;
+    case "approval":
+    case "interaction":
+      return 1;
+    case "failed_run":
+      return 2;
+    case "join_request":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function normalizeWorkItemGroupKind(kind: InboxWorkItem["kind"]): Exclude<InboxWorkItem["kind"], "interaction"> {
+  return kind === "interaction" ? "approval" : kind;
+}
+
 export function getInboxWorkItems({
   issues,
   approvals,
@@ -810,14 +830,13 @@ export function getInboxWorkItems({
         - pendingInteractionActivityTimestamp(a.interaction);
     }
 
-    return a.kind === "approval" ? -1 : 1;
+    return inboxWorkItemSortRank(a.kind) - inboxWorkItemSortRank(b.kind);
   });
 }
 
-const inboxWorkItemKindOrder: InboxWorkItem["kind"][] = [
+const inboxGroupedKindOrder: Array<Exclude<InboxWorkItem["kind"], "interaction">> = [
   "issue",
   "approval",
-  "interaction",
   "failed_run",
   "join_request",
 ];
@@ -844,7 +863,10 @@ export function groupInboxWorkItems(
     for (const item of items) {
       const resolvedGroup = item.kind === "issue"
         ? resolveIssueWorkspaceGroup(item.issue, options)
-        : { key: `kind:${item.kind}`, label: inboxWorkItemKindLabels[item.kind] };
+        : {
+            key: `kind:${normalizeWorkItemGroupKind(item.kind)}`,
+            label: inboxWorkItemKindLabels[normalizeWorkItemGroupKind(item.kind)],
+          };
       const existing = groups.get(resolvedGroup.key);
       if (existing) {
         existing.items.push(item);
@@ -877,15 +899,16 @@ export function groupInboxWorkItems(
       }));
   }
 
-  const groups = new Map<InboxWorkItem["kind"], InboxWorkItem[]>();
+  const groups = new Map<Exclude<InboxWorkItem["kind"], "interaction">, InboxWorkItem[]>();
   for (const item of items) {
-    const existing = groups.get(item.kind) ?? [];
+    const groupKind = normalizeWorkItemGroupKind(item.kind);
+    const existing = groups.get(groupKind) ?? [];
     existing.push(item);
-    groups.set(item.kind, existing);
+    groups.set(groupKind, existing);
   }
 
   const orderedGroups: InboxWorkItemGroup[] = [];
-  for (const kind of inboxWorkItemKindOrder) {
+  for (const kind of inboxGroupedKindOrder) {
     const groupItems = groups.get(kind) ?? [];
     if (groupItems.length === 0) continue;
     orderedGroups.push({

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -42,6 +42,8 @@ export const queryKeys = {
     listTouchedByMe: (companyId: string) => ["issues", companyId, "touched-by-me"] as const,
     listUnreadTouchedByMe: (companyId: string) => ["issues", companyId, "unread-touched-by-me"] as const,
     labels: (companyId: string) => ["issues", companyId, "labels"] as const,
+    pendingInboxInteractions: (companyId: string) =>
+      ["issues", companyId, "pending-inbox-interactions"] as const,
     listByProject: (companyId: string, projectId: string) =>
       ["issues", companyId, "project", projectId] as const,
     listByParent: (companyId: string, parentId: string) =>

--- a/ui/src/lib/router.tsx
+++ b/ui/src/lib/router.tsx
@@ -46,10 +46,20 @@ export * from "react-router-dom";
 type CompanyLinkProps = React.ComponentProps<typeof RouterDom.Link> & {
   disableIssueQuicklook?: boolean;
   issuePrefetch?: Issue | null;
+  issueQuicklookDescriptionOverride?: string | null;
 };
 
 export const Link = React.forwardRef<HTMLAnchorElement, CompanyLinkProps>(
-  function CompanyLink({ to, disableIssueQuicklook = false, issuePrefetch = null, ...props }, ref) {
+  function CompanyLink(
+    {
+      to,
+      disableIssueQuicklook = false,
+      issuePrefetch = null,
+      issueQuicklookDescriptionOverride = null,
+      ...props
+    },
+    ref,
+  ) {
     const companyPrefix = useActiveCompanyPrefix();
     const resolvedTo = resolveTo(to, companyPrefix);
     const issuePathId = parseIssuePathIdFromPath(typeof resolvedTo === "string" ? resolvedTo : resolvedTo.pathname);
@@ -62,6 +72,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, CompanyLinkProps>(
           issuePathId={issuePathId}
           disableIssueQuicklook={disableIssueQuicklook}
           issuePrefetch={issuePrefetch}
+          issueQuicklookDescriptionOverride={issueQuicklookDescriptionOverride}
           {...props}
         />
       );

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -90,13 +90,14 @@ import {
   UserPlus,
   Search,
   ListTree,
+  MessageSquareQuote,
 } from "lucide-react";
 
 const INBOX_HEARTBEAT_RUN_LIMIT = 200;
 const INBOX_ISSUE_LIST_LIMIT = 500;
 import { Input } from "@/components/ui/input";
 import { PageTabBar } from "../components/PageTabBar";
-import type { Approval, HeartbeatRun, Issue, JoinRequest } from "@paperclipai/shared";
+import type { Approval, HeartbeatRun, Issue, JoinRequest, PendingHumanInboxInteraction } from "@paperclipai/shared";
 import {
   ACTIONABLE_APPROVAL_STATUSES,
   DEFAULT_INBOX_ISSUE_COLUMNS,
@@ -523,6 +524,103 @@ function ApprovalInboxRow({
   );
 }
 
+function HumanInteractionInboxRow({
+  interaction,
+  unreadState = null,
+  onMarkRead,
+  onArchive,
+  archiveDisabled,
+  selected = false,
+  className,
+}: {
+  interaction: PendingHumanInboxInteraction;
+  unreadState?: NonIssueUnreadState;
+  onMarkRead?: () => void;
+  onArchive?: () => void;
+  archiveDisabled?: boolean;
+  selected?: boolean;
+  className?: string;
+}) {
+  const showUnreadSlot = unreadState !== null;
+  const showUnreadDot = unreadState === "visible" || unreadState === "fading";
+  const kindLabel = interaction.kind === "request_confirmation"
+    ? "Confirmation requested"
+    : "Questions requested";
+  const quicklookDescription =
+    interaction.previewText?.trim()
+    || interaction.summary?.trim()
+    || interaction.title?.trim()
+    || kindLabel;
+  const pathId = interaction.issue.identifier ?? interaction.issue.id;
+
+  return (
+    <div className={cn(
+      "group border-b border-border px-2 py-2.5 last:border-b-0 sm:px-1 sm:pr-3 sm:py-2",
+      className,
+    )}>
+      <div className="flex items-start gap-2 sm:items-center">
+        {showUnreadSlot ? (
+          <span className="hidden sm:inline-flex h-4 w-4 shrink-0 items-center justify-center self-center">
+            {showUnreadDot ? (
+              <button
+                type="button"
+                onClick={onMarkRead}
+                className={cn(
+                  "inline-flex h-4 w-4 items-center justify-center rounded-full transition-colors",
+                  "hover:bg-blue-500/20",
+                )}
+                aria-label="Mark as read"
+              >
+                <span className={cn(
+                  "block h-2 w-2 rounded-full transition-opacity duration-300",
+                  "bg-blue-600 dark:bg-blue-400",
+                  unreadState === "fading" ? "opacity-0" : "opacity-100",
+                )} />
+              </button>
+            ) : onArchive ? (
+              <button
+                type="button"
+                onClick={onArchive}
+                disabled={archiveDisabled}
+                className="inline-flex h-4 w-4 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
+                aria-label="Dismiss from inbox"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            ) : (
+              <span className="inline-flex h-4 w-4" aria-hidden="true" />
+            )}
+          </span>
+        ) : null}
+        <Link
+          to={`${createIssueDetailPath(pathId)}#interaction-${interaction.id}`}
+          issueQuicklookDescriptionOverride={quicklookDescription}
+          className={cn(
+            "flex min-w-0 flex-1 items-start gap-2 no-underline text-inherit transition-colors",
+            selected ? "hover:bg-transparent" : "hover:bg-accent/50",
+          )}
+        >
+          {!showUnreadSlot && <span className="hidden h-2 w-2 shrink-0 sm:inline-flex" aria-hidden="true" />}
+          <span className="hidden h-3.5 w-3.5 shrink-0 sm:inline-flex" aria-hidden="true" />
+          <span className="mt-0.5 shrink-0 rounded-md bg-muted p-1.5 sm:mt-0">
+            <MessageSquareQuote className="h-4 w-4 text-muted-foreground" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="line-clamp-2 text-sm font-medium sm:truncate sm:line-clamp-none">
+              {interaction.title ?? kindLabel}
+            </span>
+            <span className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+              <span className="font-mono">{interaction.issue.identifier ?? interaction.issue.id}</span>
+              <span className="max-w-[40ch] truncate">{interaction.issue.title}</span>
+              <span>updated {timeAgo(interaction.updatedAt)}</span>
+            </span>
+          </span>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
 function JoinRequestInboxRow({
   joinRequest,
   onApprove,
@@ -747,6 +845,12 @@ export function Inbox() {
   } = useQuery({
     queryKey: queryKeys.approvals.list(selectedCompanyId!),
     queryFn: () => approvalsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+
+  const { data: pendingInboxInteractions = [] } = useQuery({
+    queryKey: queryKeys.issues.pendingInboxInteractions(selectedCompanyId!),
+    queryFn: () => issuesApi.listPendingInboxInteractions(selectedCompanyId!),
     enabled: !!selectedCompanyId,
   });
 
@@ -1021,6 +1125,12 @@ export function Inbox() {
     }
     return filtered;
   }, [approvals, tab, allApprovalFilter, currentUserId, dismissedAtByKey]);
+  const pendingInteractionsToRender = useMemo(() => {
+    if (tab !== "unread") return pendingInboxInteractions;
+    return pendingInboxInteractions.filter(
+      (interaction) => !readItems.has(`interaction:${interaction.id}`),
+    );
+  }, [pendingInboxInteractions, readItems, tab]);
   const showJoinRequestsCategory =
     allCategoryFilter === "everything" || allCategoryFilter === "join_requests";
   const showTouchedCategory =
@@ -1050,10 +1160,20 @@ export function Inbox() {
       getInboxWorkItems({
         issues: tab === "all" && !showTouchedCategory ? [] : issuesToRender,
         approvals: tab === "all" && !showApprovalsCategory ? [] : approvalsToRender,
+        interactions: tab === "all" && !showApprovalsCategory ? [] : pendingInteractionsToRender,
         failedRuns: failedRunsForTab,
         joinRequests: joinRequestsForTab,
       }),
-    [approvalsToRender, issuesToRender, showApprovalsCategory, showTouchedCategory, tab, failedRunsForTab, joinRequestsForTab],
+    [
+      approvalsToRender,
+      issuesToRender,
+      pendingInteractionsToRender,
+      showApprovalsCategory,
+      showTouchedCategory,
+      tab,
+      failedRunsForTab,
+      joinRequestsForTab,
+    ],
   );
 
   const filteredWorkItems = useMemo(() => {
@@ -1074,6 +1194,18 @@ export function Inbox() {
         if (label.toLowerCase().includes(q)) return true;
         if (a.type.toLowerCase().includes(q)) return true;
         return false;
+      }
+      if (item.kind === "interaction") {
+        const kindLabel = item.interaction.kind === "request_confirmation"
+          ? "confirmation requested"
+          : "questions requested";
+        return (
+          kindLabel.includes(q)
+          || (item.interaction.title?.toLowerCase().includes(q) ?? false)
+          || (item.interaction.summary?.toLowerCase().includes(q) ?? false)
+          || item.interaction.issue.title.toLowerCase().includes(q)
+          || (item.interaction.issue.identifier?.toLowerCase().includes(q) ?? false)
+        );
       }
       if (item.kind === "failed_run") {
         const run = item.run;
@@ -1802,6 +1934,9 @@ export function Inbox() {
               act.navigate(createIssueDetailPath(pathId), { state: detailState });
             } else if (item.kind === "approval") {
               act.navigate(`/approvals/${item.approval.id}`);
+            } else if (item.kind === "interaction") {
+              const pathId = item.interaction.issue.identifier ?? item.interaction.issue.id;
+              act.navigate(`${createIssueDetailPath(pathId)}#interaction-${item.interaction.id}`);
             } else if (item.kind === "failed_run") {
               act.navigate(`/agents/${item.run.agentId}/runs/${item.run.id}`);
             }
@@ -2355,6 +2490,38 @@ export function Inbox() {
                           selected={isSelected}
                           disabled={isArchiving}
                           onArchive={() => handleArchiveNonIssue(approvalKey)}
+                        >
+                          {row}
+                        </SwipeToArchive>
+                      ) : row));
+                      continue;
+                    }
+
+                    if (item.kind === "interaction") {
+                      const interactionKey = `interaction:${item.interaction.id}`;
+                      const isArchiving = archivingNonIssueIds.has(interactionKey);
+                      const row = (
+                        <HumanInteractionInboxRow
+                          key={interactionKey}
+                          interaction={item.interaction}
+                          selected={isSelected}
+                          unreadState={nonIssueUnreadState(interactionKey)}
+                          onMarkRead={() => handleMarkNonIssueRead(interactionKey)}
+                          onArchive={canArchiveFromTab ? () => handleArchiveNonIssue(interactionKey) : undefined}
+                          archiveDisabled={isArchiving}
+                          className={
+                            isArchiving
+                              ? "pointer-events-none -translate-x-4 scale-[0.98] opacity-0 transition-all duration-200 ease-out"
+                              : "transition-all duration-200 ease-out"
+                          }
+                        />
+                      );
+                      elements.push(wrapItem(interactionKey, isSelected, canArchiveFromTab ? (
+                        <SwipeToArchive
+                          key={interactionKey}
+                          selected={isSelected}
+                          disabled={isArchiving}
+                          onArchive={() => handleArchiveNonIssue(interactionKey)}
                         >
                           {row}
                         </SwipeToArchive>

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -1126,11 +1126,22 @@ export function Inbox() {
     return filtered;
   }, [approvals, tab, allApprovalFilter, currentUserId, dismissedAtByKey]);
   const pendingInteractionsToRender = useMemo(() => {
-    if (tab !== "unread") return pendingInboxInteractions;
-    return pendingInboxInteractions.filter(
+    let filtered = pendingInboxInteractions;
+    if (tab === "mine") {
+      filtered = filtered.filter(
+        (interaction) =>
+          !isInboxEntityDismissed(
+            dismissedAtByKey,
+            `interaction:${interaction.id}`,
+            interaction.updatedAt,
+          ),
+      );
+    }
+    if (tab !== "unread") return filtered;
+    return filtered.filter(
       (interaction) => !readItems.has(`interaction:${interaction.id}`),
     );
-  }, [pendingInboxInteractions, readItems, tab]);
+  }, [pendingInboxInteractions, readItems, tab, dismissedAtByKey]);
   const showJoinRequestsCategory =
     allCategoryFilter === "everything" || allCategoryFilter === "join_requests";
   const showTouchedCategory =


### PR DESCRIPTION
Added notifications for "Confirmation requested" or "Questions requested" in the inbox.

When an issue needs confirmation from a human, all humans will now have a "Confirmation requested" notification, and it also shows in the inbox sidebar badge.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/a84faa13-8c96-4be3-b6ce-b278961fdfe9" />

used OpenCode with GPT-5.3 Codex OpenAI