### PR TITLE
fix(deliverables): preserve search focus during filtering

### DIFF
--- a/ui/src/pages/Deliverables.test.tsx
+++ b/ui/src/pages/Deliverables.test.tsx
@@ -250,6 +250,8 @@ describe("Deliverables page", () => {
     expect(pendingInput).toBeTruthy();
     expect(pendingInput?.isConnected).toBe(true);
     expect((pendingInput as HTMLInputElement).value).toBe("r");
+    expect(container.querySelector("svg.animate-spin")).toBeTruthy();
+    expect(container.querySelector(".opacity-70")).toBeTruthy();
 
     await act(async () => {
       resolveSearch?.({
@@ -263,6 +265,7 @@ describe("Deliverables page", () => {
     await flushReact();
 
     expect(container.textContent).toContain("Recycled draft");
+    expect(container.querySelector("svg.animate-spin")).toBeNull();
   });
 
   it("keeps the audience filter visible when audience filtering returns zero results", async () => {

--- a/ui/src/pages/Deliverables.test.tsx
+++ b/ui/src/pages/Deliverables.test.tsx
@@ -33,7 +33,8 @@ vi.mock("@/context/BreadcrumbContext", () => ({
 async function flushReact() {
   await act(async () => {
     await Promise.resolve();
-    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    vi.runOnlyPendingTimers();
+    await Promise.resolve();
   });
 }
 
@@ -79,11 +80,14 @@ describe("Deliverables page", () => {
   let container: HTMLDivElement;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     container = document.createElement("div");
     document.body.appendChild(container);
   });
 
   afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
     container.remove();
     document.body.innerHTML = "";
     vi.clearAllMocks();
@@ -150,6 +154,9 @@ describe("Deliverables page", () => {
       valueSetter?.call(input, "draft");
       input.dispatchEvent(new Event("input", { bubbles: true }));
     });
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+    });
 
     await flushReact();
     await flushReact();
@@ -193,12 +200,69 @@ describe("Deliverables page", () => {
       valueSetter?.call(input, "zzz");
       input.dispatchEvent(new Event("input", { bubbles: true }));
     });
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+    });
 
     await flushReact();
     await flushReact();
 
     expect(container.textContent).toContain("No deliverables match your search.");
     expect(container.querySelector('input[type="search"]')).toBeTruthy();
+  });
+
+  it("keeps the search input mounted while a search request is pending", async () => {
+    let resolveSearch: ((value: { items: ReturnType<typeof sampleItem>[]; limit: number; offset: number }) => void) | null = null;
+    listMock.mockImplementation((_companyId: string, filters?: { q?: string }) => {
+      if (filters?.q === "r") {
+        return new Promise((resolve) => {
+          resolveSearch = resolve;
+        });
+      }
+      return Promise.resolve({
+        items: [sampleItem()],
+        limit: 50,
+        offset: 0,
+      });
+    });
+
+    await renderDeliverables(container);
+    await flushReact();
+    await flushReact();
+
+    const input = container.querySelector('input[type="search"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      valueSetter?.call(input, "r");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+    });
+    await flushReact();
+
+    const pendingInput = container.querySelector('input[type="search"]');
+    expect(pendingInput).toBeTruthy();
+    expect(pendingInput?.isConnected).toBe(true);
+    expect((pendingInput as HTMLInputElement).value).toBe("r");
+
+    await act(async () => {
+      resolveSearch?.({
+        items: [sampleItem({ id: "deliverable-2", title: "Recycled draft" })],
+        limit: 50,
+        offset: 0,
+      });
+    });
+
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("Recycled draft");
   });
 
   it("keeps the audience filter visible when audience filtering returns zero results", async () => {

--- a/ui/src/pages/Deliverables.tsx
+++ b/ui/src/pages/Deliverables.tsx
@@ -1,6 +1,6 @@
 import { startTransition, useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Download, Package } from "lucide-react";
+import { Download, LoaderCircle, Package } from "lucide-react";
 import { Link } from "@/lib/router";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
@@ -32,17 +32,16 @@ export function Deliverables() {
   }, [setBreadcrumbs]);
 
   useEffect(() => {
-    if (searchDraft === search) return;
     const timeoutId = window.setTimeout(() => {
       startTransition(() => {
         setSearch(searchDraft);
       });
     }, DELIVERABLE_SEARCH_DEBOUNCE_MS);
     return () => window.clearTimeout(timeoutId);
-  }, [searchDraft, search]);
+  }, [searchDraft]);
 
   const searchTerm = search.trim();
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isFetching, error } = useQuery({
     queryKey: queryKeys.deliverables.list(selectedCompanyId!, {
       q: searchTerm || undefined,
       audience: audience === "all" ? undefined : audience,
@@ -84,13 +83,22 @@ export function Deliverables() {
         </div>
         {items.length > 0 || searchTerm || audience !== "all" ? (
           <div className="flex w-full max-w-md gap-2">
-            <Input
-              type="search"
-              placeholder="Search deliverables..."
-              value={searchDraft}
-              onChange={(event) => setSearchDraft(event.target.value)}
-              aria-label="Search deliverables"
-            />
+            <div className="relative flex-1">
+              <Input
+                type="search"
+                placeholder="Search deliverables..."
+                value={searchDraft}
+                onChange={(event) => setSearchDraft(event.target.value)}
+                aria-label="Search deliverables"
+                className={isFetching ? "pr-9" : undefined}
+              />
+              {isFetching ? (
+                <LoaderCircle
+                  aria-hidden="true"
+                  className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground"
+                />
+              ) : null}
+            </div>
             <select
               value={audience}
               onChange={(event) => setAudience(event.target.value as "all" | DeliverableAudience)}
@@ -119,7 +127,11 @@ export function Deliverables() {
           }
         />
       ) : (
-        <div className="overflow-hidden rounded-md border border-border">
+        <div
+          className={`overflow-hidden rounded-md border border-border transition-opacity ${
+            isFetching ? "opacity-70" : "opacity-100"
+          }`}
+        >
           <table className="w-full text-sm">
             <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
               <tr>

--- a/ui/src/pages/Deliverables.tsx
+++ b/ui/src/pages/Deliverables.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { startTransition, useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Download, Package } from "lucide-react";
 import { Link } from "@/lib/router";
@@ -18,16 +18,28 @@ const AUDIENCE_FILTERS: Array<{ value: "all" | DeliverableAudience; label: strin
   { value: "human", label: "Human" },
   { value: "internal", label: "Internal" },
 ];
+const DELIVERABLE_SEARCH_DEBOUNCE_MS = 250;
 
 export function Deliverables() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const [searchDraft, setSearchDraft] = useState("");
   const [search, setSearch] = useState("");
   const [audience, setAudience] = useState<"all" | DeliverableAudience>("all");
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Deliverables" }]);
   }, [setBreadcrumbs]);
+
+  useEffect(() => {
+    if (searchDraft === search) return;
+    const timeoutId = window.setTimeout(() => {
+      startTransition(() => {
+        setSearch(searchDraft);
+      });
+    }, DELIVERABLE_SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [searchDraft, search]);
 
   const searchTerm = search.trim();
   const { data, isLoading, error } = useQuery({
@@ -42,6 +54,12 @@ export function Deliverables() {
         limit: 200,
       }),
     enabled: !!selectedCompanyId,
+    placeholderData: (previousData, previousQuery) => {
+      const previousKey = Array.isArray(previousQuery?.queryKey) ? previousQuery.queryKey : [];
+      return previousKey[0] === "deliverables" && previousKey[1] === selectedCompanyId
+        ? previousData
+        : undefined;
+    },
   });
 
   const items = data?.items ?? [];
@@ -69,8 +87,8 @@ export function Deliverables() {
             <Input
               type="search"
               placeholder="Search deliverables..."
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
+              value={searchDraft}
+              onChange={(event) => setSearchDraft(event.target.value)}
               aria-label="Search deliverables"
             />
             <select


### PR DESCRIPTION
## Thinking Path

> - Bizbox is the control plane for autonomous AI companies, and the board UI is the operator surface for inspecting and managing company work.
> - The Deliverables page is part of the board work-product flow, where operators review artifacts produced by agents across issues.
> - That page relies on a search input backed by a React Query fetch keyed on the typed filter state.
> - In the current implementation, each keypress changes the query key immediately and the page falls back to a loading skeleton during the refetch.
> - Replacing the page content with a skeleton unmounts the focused search input, which interrupts typing and makes the filter feel broken.
> - This pull request keeps the search box mounted during filtering by debouncing the committed query value and retaining prior deliverable results while the next fetch is pending.
> - The benefit is that operators can type continuously in Deliverables without losing focus or context on every character.

## What Changed

- Debounced the Deliverables search input so draft typing does not immediately churn the server query key on every keystroke.
- Kept previous deliverable results visible while the next filtered fetch is pending instead of swapping the page back to a loading skeleton.
- Added a regression test that covers the pending-search case and verifies the search input stays mounted while the refetch is in flight.
- Updated the deliverables page test harness to use fake timers safely with the new debounce behavior.

## Verification

- `pnpm vitest run ui/src/pages/Deliverables.test.tsx`
- `pnpm -r typecheck`
- Manual check on `http://127.0.0.1:3100/CITAA/deliverables`: type continuously in `Search deliverables` and confirm focus remains in the input while results update.

## Risks

- Low risk. The change is isolated to the Deliverables page search state and its page-specific tests.
- Search requests now wait 250ms before committing the filter, which is intentional but slightly changes perceived timing.
- No API contract or schema behavior changed.

> Checked `ROADMAP.md`; this is a scoped UX bug fix in the existing deliverables surface, not overlapping roadmap-level core feature work.

## Model Used

- OpenAI Codex on GPT-5.5 with tool use and local code execution in the Codex desktop app.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
