### PR TITLE
Enhance timeout configurations and support delayed responses

### DIFF
--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -63,7 +63,7 @@ If `payloadTemplate.paperclip` is configured, the adapter strips it before sendi
 ## Timeouts
 
 - `timeoutSec` controls adapter-level request budget
-- `connectTimeoutMs` controls WebSocket open, connect challenge, and connect request handoff timeouts. Defaults to `min(timeoutSec * 1000, 60000)` when `timeoutSec` is set, otherwise `10000`.
+- `connectTimeoutMs` controls WebSocket open, connect challenge, and connect request handoff timeouts. Defaults to `min(timeoutSec * 1000, 15000)` when `timeoutSec` is set, otherwise `10000`.
 - `waitTimeoutMs` controls `agent.wait.timeoutMs`. Defaults to `timeoutSec * 1000` when `timeoutSec` is set, otherwise `30000`.
 - `agentAcceptTimeoutMs` controls how long Bizbox waits for the gateway `agent` request to be accepted. Defaults to `waitTimeoutMs + connectTimeoutMs`.
 

--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -63,7 +63,9 @@ If `payloadTemplate.paperclip` is configured, the adapter strips it before sendi
 ## Timeouts
 
 - `timeoutSec` controls adapter-level request budget
-- `waitTimeoutMs` controls `agent.wait.timeoutMs`
+- `connectTimeoutMs` controls WebSocket open, connect challenge, and connect request handoff timeouts. Defaults to `min(timeoutSec * 1000, 60000)` when `timeoutSec` is set, otherwise `10000`.
+- `waitTimeoutMs` controls `agent.wait.timeoutMs`. Defaults to `timeoutSec * 1000` when `timeoutSec` is set, otherwise `30000`.
+- `agentAcceptTimeoutMs` controls how long Bizbox waits for the gateway `agent` request to be accepted. Defaults to `waitTimeoutMs + connectTimeoutMs`.
 
 If `agent.wait` returns `timeout`, adapter returns `openclaw_gateway_wait_timeout`.
 

--- a/packages/adapters/openclaw-gateway/doc/ONBOARDING_AND_TEST_PLAN.md
+++ b/packages/adapters/openclaw-gateway/doc/ONBOARDING_AND_TEST_PLAN.md
@@ -42,7 +42,9 @@ Recommended fields:
 ```json
 {
   "paperclipApiUrl": "http://host.docker.internal:3100",
+  "connectTimeoutMs": 60000,
   "waitTimeoutMs": 120000,
+  "agentAcceptTimeoutMs": 180000,
   "sessionKeyStrategy": "issue",
   "role": "operator",
   "scopes": ["operator.admin", "operator.write"]

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -38,7 +38,7 @@ Request behavior fields:
 - payloadTemplate (object, optional): additional fields merged into gateway agent params
 - workspaceRuntime (object, optional): reserved workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
 - timeoutSec (number, optional): adapter timeout in seconds (default 120)
-- connectTimeoutMs (number, optional): websocket open, connect challenge, and connect request timeout override (default min(timeoutSec * 1000, 60000), or 10000 when timeoutSec is disabled)
+- connectTimeoutMs (number, optional): websocket open, connect challenge, and connect request timeout override (default min(timeoutSec * 1000, 15000), or 10000 when timeoutSec is disabled)
 - waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000, or 30000 when timeoutSec is disabled)
 - agentAcceptTimeoutMs (number, optional): gateway agent acceptance timeout override (default waitTimeoutMs + connectTimeoutMs)
 - autoPairOnFirstConnect (boolean, optional): on first "pairing required", attempt device.pair.list/device.pair.approve via shared auth, then retry once (default true when device auth is enabled)

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -38,7 +38,9 @@ Request behavior fields:
 - payloadTemplate (object, optional): additional fields merged into gateway agent params
 - workspaceRuntime (object, optional): reserved workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
 - timeoutSec (number, optional): adapter timeout in seconds (default 120)
-- waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000)
+- connectTimeoutMs (number, optional): websocket open, connect challenge, and connect request timeout override (default min(timeoutSec * 1000, 60000), or 10000 when timeoutSec is disabled)
+- waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000, or 30000 when timeoutSec is disabled)
+- agentAcceptTimeoutMs (number, optional): gateway agent acceptance timeout override (default waitTimeoutMs + connectTimeoutMs)
 - autoPairOnFirstConnect (boolean, optional): on first "pairing required", attempt device.pair.list/device.pair.approve via shared auth, then retry once (default true when device auth is enabled)
 - paperclipApiUrl (string, optional): absolute Paperclip base URL advertised in wake text
 - claimedApiKeyPath (string, optional): path to the claimed API key JSON file read by the agent at wake time (default ~/.openclaw/workspace/paperclip-claimed-api-key.json)

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1225,7 +1225,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const timeoutMs = timeoutSec > 0 ? timeoutSec * 1000 : 0;
   const connectTimeoutMs =
     parseOptionalPositiveInteger(parsedConfig.connectTimeoutMs) ??
-    (timeoutMs > 0 ? Math.min(timeoutMs, 60_000) : 10_000);
+    (timeoutMs > 0 ? Math.min(timeoutMs, 15_000) : 10_000);
   const waitTimeoutMs = parseOptionalPositiveInteger(parsedConfig.waitTimeoutMs) ?? (timeoutMs > 0 ? timeoutMs : 30_000);
   const agentAcceptTimeoutMs = parseOptionalPositiveInteger(parsedConfig.agentAcceptTimeoutMs) ?? waitTimeoutMs + connectTimeoutMs;
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1223,8 +1223,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const parsedConfig = parseObject(ctx.config);
   const timeoutSec = Math.max(0, Math.floor(asNumber(parsedConfig.timeoutSec, 120)));
   const timeoutMs = timeoutSec > 0 ? timeoutSec * 1000 : 0;
-  const connectTimeoutMs = timeoutMs > 0 ? Math.min(timeoutMs, 15_000) : 10_000;
+  const connectTimeoutMs =
+    parseOptionalPositiveInteger(parsedConfig.connectTimeoutMs) ??
+    (timeoutMs > 0 ? Math.min(timeoutMs, 60_000) : 10_000);
   const waitTimeoutMs = parseOptionalPositiveInteger(parsedConfig.waitTimeoutMs) ?? (timeoutMs > 0 ? timeoutMs : 30_000);
+  const agentAcceptTimeoutMs = parseOptionalPositiveInteger(parsedConfig.agentAcceptTimeoutMs) ?? waitTimeoutMs + connectTimeoutMs;
 
   const payloadTemplate = parseObject(parsedConfig.payloadTemplate);
   const artifactOutputs = parseArtifactOutputsConfig(parsedConfig.artifactOutputs);
@@ -1474,7 +1477,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
 
       const acceptedPayload = await client.request<Record<string, unknown>>("agent", agentParams, {
-        timeoutMs: connectTimeoutMs,
+        timeoutMs: agentAcceptTimeoutMs,
       });
 
       latestResultPayload = acceptedPayload;

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -530,7 +530,7 @@ describe("openclaw gateway adapter execute", () => {
     }
   });
 
-  it("allows delayed agent acceptance within the run wait budget", async () => {
+  it("allows delayed agent acceptance within the agent accept budget", async () => {
     const gateway = await createMockGatewayServer({
       agentResponseDelayMs: 1_250,
     });
@@ -550,6 +550,33 @@ describe("openclaw gateway adapter execute", () => {
       expect(result.exitCode).toBe(0);
       expect(result.timedOut).toBe(false);
       expect(gateway.getAgentPayload()?.timeout).toBe(2_000);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("times out delayed agent acceptance beyond the agent accept budget", async () => {
+    const gateway = await createMockGatewayServer({
+      agentResponseDelayMs: 250,
+    });
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          connectTimeoutMs: 1_000,
+          waitTimeoutMs: 2_000,
+          agentAcceptTimeoutMs: 50,
+        }),
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.timedOut).toBe(true);
+      expect(result.errorCode).toBe("openclaw_gateway_timeout");
+      expect(result.errorMessage).toBe("gateway request timeout (agent)");
     } finally {
       await gateway.close();
     }

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -61,6 +61,8 @@ async function createMockGatewayServer(options?: {
   artifactListPayload?: Record<string, unknown> | unknown[];
   artifactDownloads?: Record<string, Record<string, unknown>>;
   assistantEvents?: Array<Record<string, unknown>>;
+  connectResponseDelayMs?: number;
+  agentResponseDelayMs?: number;
 }) {
   const server = createServer();
   const wss = new WebSocketServer({ server });
@@ -90,21 +92,29 @@ async function createMockGatewayServer(options?: {
 
       if (frame.method === "connect") {
         connectScopes = frame.params?.scopes ?? null;
-        socket.send(
-          JSON.stringify({
-            type: "res",
-            id: frame.id,
-            ok: true,
-            payload: {
-              type: "hello-ok",
-              protocol: 3,
-              server: { version: "test", connId: "conn-1" },
-              features: { methods: ["connect", "agent", "agent.wait"], events: ["agent"] },
-              snapshot: { version: 1, ts: Date.now() },
-              policy: { maxPayload: 1_000_000, maxBufferedBytes: 1_000_000, tickIntervalMs: 30_000 },
-            },
-          }),
-        );
+        const sendConnectResponse = () => {
+          socket.send(
+            JSON.stringify({
+              type: "res",
+              id: frame.id,
+              ok: true,
+              payload: {
+                type: "hello-ok",
+                protocol: 3,
+                server: { version: "test", connId: "conn-1" },
+                features: { methods: ["connect", "agent", "agent.wait"], events: ["agent"] },
+                snapshot: { version: 1, ts: Date.now() },
+                policy: { maxPayload: 1_000_000, maxBufferedBytes: 1_000_000, tickIntervalMs: 30_000 },
+              },
+            }),
+          );
+        };
+        const delayMs = options?.connectResponseDelayMs ?? 0;
+        if (delayMs > 0) {
+          setTimeout(sendConnectResponse, delayMs);
+        } else {
+          sendConnectResponse();
+        }
         return;
       }
 
@@ -119,34 +129,43 @@ async function createMockGatewayServer(options?: {
           { delta: "chacha" },
         ];
 
-        socket.send(
-          JSON.stringify({
-            type: "res",
-            id: frame.id,
-            ok: true,
-            payload: {
-              runId,
-              status: "accepted",
-              acceptedAt: Date.now(),
-            },
-          }),
-        );
-
-        assistantEvents.forEach((data, index) => {
+        const sendAgentResponse = () => {
           socket.send(
             JSON.stringify({
-              type: "event",
-              event: "agent",
+              type: "res",
+              id: frame.id,
+              ok: true,
               payload: {
                 runId,
-                seq: index + 1,
-                stream: "assistant",
-                ts: Date.now(),
-                data,
+                status: "accepted",
+                acceptedAt: Date.now(),
               },
             }),
           );
-        });
+
+          assistantEvents.forEach((data, index) => {
+            socket.send(
+              JSON.stringify({
+                type: "event",
+                event: "agent",
+                payload: {
+                  runId,
+                  seq: index + 1,
+                  stream: "assistant",
+                  ts: Date.now(),
+                  data,
+                },
+              }),
+            );
+          });
+        };
+
+        const delayMs = options?.agentResponseDelayMs ?? 0;
+        if (delayMs > 0) {
+          setTimeout(sendAgentResponse, delayMs);
+        } else {
+          sendAgentResponse();
+        }
         return;
       }
 
@@ -506,6 +525,57 @@ describe("openclaw gateway adapter execute", () => {
       );
 
       expect(result.summary).toBe("I'm ready. What would you like to do?");
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("allows delayed agent acceptance within the run wait budget", async () => {
+    const gateway = await createMockGatewayServer({
+      agentResponseDelayMs: 1_250,
+    });
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          timeoutSec: 1,
+          waitTimeoutMs: 2_000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.timedOut).toBe(false);
+      expect(gateway.getAgentPayload()?.timeout).toBe(2_000);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("allows delayed gateway connect responses within the configured connect budget", async () => {
+    const gateway = await createMockGatewayServer({
+      connectResponseDelayMs: 1_250,
+    });
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          timeoutSec: 1,
+          connectTimeoutMs: 2_000,
+          waitTimeoutMs: 2_000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.timedOut).toBe(false);
+      expect(gateway.getConnectScopes()).toEqual(["operator.admin", "operator.write"]);
     } finally {
       await gateway.close();
     }

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1576,7 +1576,7 @@ function buildInviteOnboardingManifest(
         adapterType: "Use 'openclaw_gateway' for OpenClaw Gateway agents",
         capabilities: "Optional capability summary",
         agentDefaultsPayload:
-          "Adapter config for OpenClaw gateway. MUST include url (ws:// or wss://) and headers.x-openclaw-token (or legacy x-openclaw-auth). The standard cloud-first setup should set disableDeviceAuth=true. Optional fields: paperclipApiUrl, waitTimeoutMs, sessionKeyStrategy, sessionKey, role, scopes, devicePrivateKeyPem."
+          "Adapter config for OpenClaw gateway. MUST include url (ws:// or wss://) and headers.x-openclaw-token (or legacy x-openclaw-auth). The standard cloud-first setup should set disableDeviceAuth=true. Optional fields: paperclipApiUrl, connectTimeoutMs, waitTimeoutMs, agentAcceptTimeoutMs, sessionKeyStrategy, sessionKey, role, scopes, devicePrivateKeyPem."
       },
       registrationEndpoint: {
         method: "POST",


### PR DESCRIPTION
This pull request enhances the OpenClaw Gateway adapter's timeout configuration and improves test coverage for connection and agent acceptance timing. The main updates introduce a new `agentAcceptTimeoutMs` option, clarify and adjust the default behaviors for timeouts, and add more robust test scenarios for delayed responses.

**Timeout Configuration Improvements:**

* Added a new `agentAcceptTimeoutMs` configuration option, which controls how long the gateway waits for the agent to accept a request. The default is now `waitTimeoutMs + connectTimeoutMs`. [[1]](diffhunk://#diff-138b20e98afa356c435d3d3f1de91c7193f6601df9db0f24924788d27179be39L1226-R1230) [[2]](diffhunk://#diff-9482b076709e257fd36006c72382229ca70ceed3d91af0bddea42ad5a837898aL66-R68) [[3]](diffhunk://#diff-753b974222ad0e09ae5471ca65054c5a8844bc209361cc0bff7596a321d6d90fL41-R43) [[4]](diffhunk://#diff-8a2d3504e60fe62d635c3787b048718f4b2bda1a6dff6036282a7c1799834dc2R45-R47) [[5]](diffhunk://#diff-dcfb7c5501d409f4e4bcff82afdffecc5722c344eb0deb16dd17451cb8697935L1579-R1579)
* Clarified and improved the default values for `connectTimeoutMs` and `waitTimeoutMs` in both the documentation and implementation. [[1]](diffhunk://#diff-9482b076709e257fd36006c72382229ca70ceed3d91af0bddea42ad5a837898aL66-R68) [[2]](diffhunk://#diff-753b974222ad0e09ae5471ca65054c5a8844bc209361cc0bff7596a321d6d90fL41-R43) [[3]](diffhunk://#diff-138b20e98afa356c435d3d3f1de91c7193f6601df9db0f24924788d27179be39L1226-R1230)
* Updated the onboarding documentation and API manifest to reflect the new and changed timeout options. [[1]](diffhunk://#diff-8a2d3504e60fe62d635c3787b048718f4b2bda1a6dff6036282a7c1799834dc2R45-R47) [[2]](diffhunk://#diff-dcfb7c5501d409f4e4bcff82afdffecc5722c344eb0deb16dd17451cb8697935L1579-R1579)

**Behavioral and Test Enhancements:**

* Changed the `agent` request timeout in the server implementation to use `agentAcceptTimeoutMs` instead of `connectTimeoutMs`, ensuring acceptance timeouts are handled separately from connection timeouts.
* Improved test utilities to allow simulation of delayed responses for both connection and agent acceptance, and added tests to verify correct handling of these scenarios within the configured timeout budgets. [[1]](diffhunk://#diff-31bf96ef921d8f282fd98a2ee302e11a661636f2ba6388a578a46ddccbe7f550R64-R65) [[2]](diffhunk://#diff-31bf96ef921d8f282fd98a2ee302e11a661636f2ba6388a578a46ddccbe7f550R95) [[3]](diffhunk://#diff-31bf96ef921d8f282fd98a2ee302e11a661636f2ba6388a578a46ddccbe7f550R111-R117) [[4]](diffhunk://#diff-31bf96ef921d8f282fd98a2ee302e11a661636f2ba6388a578a46ddccbe7f550R132) [[5]](diffhunk://#diff-31bf96ef921d8f282fd98a2ee302e11a661636f2ba6388a578a46ddccbe7f550R161-R168) [[6]](diffhunk://#diff-31bf96ef921d8f282fd98a2ee302e11a661636f2ba6388a578a46ddccbe7f550R533-R583)