### PR TITLE
Implement awaiting human notification outbox and processing logic

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -107,6 +107,7 @@ A lightweight scheduler/worker in the server process handles:
 - heartbeat trigger checks
 - stuck run detection
 - budget threshold checks
+- retryable awaiting-human ClickUp notification delivery
 
 Separate queue infrastructure is not required for V1.
 
@@ -354,6 +355,7 @@ Operational policy:
 - `issue_attachments(company_id, issue_id)`
 - `company_secrets(company_id, name)` unique
 - `company_secret_versions(secret_id, version)` unique
+- `awaiting_human_notification_outbox(company_id, issue_id, dedupe_key)` unique
 
 ## 7.14 `assets` + `issue_attachments`
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -102,6 +102,14 @@ translates it into acceptance of the matching pending
 `request_confirmation` interaction, then resumes work through the normal
 interaction-resolution wake path.
 
+If an `awaiting_human` handoff has a human-facing deliverable, Bizbox
+queues the ClickUp notification in an outbox. The worker creates/reuses a
+ClickUp review task, uploads the deliverable to that task when
+`CLICKUP_AWAITING_HUMAN_REVIEW_LIST_ID` is configured, and posts the chat
+handoff with both the Bizbox deliverable link and ClickUp review task link.
+ClickUp Chat is not treated as a durable file host because its public API
+does not provide a documented chat-message attachment upload field.
+
 ### `in_review`
 
 Execution work is paused because the next move belongs to a reviewer or approver, not the current executor.

--- a/packages/db/src/migrations/0074_awaiting_human_notification_outbox.sql
+++ b/packages/db/src/migrations/0074_awaiting_human_notification_outbox.sql
@@ -1,0 +1,30 @@
+CREATE TABLE "awaiting_human_notification_outbox" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL,
+  "issue_id" uuid NOT NULL,
+  "dedupe_key" text NOT NULL,
+  "handoff_kind" text NOT NULL,
+  "status" text DEFAULT 'pending' NOT NULL,
+  "attempts" integer DEFAULT 0 NOT NULL,
+  "next_attempt_at" timestamp with time zone,
+  "notification" jsonb DEFAULT '{}'::jsonb NOT NULL,
+  "review_file" jsonb,
+  "clickup_task_id" text,
+  "clickup_task_url" text,
+  "clickup_attachment_id" text,
+  "clickup_attachment_url" text,
+  "clickup_message_id" text,
+  "last_error" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "awaiting_human_notification_outbox" ADD CONSTRAINT "awaiting_human_notification_outbox_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "awaiting_human_notification_outbox" ADD CONSTRAINT "awaiting_human_notification_outbox_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "awaiting_human_notification_outbox_company_status_idx" ON "awaiting_human_notification_outbox" USING btree ("company_id","status","next_attempt_at");
+--> statement-breakpoint
+CREATE INDEX "awaiting_human_notification_outbox_issue_idx" ON "awaiting_human_notification_outbox" USING btree ("issue_id","created_at");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "awaiting_human_notification_outbox_dedupe_uq" ON "awaiting_human_notification_outbox" USING btree ("company_id","issue_id","dedupe_key");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1778600000000,
       "tag": "0073_clickup_bridge",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1778841600000,
+      "tag": "0074_awaiting_human_notification_outbox",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/awaiting_human_notification_outbox.ts
+++ b/packages/db/src/schema/awaiting_human_notification_outbox.ts
@@ -1,0 +1,43 @@
+import { pgTable, uuid, text, timestamp, integer, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { issues } from "./issues.js";
+
+export const awaitingHumanNotificationOutbox = pgTable(
+  "awaiting_human_notification_outbox",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id),
+    issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
+    dedupeKey: text("dedupe_key").notNull(),
+    handoffKind: text("handoff_kind").notNull().$type<"request_confirmation" | "ask_user_questions" | "human_owned_blocker">(),
+    status: text("status")
+      .notNull()
+      .$type<"pending" | "processing" | "sent" | "failed" | "partial_failed" | "skipped">()
+      .default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    nextAttemptAt: timestamp("next_attempt_at", { withTimezone: true }),
+    notification: jsonb("notification").$type<Record<string, unknown>>().notNull().default({}),
+    reviewFile: jsonb("review_file").$type<Record<string, unknown>>(),
+    clickupTaskId: text("clickup_task_id"),
+    clickupTaskUrl: text("clickup_task_url"),
+    clickupAttachmentId: text("clickup_attachment_id"),
+    clickupAttachmentUrl: text("clickup_attachment_url"),
+    clickupMessageId: text("clickup_message_id"),
+    lastError: text("last_error"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyStatusIdx: index("awaiting_human_notification_outbox_company_status_idx").on(
+      table.companyId,
+      table.status,
+      table.nextAttemptAt,
+    ),
+    issueIdx: index("awaiting_human_notification_outbox_issue_idx").on(table.issueId, table.createdAt),
+    dedupeUq: uniqueIndex("awaiting_human_notification_outbox_dedupe_uq").on(
+      table.companyId,
+      table.issueId,
+      table.dedupeKey,
+    ),
+  }),
+);

--- a/packages/db/src/schema/awaiting_human_notification_outbox.ts
+++ b/packages/db/src/schema/awaiting_human_notification_outbox.ts
@@ -12,7 +12,7 @@ export const awaitingHumanNotificationOutbox = pgTable(
     handoffKind: text("handoff_kind").notNull().$type<"request_confirmation" | "ask_user_questions" | "human_owned_blocker">(),
     status: text("status")
       .notNull()
-      .$type<"pending" | "processing" | "sent" | "failed" | "partial_failed" | "skipped">()
+      .$type<"pending" | "processing" | "retrying" | "sent" | "failed" | "partial_failed" | "skipped">()
       .default("pending"),
     attempts: integer("attempts").notNull().default(0),
     nextAttemptAt: timestamp("next_attempt_at", { withTimezone: true }),

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -54,6 +54,7 @@ export { documentRevisions } from "./document_revisions.js";
 export { issueDocuments } from "./issue_documents.js";
 export { clickupBridges } from "./clickup_bridges.js";
 export { clickupOutboundEvents } from "./clickup_outbound_events.js";
+export { awaitingHumanNotificationOutbox } from "./awaiting_human_notification_outbox.js";
 export { heartbeatRuns } from "./heartbeat_runs.js";
 export { heartbeatRunEvents } from "./heartbeat_run_events.js";
 export { costEvents } from "./cost_events.js";

--- a/server/src/__tests__/awaiting-human-handoff.test.ts
+++ b/server/src/__tests__/awaiting-human-handoff.test.ts
@@ -6,16 +6,15 @@ vi.mock("../services/activity-log.js", () => ({
 }));
 
 vi.mock("../services/awaiting-human-notifications.js", () => ({
-  sendAwaitingHumanNotification: vi.fn().mockResolvedValue({
-    status: "sent",
+  enqueueAwaitingHumanNotification: vi.fn().mockResolvedValue({
+    status: "enqueued",
     channel: "clickup-chat",
-    detail: "sent",
-    externalId: "msg_123",
+    detail: "enqueued",
   }),
 }));
 
 const { logActivity } = await import("../services/activity-log.js");
-const { sendAwaitingHumanNotification } = await import("../services/awaiting-human-notifications.js");
+const { enqueueAwaitingHumanNotification } = await import("../services/awaiting-human-notifications.js");
 const { maybeLogAwaitingHumanHandoff } = await import("../services/awaiting-human-handoff.js");
 
 const basePreviousIssue = {
@@ -85,10 +84,12 @@ describe("maybeLogAwaitingHumanHandoff", () => {
     });
 
     expect(created).toBe(true);
-    expect(sendAwaitingHumanNotification).toHaveBeenCalledWith(
+    expect(enqueueAwaitingHumanNotification).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         companyId: "company-1",
         issueId: "issue-1",
+        dedupeKey: "interaction:interaction-1",
         handoffKind: "request_confirmation",
         notification: expect.objectContaining({
           link: "https://bizbox.example/issues/BIZ-35",
@@ -122,7 +123,8 @@ describe("maybeLogAwaitingHumanHandoff", () => {
     });
 
     expect(created).toBe(true);
-    expect(sendAwaitingHumanNotification).toHaveBeenCalledWith(
+    expect(enqueueAwaitingHumanNotification).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         handoffKind: "ask_user_questions",
         notification: expect.objectContaining({
@@ -151,7 +153,8 @@ describe("maybeLogAwaitingHumanHandoff", () => {
     });
 
     expect(created).toBe(true);
-    expect(sendAwaitingHumanNotification).toHaveBeenCalledWith(
+    expect(enqueueAwaitingHumanNotification).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         handoffKind: "human_owned_blocker",
         notification: expect.objectContaining({
@@ -187,12 +190,12 @@ describe("maybeLogAwaitingHumanHandoff", () => {
     });
 
     expect(created).toBe(false);
-    expect(sendAwaitingHumanNotification).not.toHaveBeenCalled();
+    expect(enqueueAwaitingHumanNotification).not.toHaveBeenCalled();
     expect(logActivity).not.toHaveBeenCalled();
   });
 
   it("retries delivery when the issue is still awaiting_human but no dedupe marker was logged", async () => {
-    vi.mocked(sendAwaitingHumanNotification)
+    vi.mocked(enqueueAwaitingHumanNotification)
       .mockResolvedValueOnce({
         status: "failed",
         channel: "clickup-chat",
@@ -245,11 +248,11 @@ describe("maybeLogAwaitingHumanHandoff", () => {
 
     expect(first).toBe(false);
     expect(second).toBe(true);
-    expect(sendAwaitingHumanNotification).toHaveBeenCalledTimes(2);
+    expect(enqueueAwaitingHumanNotification).toHaveBeenCalledTimes(2);
   });
 
   it("retries after a skipped delivery once notification config is restored", async () => {
-    vi.mocked(sendAwaitingHumanNotification)
+    vi.mocked(enqueueAwaitingHumanNotification)
       .mockResolvedValueOnce({
         status: "skipped",
         channel: "clickup-chat",
@@ -302,7 +305,7 @@ describe("maybeLogAwaitingHumanHandoff", () => {
 
     expect(first).toBe(false);
     expect(second).toBe(true);
-    expect(sendAwaitingHumanNotification).toHaveBeenCalledTimes(2);
+    expect(enqueueAwaitingHumanNotification).toHaveBeenCalledTimes(2);
   });
 
   it("does not suppress a new blocker cycle from an old-cycle dedupe log", async () => {
@@ -337,6 +340,6 @@ describe("maybeLogAwaitingHumanHandoff", () => {
     });
 
     expect(created).toBe(true);
-    expect(sendAwaitingHumanNotification).toHaveBeenCalledTimes(1);
+    expect(enqueueAwaitingHumanNotification).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/src/__tests__/awaiting-human-notifications.test.ts
+++ b/server/src/__tests__/awaiting-human-notifications.test.ts
@@ -1,12 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Db } from "@paperclipai/db";
 import {
   detectClickUpAwaitingHumanApproval,
   getClickUpChatMessageReactions,
   getClickUpChatMessageReplies,
+  resolveAwaitingHumanReviewFile,
   sendAwaitingHumanNotification,
 } from "../services/awaiting-human-notifications.js";
 
 const originalFetch = globalThis.fetch;
+
+function dbWithExecuteResults(results: unknown[][]): Db {
+  const queue = [...results];
+  return {
+    execute: vi.fn(async () => queue.shift() ?? []),
+  } as unknown as Db;
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -15,6 +24,7 @@ afterEach(() => {
   delete process.env.CLICKUP_WORKSPACE_ID;
   delete process.env.CLICKUP_ENGINEERING_CHANNEL_ID;
   delete process.env.CLICKUP_ENGINEERING_CHANNEL_NAME;
+  delete process.env.CLICKUP_AWAITING_HUMAN_REVIEW_LIST_ID;
   delete process.env.CLICKUP_APPROVAL_POSITIVE_REACTIONS;
   delete process.env.CLICKUP_APPROVAL_POSITIVE_REPLY_KEYWORDS;
 });
@@ -66,6 +76,51 @@ describe("sendAwaitingHumanNotification", () => {
       content_format: "text/md",
       content: expect.stringContaining("Source: https://bizbox.example/issues/BIZ-35"),
     });
+  });
+
+  it("includes the Bizbox deliverable and ClickUp review task when a review file is present", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+    process.env.CLICKUP_ENGINEERING_CHANNEL_ID = "channel-9";
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: "message-42" } }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotification({
+      companyId: "company-1",
+      issueId: "issue-1",
+      handoffKind: "request_confirmation",
+      notification: {
+        title: "BIZ-35 is waiting on human input",
+        summary: "Please review the attached final report.",
+        link: "https://bizbox.example/issues/BIZ-35",
+        cta: "Open BIZ-35 in Bizbox and respond there.",
+        labels: ["awaiting_human", "request_confirmation"],
+        reviewFile: {
+          source: "artifact",
+          deliverableId: "33333333-3333-4333-8333-333333333333",
+          title: "Final report",
+          filename: "final-report.md",
+          contentType: "text/markdown",
+          byteSize: 42,
+          contentPath: "/api/attachments/33333333-3333-4333-8333-333333333333/content",
+          deliverableUrl: "https://bizbox.example/api/attachments/33333333-3333-4333-8333-333333333333/content",
+          clickupTaskUrl: "https://app.clickup.com/t/task-123",
+          clickupAttachmentId: "attachment-123",
+        },
+      },
+    });
+
+    expect(result.status).toBe("sent");
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.content).toContain("Review file: final-report.md");
+    expect(body.content).toContain("Bizbox deliverable: https://bizbox.example/api/attachments/33333333-3333-4333-8333-333333333333/content");
+    expect(body.content).toContain("ClickUp review task: https://app.clickup.com/t/task-123");
+    expect(body.content).toContain("Review file attached on the ClickUp task.");
   });
 
   it("resolves the ClickUp channel id by channel name when no channel id is configured", async () => {
@@ -561,5 +616,73 @@ describe("sendAwaitingHumanNotification", () => {
       status: "no_approval",
       detail: "no-approval-signal",
     });
+  });
+});
+
+describe("resolveAwaitingHumanReviewFile", () => {
+  it("prefers a human artifact deliverable", async () => {
+    const db = dbWithExecuteResults([[
+      {
+        deliverable_id: "33333333-3333-4333-8333-333333333333",
+        title: "Final report",
+        content_path: "/api/attachments/33333333-3333-4333-8333-333333333333/content",
+        content_type: "text/markdown",
+        byte_size: 42,
+        original_filename: "final-report.md",
+        attachment_id: "33333333-3333-4333-8333-333333333333",
+        object_key: "companies/company-1/issues/issue-1/final-report.md",
+        sha256: "abc123",
+      },
+    ]]);
+
+    const file = await resolveAwaitingHumanReviewFile(db, {
+      companyId: "company-1",
+      issueId: "issue-1",
+      sourceLink: "https://bizbox.example/issues/BIZ-35",
+    });
+
+    expect(file).toMatchObject({
+      source: "artifact",
+      filename: "final-report.md",
+      deliverableUrl: "https://bizbox.example/api/attachments/33333333-3333-4333-8333-333333333333/content",
+      objectKey: "companies/company-1/issues/issue-1/final-report.md",
+      sha256: "abc123",
+    });
+  });
+
+  it("falls back to a human deliverable document", async () => {
+    const db = dbWithExecuteResults([
+      [],
+      [{
+        deliverable_id: "44444444-4444-4444-8444-444444444444",
+        key: "review-notes",
+        title: "Review notes",
+        format: "markdown",
+        byte_size: 12,
+      }],
+    ]);
+
+    const file = await resolveAwaitingHumanReviewFile(db, {
+      companyId: "company-1",
+      issueId: "issue-1",
+      sourceLink: "https://bizbox.example/issues/BIZ-35",
+    });
+
+    expect(file).toMatchObject({
+      source: "document",
+      filename: "review-notes.md",
+      contentType: "text/markdown; charset=utf-8",
+      deliverableUrl: "https://bizbox.example/api/deliverables/44444444-4444-4444-8444-444444444444/content",
+    });
+  });
+
+  it("returns null when no review deliverable exists", async () => {
+    const db = dbWithExecuteResults([[], []]);
+
+    await expect(resolveAwaitingHumanReviewFile(db, {
+      companyId: "company-1",
+      issueId: "issue-1",
+      sourceLink: "https://bizbox.example/issues/BIZ-35",
+    })).resolves.toBeNull();
   });
 });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -81,6 +81,7 @@ vi.mock("../adapters/index.ts", async () => {
 import { heartbeatService } from "../services/heartbeat.ts";
 import { issueService } from "../services/issues.ts";
 import * as documentsModule from "../services/documents.ts";
+import { recordComment } from "../otel.ts";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
@@ -862,6 +863,14 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("retried continuation");
+    expect(comments[0]?.source).toBe("native");
+    expect(recordComment).toHaveBeenCalledWith(expect.objectContaining({
+      company_id: blockedIssue?.companyId,
+      issue_status: "in_progress",
+      actor_type: "system",
+      commenter_id: continuationRun?.id,
+      assignee_agent_id: agentId,
+    }));
   });
 
   it("schedules a bounded retry for codex transient upstream failures instead of blocking the issue immediately", async () => {

--- a/server/src/services/awaiting-human-handoff.ts
+++ b/server/src/services/awaiting-human-handoff.ts
@@ -6,7 +6,7 @@ import type {
   RequestConfirmationInteraction,
 } from "@paperclipai/shared";
 import {
-  sendAwaitingHumanNotification,
+  enqueueAwaitingHumanNotification,
   type AwaitingHumanNotificationPayload,
 } from "./awaiting-human-notifications.js";
 import { logActivity } from "./activity-log.js";
@@ -254,14 +254,15 @@ export async function maybeLogAwaitingHumanHandoff(
     });
   }
 
-  const delivery = await sendAwaitingHumanNotification({
+  const delivery = await enqueueAwaitingHumanNotification(db, {
     companyId: input.updatedIssue.companyId,
     issueId: input.updatedIssue.id,
+    dedupeKey,
     handoffKind: input.handoffKind,
     notification,
   });
 
-  if (delivery.status !== "sent") {
+  if (delivery.status !== "sent" && delivery.status !== "enqueued") {
     logger.warn(
       {
         companyId: input.updatedIssue.companyId,
@@ -301,7 +302,7 @@ export async function maybeLogAwaitingHumanHandoff(
       interactionKind: input.interaction?.kind ?? null,
       blockerIssueId: firstBlocker?.id ?? null,
       blockerIdentifier: firstBlocker?.identifier ?? null,
-      dedupeKey: delivery.status === "sent" ? dedupeKey : null,
+      dedupeKey: delivery.status === "sent" || delivery.status === "enqueued" ? dedupeKey : null,
       notification,
       notificationDelivery: {
         status: delivery.status,
@@ -312,5 +313,5 @@ export async function maybeLogAwaitingHumanHandoff(
     },
   });
 
-  return delivery.status === "sent";
+  return delivery.status === "sent" || delivery.status === "enqueued";
 }

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -16,6 +16,7 @@ const CLICKUP_CHANNEL_LOOKUP_PAGE_SIZE = 100;
 const MAX_OUTBOX_ATTEMPTS = 8;
 const STALE_OUTBOX_PROCESSING_MS = 5 * 60 * 1000;
 const DEFAULT_CLICKUP_TIMEOUT_SEC = 30;
+const CLICKUP_ATTACHMENT_FILE_FIELD = "attachment[0]";
 const DEFAULT_CLICKUP_APPROVAL_POSITIVE_REACTIONS = ["thumbsup", "white_check_mark", "heavy_check_mark"] as const;
 const DEFAULT_CLICKUP_APPROVAL_POSITIVE_REPLY_KEYWORDS = [
   "approve",
@@ -816,7 +817,12 @@ async function uploadClickUpReviewFile(
   body: Buffer,
 ) {
   const form = new FormData();
-  form.append("attachment[0]", new Blob([new Uint8Array(body)], { type: reviewFile.contentType }), reviewFile.filename);
+  form.append(
+    CLICKUP_ATTACHMENT_FILE_FIELD,
+    new Blob([new Uint8Array(body)], { type: reviewFile.contentType }),
+    reviewFile.filename,
+  );
+  form.append("filename", reviewFile.filename);
   const response = await fetchText(
     `https://api.clickup.com/api/v3/workspaces/${encodeURIComponent(config.workspaceId)}/attachments/${encodeURIComponent(taskId)}/attachments`,
     {
@@ -831,10 +837,14 @@ async function uploadClickUpReviewFile(
     throw new Error(`clickup review file upload failed:${response.status}:${truncateText(response.text, 240)}`);
   }
   const payload = response.text.trim().length > 0 ? JSON.parse(response.text) : {};
-  const attachment = findFirstAttachmentLike(payload) ?? {};
+  const attachment = findFirstAttachmentLike(payload);
+  const attachmentId = readString(attachment?.id);
+  if (!attachmentId) {
+    throw new Error(`clickup review file upload response missing attachment id:${truncateText(response.text, 240)}`);
+  }
   return {
-    attachmentId: readString(attachment.id),
-    attachmentUrl: readString(attachment.url) ?? readString(attachment.url_w_query),
+    attachmentId,
+    attachmentUrl: readString(attachment?.url) ?? readString(attachment?.url_w_query),
   };
 }
 
@@ -886,6 +896,7 @@ export async function processAwaitingHumanNotificationOutbox(
         ),
       ),
     )
+    .orderBy(awaitingHumanNotificationOutbox.nextAttemptAt, awaitingHumanNotificationOutbox.createdAt)
     .limit(limit);
 
   let processed = 0;
@@ -906,16 +917,18 @@ export async function processAwaitingHumanNotificationOutbox(
     if (!claimed) continue;
     processed += 1;
 
+    let clickupTaskId = row.clickupTaskId;
+    let clickupTaskUrl = row.clickupTaskUrl;
+    let clickupAttachmentId = row.clickupAttachmentId;
+    let clickupAttachmentUrl = row.clickupAttachmentUrl;
+    let clickupMessageId = row.clickupMessageId;
+
     try {
       const config = readClickUpChatConfig();
       if (!config.personalToken) throw new Error("missing-credential: CLICKUP_PERSONAL_TOKEN");
       if (!config.workspaceId) throw new Error("missing-target: CLICKUP_WORKSPACE_ID");
 
       const reviewFile = normalizeReviewFile(row.reviewFile);
-      let clickupTaskId = row.clickupTaskId;
-      let clickupTaskUrl = row.clickupTaskUrl;
-      let clickupAttachmentId = row.clickupAttachmentId;
-      let clickupAttachmentUrl = row.clickupAttachmentUrl;
       let deliveryNote: string | null = null;
       let uploadError: Error | null = null;
 
@@ -934,7 +947,7 @@ export async function processAwaitingHumanNotificationOutbox(
           try {
             const file = await readReviewFileBody(db, storage, row.companyId, reviewFile);
             const upload = await uploadClickUpReviewFile(config, clickupTaskId, reviewFile, file.body);
-            clickupAttachmentId = upload.attachmentId ?? file.sha256;
+            clickupAttachmentId = upload.attachmentId;
             clickupAttachmentUrl = upload.attachmentUrl;
             await db
               .update(awaitingHumanNotificationOutbox)
@@ -948,7 +961,6 @@ export async function processAwaitingHumanNotificationOutbox(
         deliveryNote = "skipped_upload: missing CLICKUP_AWAITING_HUMAN_REVIEW_LIST_ID";
       }
 
-      let clickupMessageId = row.clickupMessageId;
       if (!clickupMessageId) {
         const message = await sendAwaitingHumanNotification({
           companyId: row.companyId,
@@ -1010,8 +1022,13 @@ export async function processAwaitingHumanNotificationOutbox(
       await db
         .update(awaitingHumanNotificationOutbox)
         .set({
-          status: terminal ? "failed" : row.clickupMessageId ? "partial_failed" : "failed",
+          status: terminal ? "failed" : clickupMessageId ? "partial_failed" : "failed",
           attempts,
+          clickupTaskId,
+          clickupTaskUrl,
+          clickupAttachmentId,
+          clickupAttachmentUrl,
+          clickupMessageId,
           lastError: error instanceof Error ? error.message : String(error),
           nextAttemptAt: terminal ? null : nextRetryAt(attempts),
           updatedAt: new Date(),

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -913,7 +913,7 @@ export async function processAwaitingHumanNotificationOutbox(
         ),
       ),
     )
-    .orderBy(awaitingHumanNotificationOutbox.nextAttemptAt, awaitingHumanNotificationOutbox.createdAt)
+    .orderBy(sql`${awaitingHumanNotificationOutbox.nextAttemptAt} ASC NULLS FIRST`, awaitingHumanNotificationOutbox.createdAt)
     .limit(limit);
 
   let processed = 0;
@@ -998,10 +998,39 @@ export async function processAwaitingHumanNotificationOutbox(
 
       if (uploadError) {
         const attempts = row.attempts + 1;
+        const isPermanentFailure = attempts >= MAX_OUTBOX_ATTEMPTS;
+
+        // On the final attempt, if the chat message was never sent, deliver it
+        // without the attachment so the human is still notified about the review task.
+        if (isPermanentFailure && !clickupMessageId) {
+          try {
+            const message = await sendAwaitingHumanNotification({
+              companyId: row.companyId,
+              issueId: row.issueId,
+              handoffKind: row.handoffKind,
+              notification: withClickUpTaskUrl(
+                row.notification as unknown as AwaitingHumanNotificationPayload,
+                null, // omit file link — attachment upload failed
+                clickupTaskUrl,
+                null,
+              ),
+            });
+            if (message.status === "sent") {
+              clickupMessageId = message.externalId ?? null;
+              await db
+                .update(awaitingHumanNotificationOutbox)
+                .set({ clickupMessageId, updatedAt: new Date() })
+                .where(eq(awaitingHumanNotificationOutbox.id, row.id));
+            }
+          } catch {
+            // Best-effort fallback; original uploadError still drives the final status.
+          }
+        }
+
         await db
           .update(awaitingHumanNotificationOutbox)
           .set({
-            status: attempts >= MAX_OUTBOX_ATTEMPTS ? "failed" : "partial_failed",
+            status: isPermanentFailure ? "failed" : "partial_failed",
             attempts,
             clickupTaskId,
             clickupTaskUrl,
@@ -1009,7 +1038,7 @@ export async function processAwaitingHumanNotificationOutbox(
             clickupAttachmentUrl,
             clickupMessageId,
             lastError: uploadError.message,
-            nextAttemptAt: attempts >= MAX_OUTBOX_ATTEMPTS ? null : nextRetryAt(attempts),
+            nextAttemptAt: isPermanentFailure ? null : nextRetryAt(attempts),
             updatedAt: new Date(),
           })
           .where(eq(awaitingHumanNotificationOutbox.id, row.id));

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -1,3 +1,11 @@
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+import { and, eq, inArray, lt, lte, or, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { awaitingHumanNotificationOutbox } from "@paperclipai/db";
+import type { StorageService } from "../storage/types.js";
+import { getStorageService } from "../storage/index.js";
+
 const CLICKUP_CHAT_MESSAGE_MAX_CHARS = 1_800;
 const DEFAULT_CLICKUP_CHANNEL_NAME = "engineering";
 const MAX_TITLE_LENGTH = 120;
@@ -5,6 +13,9 @@ const MAX_SUMMARY_LENGTH = 280;
 const MAX_DETAIL_BULLETS = 5;
 const MAX_BULLET_LENGTH = 220;
 const CLICKUP_CHANNEL_LOOKUP_PAGE_SIZE = 100;
+const MAX_OUTBOX_ATTEMPTS = 8;
+const STALE_OUTBOX_PROCESSING_MS = 5 * 60 * 1000;
+const DEFAULT_CLICKUP_TIMEOUT_SEC = 30;
 const DEFAULT_CLICKUP_APPROVAL_POSITIVE_REACTIONS = ["thumbsup", "white_check_mark", "heavy_check_mark"] as const;
 const DEFAULT_CLICKUP_APPROVAL_POSITIVE_REPLY_KEYWORDS = [
   "approve",
@@ -41,6 +52,7 @@ export interface AwaitingHumanNotificationPayload {
   kind?: string | null;
   audience?: string | null;
   body?: string | null;
+  reviewFile?: AwaitingHumanNotificationReviewFile | null;
 }
 
 export interface SendAwaitingHumanNotificationInput {
@@ -51,10 +63,30 @@ export interface SendAwaitingHumanNotificationInput {
 }
 
 export interface AwaitingHumanNotificationResult {
-  status: "sent" | "skipped" | "failed";
+  status: "sent" | "skipped" | "failed" | "enqueued";
   channel: "clickup-chat";
   detail: string;
   externalId?: string | null;
+}
+
+export interface EnqueueAwaitingHumanNotificationInput extends SendAwaitingHumanNotificationInput {
+  dedupeKey: string;
+}
+
+export interface AwaitingHumanNotificationReviewFile {
+  source: "artifact" | "document";
+  deliverableId: string;
+  title: string;
+  filename: string;
+  contentType: string;
+  byteSize: number;
+  contentPath: string;
+  deliverableUrl: string;
+  clickupTaskUrl?: string | null;
+  clickupAttachmentId?: string | null;
+  attachmentId?: string | null;
+  objectKey?: string | null;
+  sha256?: string | null;
 }
 
 type ClickUpChatConfig = {
@@ -62,6 +94,7 @@ type ClickUpChatConfig = {
   workspaceId: string;
   channelId: string;
   channelName: string;
+  reviewListId: string;
   approvalPositiveReactions: string[];
   approvalPositiveReplyKeywords: string[];
 };
@@ -116,6 +149,77 @@ function extractBullets(body: string | null | undefined) {
   return bullets;
 }
 
+function toRowArray<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  if (result && typeof result === "object" && Array.isArray((result as { rows?: unknown[] }).rows)) {
+    return (result as { rows: T[] }).rows;
+  }
+  return [];
+}
+
+async function readStreamToBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function sha256Hex(body: Buffer) {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function nextRetryAt(attempt: number, now = Date.now()): Date {
+  const seq = [5, 10, 20, 40, 80, 160, 320, 640];
+  const sec = seq[Math.min(Math.max(attempt - 1, 0), seq.length - 1)] ?? 640;
+  return new Date(now + sec * 1000);
+}
+
+function resolveAbsoluteUrl(pathOrUrl: string, sourceLink: string) {
+  try {
+    return new URL(pathOrUrl).toString();
+  } catch {
+    // Continue below.
+  }
+
+  try {
+    return new URL(pathOrUrl, sourceLink).toString();
+  } catch {
+    return pathOrUrl;
+  }
+}
+
+function normalizeReviewFile(value: unknown): AwaitingHumanNotificationReviewFile | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  const source = row.source === "artifact" || row.source === "document" ? row.source : null;
+  const deliverableId = readString(row.deliverableId);
+  const title = readString(row.title);
+  const filename = readString(row.filename);
+  const contentType = readString(row.contentType);
+  const contentPath = readString(row.contentPath);
+  const deliverableUrl = readString(row.deliverableUrl);
+  const byteSize = typeof row.byteSize === "number" && Number.isFinite(row.byteSize) ? row.byteSize : null;
+  if (!source || !deliverableId || !title || !filename || !contentType || !contentPath || !deliverableUrl || byteSize === null) {
+    return null;
+  }
+  return {
+    source,
+    deliverableId,
+    title,
+    filename,
+    contentType,
+    byteSize,
+    contentPath,
+    deliverableUrl,
+    clickupTaskUrl: readString(row.clickupTaskUrl),
+    clickupAttachmentId: readString(row.clickupAttachmentId),
+    attachmentId: readString(row.attachmentId),
+    objectKey: readString(row.objectKey),
+    sha256: readString(row.sha256),
+  };
+}
+
 function readClickUpChatConfig(): ClickUpChatConfig {
   const positiveReactions = (process.env.CLICKUP_APPROVAL_POSITIVE_REACTIONS ?? "")
     .split(",")
@@ -130,6 +234,7 @@ function readClickUpChatConfig(): ClickUpChatConfig {
     workspaceId: process.env.CLICKUP_WORKSPACE_ID?.trim() ?? "",
     channelId: process.env.CLICKUP_ENGINEERING_CHANNEL_ID?.trim() ?? "",
     channelName: process.env.CLICKUP_ENGINEERING_CHANNEL_NAME?.trim() || DEFAULT_CLICKUP_CHANNEL_NAME,
+    reviewListId: process.env.CLICKUP_AWAITING_HUMAN_REVIEW_LIST_ID?.trim() ?? "",
     approvalPositiveReactions: positiveReactions.length > 0
       ? [...new Set(positiveReactions)]
       : [...DEFAULT_CLICKUP_APPROVAL_POSITIVE_REACTIONS],
@@ -306,6 +411,18 @@ function renderClickUpMessage(notification: AwaitingHumanNotificationPayload) {
     lines.push(...bullets.map((bullet) => `- ${bullet}`));
   }
 
+  if (notification.reviewFile) {
+    lines.push("");
+    lines.push(`Review file: ${notification.reviewFile.filename}`);
+    lines.push(`Bizbox deliverable: ${notification.reviewFile.deliverableUrl}`);
+    if (notification.reviewFile.clickupTaskUrl) {
+      lines.push(`ClickUp review task: ${notification.reviewFile.clickupTaskUrl}`);
+      if (notification.reviewFile.clickupAttachmentId) {
+        lines.push("Review file attached on the ClickUp task.");
+      }
+    }
+  }
+
   lines.push("");
   lines.push(`Source: ${notification.link.trim()}`);
 
@@ -355,6 +472,176 @@ async function resolveClickUpChannelId(config: ClickUpChatConfig): Promise<strin
   }
 
   return null;
+}
+
+export async function resolveAwaitingHumanReviewFile(
+  db: Db,
+  input: { companyId: string; issueId: string; sourceLink: string },
+): Promise<AwaitingHumanNotificationReviewFile | null> {
+  const artifactRows = await db.execute<{
+    deliverable_id: string;
+    title: string;
+    content_path: string;
+    content_type: string;
+    byte_size: number;
+    original_filename: string | null;
+    attachment_id: string | null;
+    object_key: string | null;
+    sha256: string | null;
+  }>(sql`
+    SELECT
+      wp.id AS deliverable_id,
+      wp.title,
+      wp.metadata ->> 'contentPath' AS content_path,
+      wp.metadata ->> 'contentType' AS content_type,
+      COALESCE(NULLIF(wp.metadata ->> 'byteSize', '')::integer, a.byte_size, 0) AS byte_size,
+      COALESCE(wp.metadata ->> 'originalFilename', a.original_filename, 'deliverable') AS original_filename,
+      wp.metadata ->> 'attachmentId' AS attachment_id,
+      a.object_key,
+      a.sha256
+    FROM issue_work_products wp
+    LEFT JOIN issue_attachments ia ON ia.id::text = wp.metadata ->> 'attachmentId'
+    LEFT JOIN assets a ON a.id = ia.asset_id
+    WHERE wp.company_id = ${input.companyId}
+      AND wp.issue_id = ${input.issueId}
+      AND wp.type = 'artifact'
+      AND COALESCE(wp.audience, 'human') = 'human'
+      AND wp.metadata ->> 'contentPath' IS NOT NULL
+    ORDER BY
+      CASE
+        WHEN wp.review_state = 'needs_board_review' THEN 0
+        WHEN wp.status = 'ready_for_review' THEN 1
+        WHEN wp.status = 'active' THEN 2
+        ELSE 3
+      END,
+      wp.is_primary DESC,
+      wp.updated_at DESC
+    LIMIT 1
+  `);
+  const artifact = toRowArray<{
+    deliverable_id: string;
+    title: string;
+    content_path: string;
+    content_type: string;
+    byte_size: number;
+    original_filename: string | null;
+    attachment_id: string | null;
+    object_key: string | null;
+    sha256: string | null;
+  }>(artifactRows)[0];
+  if (artifact?.content_path && artifact.content_type) {
+    return {
+      source: "artifact",
+      deliverableId: artifact.deliverable_id,
+      title: artifact.title,
+      filename: artifact.original_filename?.trim() || "deliverable",
+      contentType: artifact.content_type,
+      byteSize: Number(artifact.byte_size) || 0,
+      contentPath: artifact.content_path,
+      deliverableUrl: resolveAbsoluteUrl(artifact.content_path, input.sourceLink),
+      attachmentId: artifact.attachment_id,
+      objectKey: artifact.object_key,
+      sha256: artifact.sha256,
+    };
+  }
+
+  const documentRows = await db.execute<{
+    deliverable_id: string;
+    key: string;
+    title: string | null;
+    format: string;
+    byte_size: number;
+  }>(sql`
+    SELECT
+      idoc.id AS deliverable_id,
+      idoc.key,
+      d.title,
+      d.format,
+      COALESCE(octet_length(d.latest_body), 0)::integer AS byte_size
+    FROM issue_documents idoc
+    JOIN documents d ON d.id = idoc.document_id
+    WHERE idoc.company_id = ${input.companyId}
+      AND idoc.issue_id = ${input.issueId}
+      AND COALESCE(idoc.audience, 'human') = 'human'
+      AND idoc.key <> 'continuation-summary'
+    ORDER BY d.updated_at DESC, idoc.updated_at DESC
+    LIMIT 1
+  `);
+  const document = toRowArray<{
+    deliverable_id: string;
+    key: string;
+    title: string | null;
+    format: string;
+    byte_size: number;
+  }>(documentRows)[0];
+  if (!document) return null;
+  const key = document.key?.trim() || "document";
+  const contentPath = `/api/deliverables/${document.deliverable_id}/content`;
+  return {
+    source: "document",
+    deliverableId: document.deliverable_id,
+    title: document.title?.trim() || key,
+    filename: `${key}.md`,
+    contentType: document.format === "markdown" ? "text/markdown; charset=utf-8" : "text/plain; charset=utf-8",
+    byteSize: Number(document.byte_size) || 0,
+    contentPath,
+    deliverableUrl: resolveAbsoluteUrl(contentPath, input.sourceLink),
+  };
+}
+
+export async function enqueueAwaitingHumanNotification(
+  db: Db,
+  input: EnqueueAwaitingHumanNotificationInput,
+): Promise<AwaitingHumanNotificationResult> {
+  const reviewFile = await resolveAwaitingHumanReviewFile(db, {
+    companyId: input.companyId,
+    issueId: input.issueId,
+    sourceLink: input.notification.link,
+  });
+  const notification = {
+    ...input.notification,
+    ...(reviewFile ? { reviewFile } : {}),
+  };
+  const storedReviewFile = reviewFile ? { ...reviewFile } : null;
+  const [row] = await db
+    .insert(awaitingHumanNotificationOutbox)
+    .values({
+      companyId: input.companyId,
+      issueId: input.issueId,
+      dedupeKey: input.dedupeKey,
+      handoffKind: input.handoffKind,
+      status: "pending",
+      notification,
+      reviewFile: storedReviewFile,
+    })
+    .onConflictDoUpdate({
+      target: [
+        awaitingHumanNotificationOutbox.companyId,
+        awaitingHumanNotificationOutbox.issueId,
+        awaitingHumanNotificationOutbox.dedupeKey,
+      ],
+      set: {
+        handoffKind: input.handoffKind,
+        notification,
+        reviewFile: storedReviewFile,
+        status: sql`case when ${awaitingHumanNotificationOutbox.status} = 'sent' then 'sent' else 'pending' end`,
+        attempts: sql`case when ${awaitingHumanNotificationOutbox.status} = 'sent' then ${awaitingHumanNotificationOutbox.attempts} else 0 end`,
+        nextAttemptAt: null,
+        lastError: null,
+        updatedAt: new Date(),
+      },
+    })
+    .returning({
+      status: awaitingHumanNotificationOutbox.status,
+      clickupMessageId: awaitingHumanNotificationOutbox.clickupMessageId,
+    });
+
+  return {
+    status: row?.status === "sent" ? "sent" : "enqueued",
+    channel: "clickup-chat",
+    detail: row?.status === "sent" ? "already-sent" : "enqueued",
+    externalId: row?.clickupMessageId ?? null,
+  };
 }
 
 export async function sendAwaitingHumanNotification(
@@ -423,6 +710,318 @@ export async function sendAwaitingHumanNotification(
       detail: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+function parseClickUpTaskResponse(rawText: string): { taskId: string; taskUrl: string | null } {
+  const payload = JSON.parse(rawText) as Record<string, unknown>;
+  const taskId = readString(payload.id);
+  if (!taskId) throw new Error("clickup review task response missing id");
+  return {
+    taskId,
+    taskUrl: readString(payload.url),
+  };
+}
+
+function findFirstAttachmentLike(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") return null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findFirstAttachmentLike(item);
+      if (found) return found;
+    }
+    return null;
+  }
+  const row = value as Record<string, unknown>;
+  if (readString(row.id) || readString(row.url)) return row;
+  for (const child of Object.values(row)) {
+    const found = findFirstAttachmentLike(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+async function fetchText(url: string, init: RequestInit, timeoutSec = DEFAULT_CLICKUP_TIMEOUT_SEC) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutSec * 1000);
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    const text = await response.text();
+    return { ok: response.ok, status: response.status, text };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function createClickUpReviewTask(config: ClickUpChatConfig, notification: AwaitingHumanNotificationPayload) {
+  if (!config.reviewListId) {
+    throw new Error("missing-target: CLICKUP_AWAITING_HUMAN_REVIEW_LIST_ID");
+  }
+  const body = renderClickUpMessage(notification);
+  const response = await fetchText(
+    `https://api.clickup.com/api/v2/list/${encodeURIComponent(config.reviewListId)}/task`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: config.personalToken,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: truncateText(notification.title, 120),
+        description: body,
+        notify_all: false,
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`clickup review task create failed:${response.status}:${truncateText(response.text, 240)}`);
+  }
+  return parseClickUpTaskResponse(response.text);
+}
+
+async function readReviewFileBody(
+  db: Db,
+  storage: StorageService,
+  companyId: string,
+  reviewFile: AwaitingHumanNotificationReviewFile,
+) {
+  if (reviewFile.source === "artifact") {
+    if (!reviewFile.objectKey) throw new Error("review artifact is missing object key");
+    const object = await storage.getObject(companyId, reviewFile.objectKey);
+    const body = await readStreamToBuffer(object.stream);
+    return {
+      body,
+      sha256: reviewFile.sha256 ?? sha256Hex(body),
+    };
+  }
+
+  const rows = await db.execute<{ body: string }>(sql`
+    SELECT d.latest_body AS body
+    FROM issue_documents idoc
+    JOIN documents d ON d.id = idoc.document_id
+    WHERE idoc.id = ${reviewFile.deliverableId}
+      AND idoc.company_id = ${companyId}
+    LIMIT 1
+  `);
+  const body = Buffer.from(toRowArray<{ body: string }>(rows)[0]?.body ?? "", "utf8");
+  return {
+    body,
+    sha256: sha256Hex(body),
+  };
+}
+
+async function uploadClickUpReviewFile(
+  config: ClickUpChatConfig,
+  taskId: string,
+  reviewFile: AwaitingHumanNotificationReviewFile,
+  body: Buffer,
+) {
+  const form = new FormData();
+  form.append("attachment[0]", new Blob([new Uint8Array(body)], { type: reviewFile.contentType }), reviewFile.filename);
+  const response = await fetchText(
+    `https://api.clickup.com/api/v3/workspaces/${encodeURIComponent(config.workspaceId)}/attachments/${encodeURIComponent(taskId)}/attachments`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: config.personalToken,
+      },
+      body: form,
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`clickup review file upload failed:${response.status}:${truncateText(response.text, 240)}`);
+  }
+  const payload = response.text.trim().length > 0 ? JSON.parse(response.text) : {};
+  const attachment = findFirstAttachmentLike(payload) ?? {};
+  return {
+    attachmentId: readString(attachment.id),
+    attachmentUrl: readString(attachment.url) ?? readString(attachment.url_w_query),
+  };
+}
+
+function withClickUpTaskUrl(
+  notification: AwaitingHumanNotificationPayload,
+  reviewFile: AwaitingHumanNotificationReviewFile | null,
+  clickupTaskUrl: string | null,
+  clickupAttachmentId: string | null,
+) {
+  if (!reviewFile) return notification;
+  return {
+    ...notification,
+    reviewFile: {
+      ...reviewFile,
+      clickupTaskUrl,
+      clickupAttachmentId,
+    },
+  };
+}
+
+export async function processAwaitingHumanNotificationOutbox(
+  db: Db,
+  opts: { limit?: number; storage?: StorageService } = {},
+) {
+  const limit = opts.limit ?? 20;
+  const storage = opts.storage ?? getStorageService();
+  const now = new Date();
+
+  await db
+    .update(awaitingHumanNotificationOutbox)
+    .set({ status: "pending", updatedAt: now })
+    .where(
+      and(
+        eq(awaitingHumanNotificationOutbox.status, "processing"),
+        lt(awaitingHumanNotificationOutbox.updatedAt, new Date(now.getTime() - STALE_OUTBOX_PROCESSING_MS)),
+      ),
+    );
+
+  const rows = await db
+    .select()
+    .from(awaitingHumanNotificationOutbox)
+    .where(
+      and(
+        inArray(awaitingHumanNotificationOutbox.status, ["pending", "failed", "partial_failed"]),
+        lt(awaitingHumanNotificationOutbox.attempts, MAX_OUTBOX_ATTEMPTS),
+        or(
+          sql`${awaitingHumanNotificationOutbox.nextAttemptAt} is null`,
+          lte(awaitingHumanNotificationOutbox.nextAttemptAt, now),
+        ),
+      ),
+    )
+    .limit(limit);
+
+  let processed = 0;
+  let sent = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    const [claimed] = await db
+      .update(awaitingHumanNotificationOutbox)
+      .set({ status: "processing", updatedAt: new Date() })
+      .where(
+        and(
+          eq(awaitingHumanNotificationOutbox.id, row.id),
+          inArray(awaitingHumanNotificationOutbox.status, ["pending", "failed", "partial_failed"]),
+        ),
+      )
+      .returning({ id: awaitingHumanNotificationOutbox.id });
+    if (!claimed) continue;
+    processed += 1;
+
+    try {
+      const config = readClickUpChatConfig();
+      if (!config.personalToken) throw new Error("missing-credential: CLICKUP_PERSONAL_TOKEN");
+      if (!config.workspaceId) throw new Error("missing-target: CLICKUP_WORKSPACE_ID");
+
+      const reviewFile = normalizeReviewFile(row.reviewFile);
+      let clickupTaskId = row.clickupTaskId;
+      let clickupTaskUrl = row.clickupTaskUrl;
+      let clickupAttachmentId = row.clickupAttachmentId;
+      let clickupAttachmentUrl = row.clickupAttachmentUrl;
+      let deliveryNote: string | null = null;
+      let uploadError: Error | null = null;
+
+      if (reviewFile && config.reviewListId) {
+        if (!clickupTaskId) {
+          const task = await createClickUpReviewTask(config, row.notification as unknown as AwaitingHumanNotificationPayload);
+          clickupTaskId = task.taskId;
+          clickupTaskUrl = task.taskUrl;
+          await db
+            .update(awaitingHumanNotificationOutbox)
+            .set({ clickupTaskId, clickupTaskUrl, updatedAt: new Date() })
+            .where(eq(awaitingHumanNotificationOutbox.id, row.id));
+        }
+
+        if (!clickupAttachmentId && clickupTaskId) {
+          try {
+            const file = await readReviewFileBody(db, storage, row.companyId, reviewFile);
+            const upload = await uploadClickUpReviewFile(config, clickupTaskId, reviewFile, file.body);
+            clickupAttachmentId = upload.attachmentId ?? file.sha256;
+            clickupAttachmentUrl = upload.attachmentUrl;
+            await db
+              .update(awaitingHumanNotificationOutbox)
+              .set({ clickupAttachmentId, clickupAttachmentUrl, updatedAt: new Date() })
+              .where(eq(awaitingHumanNotificationOutbox.id, row.id));
+          } catch (error) {
+            uploadError = error instanceof Error ? error : new Error(String(error));
+          }
+        }
+      } else if (reviewFile && !config.reviewListId) {
+        deliveryNote = "skipped_upload: missing CLICKUP_AWAITING_HUMAN_REVIEW_LIST_ID";
+      }
+
+      let clickupMessageId = row.clickupMessageId;
+      if (!clickupMessageId) {
+        const message = await sendAwaitingHumanNotification({
+          companyId: row.companyId,
+          issueId: row.issueId,
+          handoffKind: row.handoffKind,
+          notification: withClickUpTaskUrl(
+            row.notification as unknown as AwaitingHumanNotificationPayload,
+            reviewFile,
+            clickupTaskUrl,
+            clickupAttachmentId,
+          ),
+        });
+        if (message.status !== "sent") {
+          throw new Error(message.detail);
+        }
+        clickupMessageId = message.externalId ?? null;
+      }
+
+      if (uploadError) {
+        const attempts = row.attempts + 1;
+        await db
+          .update(awaitingHumanNotificationOutbox)
+          .set({
+            status: attempts >= MAX_OUTBOX_ATTEMPTS ? "failed" : "partial_failed",
+            attempts,
+            clickupTaskId,
+            clickupTaskUrl,
+            clickupAttachmentId,
+            clickupAttachmentUrl,
+            clickupMessageId,
+            lastError: uploadError.message,
+            nextAttemptAt: attempts >= MAX_OUTBOX_ATTEMPTS ? null : nextRetryAt(attempts),
+            updatedAt: new Date(),
+          })
+          .where(eq(awaitingHumanNotificationOutbox.id, row.id));
+        failed += 1;
+        continue;
+      }
+
+      await db
+        .update(awaitingHumanNotificationOutbox)
+        .set({
+          status: "sent",
+          attempts: row.attempts + 1,
+          clickupTaskId,
+          clickupTaskUrl,
+          clickupAttachmentId,
+          clickupAttachmentUrl,
+          clickupMessageId,
+          lastError: deliveryNote,
+          nextAttemptAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(awaitingHumanNotificationOutbox.id, row.id));
+      sent += 1;
+    } catch (error) {
+      const attempts = row.attempts + 1;
+      const terminal = attempts >= MAX_OUTBOX_ATTEMPTS;
+      await db
+        .update(awaitingHumanNotificationOutbox)
+        .set({
+          status: terminal ? "failed" : row.clickupMessageId ? "partial_failed" : "failed",
+          attempts,
+          lastError: error instanceof Error ? error.message : String(error),
+          nextAttemptAt: terminal ? null : nextRetryAt(attempts),
+          updatedAt: new Date(),
+        })
+        .where(eq(awaitingHumanNotificationOutbox.id, row.id));
+      failed += 1;
+    }
+  }
+
+  return { processed, sent, failed };
 }
 
 export async function getClickUpChatMessageReplies(messageId: string): Promise<{

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -627,20 +627,38 @@ export async function enqueueAwaitingHumanNotification(
         reviewFile: storedReviewFile,
         status: sql`
           case
-            when ${awaitingHumanNotificationOutbox.status} in ('sent', 'processing')
+            when ${awaitingHumanNotificationOutbox.status} in ('sent', 'processing', 'retrying', 'partial_failed')
+              then ${awaitingHumanNotificationOutbox.status}
+            when ${awaitingHumanNotificationOutbox.status} = 'failed'
+              and ${awaitingHumanNotificationOutbox.attempts} < ${MAX_OUTBOX_ATTEMPTS}
+              and ${awaitingHumanNotificationOutbox.nextAttemptAt} is not null
+              then 'retrying'
+            when ${awaitingHumanNotificationOutbox.status} = 'failed'
               then ${awaitingHumanNotificationOutbox.status}
             else 'pending'
           end
         `,
         attempts: sql`
           case
-            when ${awaitingHumanNotificationOutbox.status} in ('sent', 'processing')
+            when ${awaitingHumanNotificationOutbox.status} in ('sent', 'processing', 'retrying', 'partial_failed', 'failed')
               then ${awaitingHumanNotificationOutbox.attempts}
             else 0
           end
         `,
-        nextAttemptAt: null,
-        lastError: null,
+        nextAttemptAt: sql`
+          case
+            when ${awaitingHumanNotificationOutbox.status} in ('retrying', 'partial_failed', 'failed')
+              then ${awaitingHumanNotificationOutbox.nextAttemptAt}
+            else null
+          end
+        `,
+        lastError: sql`
+          case
+            when ${awaitingHumanNotificationOutbox.status} in ('sent', 'processing', 'retrying', 'partial_failed', 'failed')
+              then ${awaitingHumanNotificationOutbox.lastError}
+            else null
+          end
+        `,
         updatedAt: new Date(),
       },
     })
@@ -900,12 +918,23 @@ export async function processAwaitingHumanNotificationOutbox(
       ),
     );
 
+  await db
+    .update(awaitingHumanNotificationOutbox)
+    .set({ status: "retrying", updatedAt: now })
+    .where(
+      and(
+        eq(awaitingHumanNotificationOutbox.status, "failed"),
+        lt(awaitingHumanNotificationOutbox.attempts, MAX_OUTBOX_ATTEMPTS),
+        sql`${awaitingHumanNotificationOutbox.nextAttemptAt} is not null`,
+      ),
+    );
+
   const rows = await db
     .select()
     .from(awaitingHumanNotificationOutbox)
     .where(
       and(
-        inArray(awaitingHumanNotificationOutbox.status, ["pending", "failed", "partial_failed"]),
+        inArray(awaitingHumanNotificationOutbox.status, ["pending", "retrying", "partial_failed"]),
         lt(awaitingHumanNotificationOutbox.attempts, MAX_OUTBOX_ATTEMPTS),
         or(
           sql`${awaitingHumanNotificationOutbox.nextAttemptAt} is null`,
@@ -927,7 +956,7 @@ export async function processAwaitingHumanNotificationOutbox(
       .where(
         and(
           eq(awaitingHumanNotificationOutbox.id, row.id),
-          inArray(awaitingHumanNotificationOutbox.status, ["pending", "failed", "partial_failed"]),
+          inArray(awaitingHumanNotificationOutbox.status, ["pending", "retrying", "partial_failed"]),
         ),
       )
       .returning({ id: awaitingHumanNotificationOutbox.id });
@@ -1068,7 +1097,7 @@ export async function processAwaitingHumanNotificationOutbox(
       await db
         .update(awaitingHumanNotificationOutbox)
         .set({
-          status: terminal ? "failed" : clickupMessageId ? "partial_failed" : "failed",
+          status: terminal ? "failed" : clickupMessageId ? "partial_failed" : "retrying",
           attempts,
           clickupTaskId,
           clickupTaskUrl,

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -990,6 +990,10 @@ export async function processAwaitingHumanNotificationOutbox(
           throw new Error(message.detail);
         }
         clickupMessageId = message.externalId ?? null;
+        await db
+          .update(awaitingHumanNotificationOutbox)
+          .set({ clickupMessageId, updatedAt: new Date() })
+          .where(eq(awaitingHumanNotificationOutbox.id, row.id));
       }
 
       if (uploadError) {

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -625,8 +625,20 @@ export async function enqueueAwaitingHumanNotification(
         handoffKind: input.handoffKind,
         notification,
         reviewFile: storedReviewFile,
-        status: sql`case when ${awaitingHumanNotificationOutbox.status} = 'sent' then 'sent' else 'pending' end`,
-        attempts: sql`case when ${awaitingHumanNotificationOutbox.status} = 'sent' then ${awaitingHumanNotificationOutbox.attempts} else 0 end`,
+        status: sql`
+          case
+            when ${awaitingHumanNotificationOutbox.status} in ('sent', 'processing')
+              then ${awaitingHumanNotificationOutbox.status}
+            else 'pending'
+          end
+        `,
+        attempts: sql`
+          case
+            when ${awaitingHumanNotificationOutbox.status} in ('sent', 'processing')
+              then ${awaitingHumanNotificationOutbox.attempts}
+            else 0
+          end
+        `,
         nextAttemptAt: null,
         lastError: null,
         updatedAt: new Date(),
@@ -870,6 +882,11 @@ export async function processAwaitingHumanNotificationOutbox(
   opts: { limit?: number; storage?: StorageService } = {},
 ) {
   const limit = opts.limit ?? 20;
+  const config = readClickUpChatConfig();
+  if (!config.personalToken || !config.workspaceId) {
+    return { processed: 0, sent: 0, failed: 0 };
+  }
+
   const storage = opts.storage ?? getStorageService();
   const now = new Date();
 
@@ -924,10 +941,6 @@ export async function processAwaitingHumanNotificationOutbox(
     let clickupMessageId = row.clickupMessageId;
 
     try {
-      const config = readClickUpChatConfig();
-      if (!config.personalToken) throw new Error("missing-credential: CLICKUP_PERSONAL_TOKEN");
-      if (!config.workspaceId) throw new Error("missing-target: CLICKUP_WORKSPACE_ID");
-
       const reviewFile = normalizeReviewFile(row.reviewFile);
       let deliveryNote: string | null = null;
       let uploadError: Error | null = null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -96,7 +96,7 @@ import { agentThreadService } from "./agent-threads.js";
 import { clickupBridgeService } from "./clickup-bridge.js";
 import { documentService } from "./documents.js";
 import { workProductService } from "./work-products.js";
-import { recordRunStatus } from "../otel.js";
+import { recordComment, recordRunStatus } from "../otel.js";
 import {
   getIssueContinuationSummaryDocument,
   refreshIssueContinuationSummary,
@@ -6912,6 +6912,7 @@ export function heartbeatService(db: Db) {
         .select({
           id: issues.id,
           companyId: issues.companyId,
+          projectId: issues.projectId,
           identifier: issues.identifier,
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
@@ -7147,7 +7148,7 @@ export function heartbeatService(db: Db) {
             updatedAt: new Date(),
           })
           .where(eq(issues.id, issue.id));
-        await tx
+        const [insertedComment] = await tx
           .insert(issueComments)
           .values({
             companyId: issue.companyId,
@@ -7155,9 +7156,26 @@ export function heartbeatService(db: Db) {
             authorAgentId: null,
             authorUserId: null,
             createdByRunId: run.id,
+            source: "native",
             body: comment,
           })
-          .onConflictDoNothing();
+          .onConflictDoNothing()
+          .returning({ id: issueComments.id });
+        if (insertedComment) {
+          await tx
+            .update(issues)
+            .set({ updatedAt: new Date() })
+            .where(eq(issues.id, issue.id));
+          recordComment({
+            company_id: issue.companyId,
+            project_id: issue.projectId ?? undefined,
+            issue_status: issue.status,
+            actor_type: "system",
+            commenter_id: run.id,
+            assignee_agent_id: issue.assigneeAgentId ?? undefined,
+            assignee_user_id: issue.assigneeUserId ?? undefined,
+          });
+        }
         return {
           kind: "blocked" as const,
           issueId: issue.id,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -76,7 +76,10 @@ import {
 } from "./issue-liveness.js";
 import { logActivity, publishPluginDomainEvent, type LogActivityInput } from "./activity-log.js";
 import { maybeLogAwaitingHumanHandoff } from "./awaiting-human-handoff.js";
-import { detectClickUpAwaitingHumanApproval } from "./awaiting-human-notifications.js";
+import {
+  detectClickUpAwaitingHumanApproval,
+  processAwaitingHumanNotificationOutbox,
+} from "./awaiting-human-notifications.js";
 import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
@@ -8371,6 +8374,7 @@ export function heartbeatService(db: Db) {
 
     processClickupOutbound: async () => {
       await clickupBridge.processOutbound();
+      await processAwaitingHumanNotificationOutbox(db, { storage });
     },
 
     pollClickupInbound: async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7147,12 +7147,22 @@ export function heartbeatService(db: Db) {
             updatedAt: new Date(),
           })
           .where(eq(issues.id, issue.id));
+        await tx
+          .insert(issueComments)
+          .values({
+            companyId: issue.companyId,
+            issueId: issue.id,
+            authorAgentId: null,
+            authorUserId: null,
+            createdByRunId: run.id,
+            body: comment,
+          })
+          .onConflictDoNothing();
         return {
           kind: "blocked" as const,
           issueId: issue.id,
           issueIdentifier: issue.identifier,
           previousStatus: issue.status,
-          comment,
         };
       }
 
@@ -7230,7 +7240,6 @@ export function heartbeatService(db: Db) {
     });
 
     if (promotionResult?.kind === "blocked") {
-      await issuesSvc.addComment(promotionResult.issueId, promotionResult.comment, {});
       await logActivity(db, {
         companyId: run.companyId,
         actorType: "system",


### PR DESCRIPTION
This pull request introduces a robust outbox mechanism for handling "awaiting human" notifications, particularly for ClickUp integration. The main goal is to ensure reliable, deduplicated, and retryable delivery of human-facing notifications and deliverables, with support for attaching review files and linking to ClickUp review tasks. The changes span schema additions, service refactoring, documentation updates, and expanded test coverage.

**Key changes:**

### Outbox Table & Schema

- Added a new database table `awaiting_human_notification_outbox` with fields to track notification delivery status, deduplication, attempts, ClickUp task/attachment/message IDs, and error details. This enables reliable, idempotent, and retryable notification delivery. (`packages/db/src/migrations/0074_awaiting_human_notification_outbox.sql`, `packages/db/src/schema/awaiting_human_notification_outbox.ts`, `packages/db/src/schema/index.ts`, `packages/db/src/migrations/meta/_journal.json`) [[1]](diffhunk://#diff-7eb2ab9cc1e9779e6b3e5c68cc650e631fbd5cac898efa532743f908fc98e442R1-R30) [[2]](diffhunk://#diff-c88a39f4c29d4a9bce9f548b0fed1ea04d4ae4f381e50fbb87df95924f6e2019R1-R43) [[3]](diffhunk://#diff-e0de6ed8e004b97d9ecc000f4a6b1a8352ad9c04df99666f290605739b9aec26R57) [[4]](diffhunk://#diff-daac5122c1161dd5f036f01de8b354270bf5ed5f342b73846495b14c9b844296R522-R528)

### Notification Delivery Refactor

- Refactored notification delivery logic to enqueue notifications into the outbox instead of sending immediately, renaming the function to `enqueueAwaitingHumanNotification` and updating all usages and tests accordingly. This allows for background processing and retries. (`server/src/services/awaiting-human-handoff.ts`, `server/src/__tests__/awaiting-human-handoff.test.ts`) [[1]](diffhunk://#diff-eeebd94a3ef8bbc231359a7a983b073c40cb3a7fa76f976eacb18ed69ae8c100L9-R9) [[2]](diffhunk://#diff-eeebd94a3ef8bbc231359a7a983b073c40cb3a7fa76f976eacb18ed69ae8c100L257-R265) [[3]](diffhunk://#diff-eeebd94a3ef8bbc231359a7a983b073c40cb3a7fa76f976eacb18ed69ae8c100L304-R305) [[4]](diffhunk://#diff-eeebd94a3ef8bbc231359a7a983b073c40cb3a7fa76f976eacb18ed69ae8c100L315-R316) [[5]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9L9-R17) [[6]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9L88-R92) [[7]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9L125-R127) [[8]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9L154-R157) [[9]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9L190-R198) [[10]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9L248-R255) [[11]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9L305-R308) [[12]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9L340-R343)

- Updated the heartbeat/worker scheduler to include retryable delivery of awaiting-human notifications using the outbox. (`doc/SPEC-implementation.md`, `server/src/services/heartbeat.ts`) [[1]](diffhunk://#diff-9b34d711380a5f08c5295893aae95453a9a58ada8876f27e15b811fd4ffb3495R110) [[2]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L79-R82)

### ClickUp Review File & Deliverable Handling

- Implemented logic to attach Bizbox deliverables to ClickUp review tasks, post links to both Bizbox and ClickUp resources, and avoid using ClickUp Chat as a file host due to API limitations. (`doc/execution-semantics.md`, `server/src/__tests__/awaiting-human-notifications.test.ts`) [[1]](diffhunk://#diff-b1e96a247955e130d82dcc77ceac622a95f66a8fe4f19d2f9cf502e96bafda7aR105-R112) [[2]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69R81-R125)

- Added `resolveAwaitingHumanReviewFile` to select the best available review file (artifact or document) for notification delivery, with comprehensive tests for artifact/document fallback logic. (`server/src/__tests__/awaiting-human-notifications.test.ts`)

### Documentation & Policy

- Updated operational policy and implementation documentation to describe the outbox table, its uniqueness constraints, and the new notification delivery flow. (`doc/SPEC-implementation.md`)

---

These changes lay the foundation for reliable, auditable, and extensible human-in-the-loop notification delivery, especially for integrations with platforms like ClickUp.