### PR TITLE
fix(openclaw): persist pairing keys on agent updates

### DIFF
--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -450,6 +450,58 @@ describe("agent routes adapter validation", () => {
     expect(String(adapterConfig?.devicePrivateKeyPem ?? "")).toContain("BEGIN PRIVATE KEY");
   });
 
+  it("preserves an existing OpenClaw device key on update", async () => {
+    const existingDevicePrivateKeyPem =
+      "-----BEGIN PRIVATE KEY-----\nexisting\n-----END PRIVATE KEY-----";
+    const existingAgent = {
+      id: "11111111-1111-4111-8111-111111111112",
+      companyId: "company-1",
+      name: "CEO",
+      urlKey: "ceo",
+      role: "ceo",
+      title: null,
+      icon: null,
+      status: "idle",
+      reportsTo: null,
+      capabilities: null,
+      adapterType: "openclaw_gateway",
+      adapterConfig: {
+        url: "ws://citro-openclaw.internal:18789",
+        disableDeviceAuth: false,
+        devicePrivateKeyPem: existingDevicePrivateKeyPem,
+        authTokenRef: { type: "secret_ref", secretId: "secret-1", version: "latest" },
+      },
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+      spentMonthlyCents: 0,
+      pauseReason: null,
+      pausedAt: null,
+      permissions: { canCreateAgents: false },
+      lastHeartbeatAt: null,
+      metadata: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockAgentService.getById.mockResolvedValue(existingAgent);
+
+    const app = await createApp();
+    const res = await request(app)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111112")
+      .send({
+        adapterConfig: {
+          disableDeviceAuth: false,
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const patch = mockAgentService.update.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    const adapterConfig = patch?.adapterConfig as Record<string, unknown> | undefined;
+    expect(adapterConfig?.disableDeviceAuth).toBe(false);
+    expect(adapterConfig?.devicePrivateKeyPem).toBe(existingDevicePrivateKeyPem);
+  });
+
   it("persists normalized OpenClaw connection status on agent metadata", async () => {
     const { registerServerAdapter } = await import("../adapters/index.js");
     registerServerAdapter({

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -396,6 +396,60 @@ describe("agent routes adapter validation", () => {
     expect(adapterConfig?.devicePrivateKeyPem).toBe(sharedPem);
   });
 
+  it("generates an OpenClaw device key when an update enables pairing mode", async () => {
+    const existingAgent = {
+      id: "11111111-1111-4111-8111-111111111112",
+      companyId: "company-1",
+      name: "CEO",
+      urlKey: "ceo",
+      role: "ceo",
+      title: null,
+      icon: null,
+      status: "idle",
+      reportsTo: null,
+      capabilities: null,
+      adapterType: "openclaw_gateway",
+      adapterConfig: {
+        url: "ws://citro-openclaw.internal:18789",
+        authTokenRef: { type: "secret_ref", secretId: "secret-1", version: "latest" },
+      },
+      runtimeConfig: {},
+      budgetMonthlyCents: 0,
+      spentMonthlyCents: 0,
+      pauseReason: null,
+      pausedAt: null,
+      permissions: { canCreateAgents: false },
+      lastHeartbeatAt: null,
+      metadata: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockAgentService.getById.mockResolvedValue(existingAgent);
+
+    const app = await createApp();
+    const res = await request(app)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111112")
+      .send({
+        adapterConfig: {
+          disableDeviceAuth: false,
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const patch = mockAgentService.update.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    const adapterConfig = patch?.adapterConfig as Record<string, unknown> | undefined;
+    expect(adapterConfig?.disableDeviceAuth).toBe(false);
+    expect(adapterConfig?.authTokenRef).toEqual({
+      type: "secret_ref",
+      secretId: "secret-1",
+      version: "latest",
+    });
+    expect(typeof adapterConfig?.devicePrivateKeyPem).toBe("string");
+    expect(String(adapterConfig?.devicePrivateKeyPem ?? "")).toContain("BEGIN PRIVATE KEY");
+  });
+
   it("persists normalized OpenClaw connection status on agent metadata", async () => {
     const { registerServerAdapter } = await import("../adapters/index.js");
     registerServerAdapter({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2411,6 +2411,11 @@ export function agentRoutes(db: Db) {
         requestedAdapterType,
         rawEffectiveAdapterConfig,
       );
+      effectiveAdapterConfig = await ensureGatewayDeviceKey(
+        existing.companyId,
+        requestedAdapterType,
+        effectiveAdapterConfig,
+      );
       if (requestedAdapterType === "openclaw_gateway") {
         effectiveAdapterConfig = await persistOpenClawGatewayAuthToken({
           companyId: existing.companyId,


### PR DESCRIPTION
## Thinking Path

> - Bizbox is the control plane for AI-agent companies, so agent adapter config has to stay stable across heartbeats and edits.
> - The OpenClaw gateway adapter is part of the agent runtime boundary where connection identity and pairing behavior live.
> - Device-pairing mode depends on a persisted `devicePrivateKeyPem`; without it, the adapter generates an ephemeral device identity per run.
> - The create, builder, and join-default flows already persisted that key, but the saved-agent update route did not.
> - That gap meant an existing agent could be switched into pairing mode through an update and then re-trigger pairing on every run.
> - This pull request makes the update route reuse the same key-generation/reuse helper as the create path and adds a regression test for that transition.
> - The benefit is that edited OpenClaw agents keep a stable device identity, so pairing approvals can be reused instead of failing repeatedly.

## What Changed

- Updated the saved-agent PATCH route to run `ensureGatewayDeviceKey(...)` for `openclaw_gateway` configs before token persistence.
- Added a regression test that updates an existing OpenClaw agent into pairing mode and verifies the persisted config contains a generated device key.
- Re-ran the focused OpenClaw persistence tests covering create, builder, join normalization, and the new update-path regression.

## Verification

- `./node_modules/.bin/vitest run server/src/__tests__/agent-adapter-validation-routes.test.ts -t "OpenClaw device key"`
- `./node_modules/.bin/vitest run server/src/__tests__/builder-routes.test.ts -t "generates persistent OpenClaw device key for pairing mode"`
- `./node_modules/.bin/vitest run server/src/__tests__/invite-accept-gateway-defaults.test.ts -t "generates persistent device key when device auth is enabled"`

## Risks

- Low risk. The change only affects OpenClaw agent updates when adapter configuration is being persisted, and it reuses the same helper already exercised by the create/hire path.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 Codex via the Codex desktop app, with tool use, code execution, and patch application in the local worktree.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
