### PR TITLE
feat(ui): add multi-entity mention tagging

### DIFF
--- a/packages/shared/src/deliverable-references.test.ts
+++ b/packages/shared/src/deliverable-references.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDeliverableReferenceHref,
+  parseDeliverableReferenceHref,
+} from "./deliverable-references.js";
+
+describe("deliverable references", () => {
+  it("parses company-relative and absolute deliverable detail links", () => {
+    expect(parseDeliverableReferenceHref("/deliverables/deliverable-123")).toEqual({
+      deliverableId: "deliverable-123",
+    });
+    expect(parseDeliverableReferenceHref("/PAP/deliverables/deliverable-456")).toEqual({
+      deliverableId: "deliverable-456",
+    });
+    expect(
+      parseDeliverableReferenceHref("https://paperclip.ing/PAP/deliverables/deliverable-789#preview"),
+    ).toEqual({
+      deliverableId: "deliverable-789",
+    });
+    expect(parseDeliverableReferenceHref("https://paperclip.ing/projects/deliverable-789")).toBeNull();
+  });
+
+  it("builds company-relative deliverable detail links", () => {
+    expect(buildDeliverableReferenceHref("deliverable-123")).toBe("/deliverables/deliverable-123");
+  });
+});

--- a/packages/shared/src/deliverable-references.ts
+++ b/packages/shared/src/deliverable-references.ts
@@ -1,0 +1,32 @@
+export function buildDeliverableReferenceHref(deliverableId: string): string {
+  return `/deliverables/${deliverableId.trim()}`;
+}
+
+export function parseDeliverableReferenceHref(href: string): { deliverableId: string } | null {
+  const raw = href.trim();
+  if (!raw) return null;
+
+  let url: URL;
+  try {
+    url = raw.startsWith("/")
+      ? new URL(raw, "https://paperclip.invalid")
+      : new URL(raw);
+  } catch {
+    return null;
+  }
+
+  const segments = url.pathname
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    if (segments[index]?.toLowerCase() !== "deliverables") continue;
+    const deliverableId = (segments[index + 1] ?? "").trim();
+    if (deliverableId) {
+      return { deliverableId };
+    }
+  }
+
+  return null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -513,6 +513,11 @@ export {
   parseIssueArtifactWorkProductMetadata,
 } from "./types/index.js";
 export {
+  buildDeliverableReferenceHref,
+  parseDeliverableReferenceHref,
+} from "./deliverable-references.js";
+
+export {
   ISSUE_REFERENCE_IDENTIFIER_RE,
   buildIssueReferenceHref,
   extractIssueReferenceIdentifiers,

--- a/ui/src/components/MarkdownBody.test.tsx
+++ b/ui/src/components/MarkdownBody.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   buildAgentMentionHref,
+  buildDeliverableReferenceHref,
   buildIssueReferenceHref,
   buildProjectMentionHref,
   buildSkillMentionHref,
@@ -87,12 +88,12 @@ describe("MarkdownBody", () => {
     expect(html).toContain('alt="Org chart"');
   });
 
-  it("renders user, agent, project, and skill mentions as chips", () => {
+  it("renders user, agent, deliverable, project, and skill mentions as chips", () => {
     const html = renderToStaticMarkup(
       <QueryClientProvider client={new QueryClient()}>
         <ThemeProvider>
           <MarkdownBody>
-            {`[@Taylor](${buildUserMentionHref("user-123")}) [@CodexCoder](${buildAgentMentionHref("agent-123", "code")}) [@Paperclip App](${buildProjectMentionHref("project-456", "#336699")}) [/release-changelog](${buildSkillMentionHref("skill-789", "release-changelog")})`}
+            {`[@Taylor](${buildUserMentionHref("user-123")}) [@CodexCoder](${buildAgentMentionHref("agent-123", "code")}) [@@@Final Report](${buildDeliverableReferenceHref("deliverable-999")}) [@Paperclip App](${buildProjectMentionHref("project-456", "#336699")}) [/release-changelog](${buildSkillMentionHref("skill-789", "release-changelog")})`}
           </MarkdownBody>
         </ThemeProvider>
       </QueryClientProvider>,
@@ -103,6 +104,8 @@ describe("MarkdownBody", () => {
     expect(html).toContain('href="/agents/agent-123"');
     expect(html).toContain('data-mention-kind="agent"');
     expect(html).toContain("--paperclip-mention-icon-mask");
+    expect(html).toContain('href="/deliverables/deliverable-999"');
+    expect(html).toContain('data-mention-kind="deliverable"');
     expect(html).toContain('href="/projects/project-456"');
     expect(html).toContain('data-mention-kind="project"');
     expect(html).toContain("--paperclip-mention-project-color:#336699");

--- a/ui/src/components/MarkdownBody.tsx
+++ b/ui/src/components/MarkdownBody.tsx
@@ -252,10 +252,12 @@ export function MarkdownBody({
           ? `/projects/${parsed.projectId}`
           : parsed.kind === "issue"
             ? `/issues/${parsed.identifier}`
-          : parsed.kind === "skill"
-            ? `/skills/${parsed.skillId}`
-            : parsed.kind === "user"
-              ? "/company/settings/access"
+            : parsed.kind === "deliverable"
+              ? `/deliverables/${parsed.deliverableId}`
+            : parsed.kind === "skill"
+              ? `/skills/${parsed.skillId}`
+              : parsed.kind === "user"
+                ? "/company/settings/access"
             : `/agents/${parsed.agentId}`;
         return (
           <a

--- a/ui/src/components/MarkdownEditor.test.tsx
+++ b/ui/src/components/MarkdownEditor.test.tsx
@@ -3,7 +3,12 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildProjectMentionHref, buildSkillMentionHref } from "@paperclipai/shared";
+import {
+  buildDeliverableReferenceHref,
+  buildIssueReferenceHref,
+  buildProjectMentionHref,
+  buildSkillMentionHref,
+} from "@paperclipai/shared";
 import {
   computeMentionMenuPosition,
   findClosestAutocompleteAnchor,
@@ -360,10 +365,43 @@ describe("MarkdownEditor", () => {
     expect(findMentionMatch("Ping @Paperclip App", "Ping @Paperclip App".length)).toEqual({
       trigger: "mention",
       marker: "@",
+      mentionKind: "agent",
+      markerCount: 1,
       query: "Paperclip App",
       atPos: 5,
       endPos: "Ping @Paperclip App".length,
     });
+  });
+
+  it("switches the mention domain based on repeated @ markers", () => {
+    expect(findMentionMatch("@@PAP", "@@PAP".length)).toEqual({
+      trigger: "mention",
+      marker: "@",
+      mentionKind: "issue",
+      markerCount: 2,
+      query: "PAP",
+      atPos: 0,
+      endPos: "@@PAP".length,
+    });
+    expect(findMentionMatch("@@@Final", "@@@Final".length)).toEqual({
+      trigger: "mention",
+      marker: "@",
+      mentionKind: "deliverable",
+      markerCount: 3,
+      query: "Final",
+      atPos: 0,
+      endPos: "@@@Final".length,
+    });
+    expect(findMentionMatch("@@@@Auth", "@@@@Auth".length)).toEqual({
+      trigger: "mention",
+      marker: "@",
+      mentionKind: "project",
+      markerCount: 4,
+      query: "Auth",
+      atPos: 0,
+      endPos: "@@@@Auth".length,
+    });
+    expect(findMentionMatch("@@@@@Nope", "@@@@@Nope".length)).toBeNull();
   });
 
   it("still rejects slash commands once spaces are typed", () => {
@@ -383,6 +421,8 @@ describe("MarkdownEditor", () => {
       {
         trigger: "skill",
         marker: "/",
+        markerCount: 1,
+        mentionKind: null,
         query: "agent",
         textNode,
         atPos: 0,
@@ -391,6 +431,8 @@ describe("MarkdownEditor", () => {
       {
         trigger: "skill",
         marker: "/",
+        markerCount: 1,
+        mentionKind: null,
         query: "agent",
         textNode,
         atPos: 0,
@@ -402,6 +444,8 @@ describe("MarkdownEditor", () => {
       {
         trigger: "skill",
         marker: "/",
+        markerCount: 1,
+        mentionKind: null,
         query: "agent",
         textNode,
         atPos: 0,
@@ -410,6 +454,8 @@ describe("MarkdownEditor", () => {
       {
         trigger: "skill",
         marker: "/",
+        markerCount: 1,
+        mentionKind: null,
         query: "agent-browser",
         textNode,
         atPos: 0,
@@ -467,7 +513,7 @@ describe("MarkdownEditor", () => {
     await act(async () => {
       root.render(
         <MarkdownEditor
-          value="@Pap"
+          value="@@@@Pap"
           onChange={handleChange}
           mentions={[
             {
@@ -492,7 +538,7 @@ describe("MarkdownEditor", () => {
 
     const selection = window.getSelection();
     const range = document.createRange();
-    range.setStart(textNode!, "@Pap".length);
+    range.setStart(textNode!, "@@@@Pap".length);
     range.collapse(true);
     selection?.removeAllRanges();
     selection?.addRange(range);
@@ -512,8 +558,172 @@ describe("MarkdownEditor", () => {
     });
 
     expect(handleChange).toHaveBeenCalledWith(
-      `[@Paperclip App](${buildProjectMentionHref("project-123", "#336699")}) `,
+      `[Paperclip App](${buildProjectMentionHref("project-123", "#336699")}) `,
     );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("opens issue mode immediately for @@ and inserts a canonical issue link on selection", async () => {
+    const handleChange = vi.fn();
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MarkdownEditor
+          value="@@"
+          onChange={handleChange}
+          mentions={[
+            {
+              id: "issue:issue-123",
+              kind: "issue",
+              name: "Tighten wake context",
+              issueId: "issue-123",
+              issueIdentifier: "PAP-123",
+            },
+          ]}
+        />,
+      );
+    });
+
+    await flush();
+
+    const editable = container.querySelector('[contenteditable="true"]');
+    const textNode = editable?.firstChild;
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(textNode!, "@@".length);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    act(() => {
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+
+    await flush();
+
+    expect(document.body.textContent).toContain("Agents");
+    expect(document.body.textContent).toContain("Search issues");
+    expect(document.body.textContent).toContain("Issues");
+    expect(document.body.textContent).toContain("Deliverables");
+    expect(document.body.textContent).toContain("Projects");
+    const option = Array.from(document.body.querySelectorAll('button[type="button"]'))
+      .find((node) => node.textContent?.includes("PAP-123"));
+    expect(option).toBeTruthy();
+
+    act(() => {
+      option?.dispatchEvent(new Event("touchstart", { bubbles: true, cancelable: true }));
+    });
+
+    expect(handleChange).toHaveBeenCalledWith(
+      `[PAP-123](${buildIssueReferenceHref("PAP-123")}) `,
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("opens deliverable mode immediately for @@@ and inserts a canonical deliverable link on selection", async () => {
+    const handleChange = vi.fn();
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MarkdownEditor
+          value="@@@"
+          onChange={handleChange}
+          mentions={[
+            {
+              id: "deliverable:deliverable-123",
+              kind: "deliverable",
+              name: "Final Report",
+              deliverableId: "deliverable-123",
+              deliverableContextLabel: "PAP-9 Quarterly review",
+            },
+          ]}
+        />,
+      );
+    });
+
+    await flush();
+
+    const editable = container.querySelector('[contenteditable="true"]');
+    const textNode = editable?.firstChild;
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(textNode!, "@@@".length);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    act(() => {
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+
+    await flush();
+
+    expect(document.body.textContent).toContain("Search deliverables");
+    const option = Array.from(document.body.querySelectorAll('button[type="button"]'))
+      .find((node) => node.textContent?.includes("Final Report"));
+    expect(option).toBeTruthy();
+
+    act(() => {
+      option?.dispatchEvent(new Event("touchstart", { bubbles: true, cancelable: true }));
+    });
+
+    expect(handleChange).toHaveBeenCalledWith(
+      `[Final Report](${buildDeliverableReferenceHref("deliverable-123")}) `,
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("closes the menu when five @ markers are typed", async () => {
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MarkdownEditor
+          value="@@@@@"
+          onChange={() => {}}
+          mentions={[
+            {
+              id: "project:project-123",
+              kind: "project",
+              name: "Paperclip App",
+              projectId: "project-123",
+              projectColor: "#336699",
+            },
+          ]}
+        />,
+      );
+    });
+
+    await flush();
+
+    const editable = container.querySelector('[contenteditable="true"]');
+    const textNode = editable?.firstChild;
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(textNode!, "@@@@@".length);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    act(() => {
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+
+    await flush();
+
+    expect(document.body.textContent).not.toContain("Search projects");
+    expect(document.body.textContent).not.toContain("Agents");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/MarkdownEditor.test.tsx
+++ b/ui/src/components/MarkdownEditor.test.tsx
@@ -13,6 +13,7 @@ import {
   computeMentionMenuPosition,
   findClosestAutocompleteAnchor,
   findMentionMatch,
+  getMentionMenuSize,
   isSameAutocompleteSession,
   MarkdownEditor,
   placeCaretAfterMentionAnchor,
@@ -353,7 +354,7 @@ describe("MarkdownEditor", () => {
       ),
     ).toEqual({
       top: 372,
-      left: 144,
+      left: 64,
     });
   });
 
@@ -365,7 +366,7 @@ describe("MarkdownEditor", () => {
       ),
     ).toEqual({
       top: 12,
-      left: 92,
+      left: 8,
     });
   });
 
@@ -373,12 +374,23 @@ describe("MarkdownEditor", () => {
     expect(
       computeMentionMenuPosition(
         { viewportTop: 160, viewportLeft: 120 },
-        { offsetLeft: 0, offsetTop: 0, width: 320, height: 220 },
-        { width: 188, height: 42 },
+        { offsetLeft: 0, offsetTop: 0, width: 420, height: 280 },
+        getMentionMenuSize(0, "mention"),
       ),
     ).toEqual({
       top: 164,
       left: 120,
+    });
+  });
+
+  it("includes the mention header chrome when sizing empty-state menus", () => {
+    expect(getMentionMenuSize(0, "mention")).toEqual({
+      width: 280,
+      height: 92,
+    });
+    expect(getMentionMenuSize(0, "skill")).toEqual({
+      width: 280,
+      height: 62,
     });
   });
 

--- a/ui/src/components/MarkdownEditor.test.tsx
+++ b/ui/src/components/MarkdownEditor.test.tsx
@@ -27,6 +27,20 @@ const mdxEditorMockState = vi.hoisted(() => ({
   suppressHtmlProcessingValues: [] as boolean[],
 }));
 
+const editorAutocompleteMockState = vi.hoisted(() => ({
+  slashCommands: [] as Array<{
+    id: string;
+    kind: "skill";
+    skillId: string;
+    key: string;
+    name: string;
+    slug: string;
+    description: string | null;
+    href: string;
+    aliases: string[];
+  }>,
+}));
+
 vi.mock("@mdxeditor/editor", async () => {
   const React = await import("react");
 
@@ -144,6 +158,12 @@ vi.mock("../lib/paste-normalization", () => ({
   pasteNormalizationPlugin: () => ({}),
 }));
 
+vi.mock("../context/EditorAutocompleteContext", () => ({
+  useEditorAutocomplete: () => ({
+    slashCommands: editorAutocompleteMockState.slashCommands,
+  }),
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -161,6 +181,7 @@ describe("MarkdownEditor", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     originalRangeRect = Range.prototype.getBoundingClientRect;
+    editorAutocompleteMockState.slashCommands = [];
     Range.prototype.getBoundingClientRect = () => ({
       x: 32,
       y: 24,
@@ -415,6 +436,57 @@ describe("MarkdownEditor", () => {
     expect(shouldAcceptAutocompleteKey("Tab", "skill")).toBe(true);
   });
 
+  it("does not render mention domain tabs for slash-command autocomplete", async () => {
+    editorAutocompleteMockState.slashCommands = [
+      {
+        id: "skill:skill-123",
+        kind: "skill",
+        skillId: "skill-123",
+        key: "agent-browser",
+        name: "Agent Browser",
+        slug: "agent-browser",
+        description: "Launch the browser skill",
+        href: buildSkillMentionHref("skill-123", "agent-browser"),
+        aliases: ["agent-browser", "Agent Browser"],
+      },
+    ];
+
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MarkdownEditor
+          value="/agent"
+          onChange={() => {}}
+        />,
+      );
+    });
+
+    await flush();
+
+    const editable = container.querySelector('[contenteditable="true"]');
+    const textNode = editable?.firstChild;
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(textNode!, "/agent".length);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    act(() => {
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+
+    await flush();
+
+    expect(document.body.textContent).not.toContain("Members");
+    expect(document.body.textContent).toContain("Search skills");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("keeps the same autocomplete session active while the slash query is unchanged", () => {
     const textNode = document.createTextNode("/agent");
     expect(isSameAutocompleteSession(
@@ -566,6 +638,59 @@ describe("MarkdownEditor", () => {
     });
   });
 
+  it("includes human members in single-@ results", async () => {
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MarkdownEditor
+          value="@Tay"
+          onChange={() => {}}
+          mentions={[
+            {
+              id: "user:user-123",
+              kind: "user",
+              name: "Taylor",
+              userId: "user-123",
+            },
+            {
+              id: "agent:agent-123",
+              kind: "agent",
+              name: "CodexCoder",
+              agentId: "agent-123",
+              agentIcon: "code",
+            },
+          ]}
+        />,
+      );
+    });
+
+    await flush();
+
+    const editable = container.querySelector('[contenteditable="true"]');
+    const textNode = editable?.firstChild;
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(textNode!, "@Tay".length);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    act(() => {
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+
+    await flush();
+
+    expect(document.body.textContent).toContain("Members");
+    expect(document.body.textContent).toContain("Search members");
+    expect(document.body.textContent).toContain("Taylor");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("opens issue mode immediately for @@ and inserts a canonical issue link on selection", async () => {
     const handleChange = vi.fn();
     const root = createRoot(container);
@@ -605,7 +730,7 @@ describe("MarkdownEditor", () => {
 
     await flush();
 
-    expect(document.body.textContent).toContain("Agents");
+    expect(document.body.textContent).toContain("Members");
     expect(document.body.textContent).toContain("Search issues");
     expect(document.body.textContent).toContain("Issues");
     expect(document.body.textContent).toContain("Deliverables");
@@ -723,7 +848,7 @@ describe("MarkdownEditor", () => {
     await flush();
 
     expect(document.body.textContent).not.toContain("Search projects");
-    expect(document.body.textContent).not.toContain("Agents");
+    expect(document.body.textContent).not.toContain("Members");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -208,7 +208,7 @@ const MENTION_MENU_PADDING = 8;
 const MENTION_MENU_ROW_HEIGHT = 34;
 const MENTION_MENU_CHROME_HEIGHT = 8;
 const MENTION_DOMAIN_TABS = [
-  { kind: "agent", label: "Agents" },
+  { kind: "agent", label: "Members" },
   { kind: "issue", label: "Issues" },
   { kind: "deliverable", label: "Deliverables" },
   { kind: "project", label: "Projects" },
@@ -637,7 +637,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     const candidates = mentions.filter((mention) => {
       switch (mentionState.mentionKind) {
         case "agent":
-          return mention.kind === "agent";
+          return mention.kind === "agent" || mention.kind === "user";
         case "issue":
           return mention.kind === "issue";
         case "deliverable":
@@ -1218,22 +1218,27 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
             }}
           >
             <div className="border-b border-border">
-              <div className="flex items-center gap-1 overflow-x-auto px-2 py-1.5 text-xs text-muted-foreground">
-                {MENTION_DOMAIN_TABS.map((tab) => (
-                  <div
-                    key={tab.kind}
-                    className={cn(
-                      "shrink-0 rounded-sm px-2 py-1",
-                      mentionState.mentionKind === tab.kind
-                        ? "bg-accent text-foreground"
-                        : "opacity-70",
-                    )}
-                  >
-                    {tab.label}
-                  </div>
-                ))}
-              </div>
-              <div className="border-t border-border px-3 py-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+              {mentionState.trigger === "mention" ? (
+                <div className="flex items-center gap-1 overflow-x-auto px-2 py-1.5 text-xs text-muted-foreground">
+                  {MENTION_DOMAIN_TABS.map((tab) => (
+                    <div
+                      key={tab.kind}
+                      className={cn(
+                        "shrink-0 rounded-sm px-2 py-1",
+                        mentionState.mentionKind === tab.kind
+                          ? "bg-accent text-foreground"
+                          : "opacity-70",
+                      )}
+                    >
+                      {tab.label}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              <div className={cn(
+                "px-3 py-1.5 text-[11px] uppercase tracking-wide text-muted-foreground",
+                mentionState.trigger === "mention" && "border-t border-border",
+              )}>
                 {mentionPromptLabel(mentionState)}
               </div>
             </div>
@@ -1368,7 +1373,7 @@ function mentionPromptLabel(state: MentionState): string {
       return "Search projects";
     case "agent":
     default:
-      return "Search agents";
+      return "Search members";
   }
 }
 

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -31,8 +31,14 @@ import {
   thematicBreakPlugin,
   type RealmPlugin,
 } from "@mdxeditor/editor";
-import { buildAgentMentionHref, buildProjectMentionHref, buildUserMentionHref } from "@paperclipai/shared";
-import { Boxes, User } from "lucide-react";
+import {
+  buildAgentMentionHref,
+  buildDeliverableReferenceHref,
+  buildIssueReferenceHref,
+  buildProjectMentionHref,
+  buildUserMentionHref,
+} from "@paperclipai/shared";
+import { Boxes, CircleDot, FileText, FolderKanban, User } from "lucide-react";
 import { AgentIcon } from "./AgentIconPicker";
 import { applyMentionChipDecoration, clearMentionChipDecoration, parseMentionChipHref } from "../lib/mention-chips";
 import { MentionAwareLinkNode, mentionAwareLinkNodeReplacement } from "../lib/mention-aware-link-node";
@@ -48,12 +54,19 @@ import { useEditorAutocomplete, type SkillCommandOption } from "../context/Edito
 export interface MentionOption {
   id: string;
   name: string;
-  kind?: "agent" | "project" | "user";
+  kind?: "agent" | "project" | "user" | "issue" | "deliverable";
+  searchText?: string;
   agentId?: string;
   agentIcon?: string | null;
   projectId?: string;
   projectColor?: string | null;
+  projectStatus?: string | null;
   userId?: string;
+  issueId?: string;
+  issueIdentifier?: string;
+  deliverableId?: string;
+  deliverableContextLabel?: string | null;
+  deliverableFilename?: string | null;
 }
 
 /* ---- Editor props ---- */
@@ -162,6 +175,8 @@ function isSafeMarkdownLinkUrl(url: string): boolean {
 interface MentionState {
   trigger: "mention" | "skill";
   marker: "@" | "/";
+  markerCount: number;
+  mentionKind: "agent" | "issue" | "deliverable" | "project" | null;
   query: string;
   top: number;
   left: number;
@@ -192,6 +207,12 @@ const MENTION_MENU_HEIGHT = 208;
 const MENTION_MENU_PADDING = 8;
 const MENTION_MENU_ROW_HEIGHT = 34;
 const MENTION_MENU_CHROME_HEIGHT = 8;
+const MENTION_DOMAIN_TABS = [
+  { kind: "agent", label: "Agents" },
+  { kind: "issue", label: "Issues" },
+  { kind: "deliverable", label: "Deliverables" },
+  { kind: "project", label: "Projects" },
+] as const;
 
 const CODE_BLOCK_LANGUAGES: Record<string, string> = {
   txt: "Text",
@@ -224,17 +245,30 @@ const FALLBACK_CODE_BLOCK_DESCRIPTOR: CodeBlockEditorDescriptor = {
 export function findMentionMatch(
   text: string,
   offset: number,
-): Pick<MentionState, "trigger" | "marker" | "query" | "atPos" | "endPos"> | null {
+): Pick<MentionState, "trigger" | "marker" | "markerCount" | "mentionKind" | "query" | "atPos" | "endPos"> | null {
   let atPos = -1;
   let trigger: MentionState["trigger"] | null = null;
   let marker: MentionState["marker"] | null = null;
+  let markerCount = 0;
   for (let i = offset - 1; i >= 0; i--) {
     const ch = text[i];
     if (ch === "@" || ch === "/") {
-      if (i === 0 || /\s/.test(text[i - 1])) {
+      if (ch === "@") {
+        let start = i;
+        while (start > 0 && text[start - 1] === "@") {
+          start -= 1;
+        }
+        if (start === 0 || /\s/.test(text[start - 1])) {
+          atPos = start;
+          trigger = "mention";
+          marker = "@";
+          markerCount = i - start + 1;
+        }
+      } else if (i === 0 || /\s/.test(text[i - 1])) {
         atPos = i;
-        trigger = ch === "@" ? "mention" : "skill";
-        marker = ch;
+        trigger = "skill";
+        marker = "/";
+        markerCount = 1;
       }
       break;
     }
@@ -242,16 +276,28 @@ export function findMentionMatch(
   }
 
   if (atPos === -1) return null;
-  const query = text.slice(atPos + 1, offset);
+  const query = text.slice(atPos + markerCount, offset);
   if (trigger === "skill" && /\s/.test(query)) return null;
+  const mentionKind = trigger === "mention" ? resolveMentionKind(markerCount) : null;
+  if (trigger === "mention" && mentionKind === null) return null;
 
   return {
     trigger: trigger ?? "mention",
     marker: marker ?? "@",
+    markerCount,
+    mentionKind,
     query,
     atPos,
     endPos: offset,
   };
+}
+
+function resolveMentionKind(markerCount: number): MentionState["mentionKind"] {
+  if (markerCount <= 1) return "agent";
+  if (markerCount === 2) return "issue";
+  if (markerCount === 3) return "deliverable";
+  if (markerCount === 4) return "project";
+  return null;
 }
 
 function detectMention(container: HTMLElement): MentionState | null {
@@ -278,6 +324,8 @@ function detectMention(container: HTMLElement): MentionState | null {
   return {
     trigger: match.trigger,
     marker: match.marker,
+    markerCount: match.markerCount,
+    mentionKind: match.mentionKind,
     query: match.query,
     top: rect.bottom - containerRect.top,
     left: rect.left - containerRect.left,
@@ -354,8 +402,14 @@ function isSelectionInsideCodeLikeElement(container: HTMLElement | null) {
 }
 
 function mentionMarkdown(option: MentionOption): string {
+  if (option.kind === "issue" && option.issueIdentifier) {
+    return `[${option.issueIdentifier}](${buildIssueReferenceHref(option.issueIdentifier)}) `;
+  }
+  if (option.kind === "deliverable" && option.deliverableId) {
+    return `[${option.name}](${buildDeliverableReferenceHref(option.deliverableId)}) `;
+  }
   if (option.kind === "project" && option.projectId) {
-    return `[@${option.name}](${buildProjectMentionHref(option.projectId, option.projectColor ?? null)}) `;
+    return `[${option.name}](${buildProjectMentionHref(option.projectId, option.projectColor ?? null)}) `;
   }
   if (option.kind === "user" && option.userId) {
     return `[@${option.name}](${buildUserMentionHref(option.userId)}) `;
@@ -383,12 +437,14 @@ export function shouldAcceptAutocompleteKey(
 }
 
 export function isSameAutocompleteSession(
-  left: Pick<MentionState, "trigger" | "marker" | "query" | "textNode" | "atPos" | "endPos"> | null,
-  right: Pick<MentionState, "trigger" | "marker" | "query" | "textNode" | "atPos" | "endPos"> | null,
+  left: Pick<MentionState, "trigger" | "marker" | "markerCount" | "mentionKind" | "query" | "textNode" | "atPos" | "endPos"> | null,
+  right: Pick<MentionState, "trigger" | "marker" | "markerCount" | "mentionKind" | "query" | "textNode" | "atPos" | "endPos"> | null,
 ): boolean {
   if (!left || !right) return false;
   return left.trigger === right.trigger
     && left.marker === right.marker
+    && left.markerCount === right.markerCount
+    && left.mentionKind === right.mentionKind
     && left.query === right.query
     && left.textNode === right.textNode
     && left.atPos === right.atPos
@@ -405,6 +461,12 @@ function autocompleteOptionMatchesLink(option: AutocompleteOption, href: string)
 
   if (option.kind === "project" && option.projectId) {
     return parsed.kind === "project" && parsed.projectId === option.projectId;
+  }
+  if (option.kind === "issue" && option.issueIdentifier) {
+    return parsed.kind === "issue" && parsed.identifier === option.issueIdentifier;
+  }
+  if (option.kind === "deliverable" && option.deliverableId) {
+    return parsed.kind === "deliverable" && parsed.deliverableId === option.deliverableId;
   }
   if (option.kind === "user" && option.userId) {
     return parsed.kind === "user" && parsed.userId === option.userId;
@@ -473,7 +535,7 @@ export function placeCaretAfterMentionAnchor(target: HTMLAnchorElement): boolean
 
 /** Replace the active autocomplete token in the markdown string with the selected token. */
 function applyMention(markdown: string, state: MentionState, option: AutocompleteOption): string {
-  const search = `${state.marker}${state.query}`;
+  const search = `${state.marker.repeat(state.markerCount)}${state.query}`;
   const replacement = autocompleteMarkdown(option);
   const idx = markdown.lastIndexOf(search);
   if (idx === -1) return markdown;
@@ -572,7 +634,37 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         .slice(0, 8);
     }
     if (!mentions) return [];
-    return mentions.filter((m) => m.name.toLowerCase().includes(q)).slice(0, 8);
+    const candidates = mentions.filter((mention) => {
+      switch (mentionState.mentionKind) {
+        case "agent":
+          return mention.kind === "agent";
+        case "issue":
+          return mention.kind === "issue";
+        case "deliverable":
+          return mention.kind === "deliverable";
+        case "project":
+          return mention.kind === "project";
+        default:
+          return false;
+      }
+    });
+    return candidates
+      .filter((mention) => {
+        if (!q) return true;
+        const haystack = [
+          mention.name,
+          mention.searchText,
+          mention.kind === "issue" ? mention.issueIdentifier : null,
+          mention.kind === "deliverable" ? mention.deliverableFilename : null,
+          mention.kind === "deliverable" ? mention.deliverableContextLabel : null,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(q);
+      })
+      .sort((left, right) => rankMentionOption(right, q) - rankMentionOption(left, q))
+      .slice(0, 8);
   }, [mentionState, mentions, slashCommands]);
 
   useImperativeHandle(forwardedRef, () => ({
@@ -704,7 +796,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     }
   }, [editorValue]);
 
-  const decorateProjectMentions = useCallback(() => {
+  const decorateMentionChips = useCallback(() => {
     const editable = containerRef.current?.querySelector('[contenteditable="true"]');
     if (!editable) return;
     const links = editable.querySelectorAll("a");
@@ -725,12 +817,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         continue;
       }
 
-      if (parsed.kind === "skill") {
-        applyMentionChipDecoration(link, parsed);
-        continue;
-      }
-
-      if (parsed.kind === "user" || parsed.kind === "issue") {
+      if (parsed.kind === "skill" || parsed.kind === "user" || parsed.kind === "issue" || parsed.kind === "deliverable") {
         applyMentionChipDecoration(link, parsed);
         continue;
       }
@@ -825,9 +912,9 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
   useEffect(() => {
     const editable = containerRef.current?.querySelector('[contenteditable="true"]');
     if (!editable) return;
-    decorateProjectMentions();
+    decorateMentionChips();
     const observer = new MutationObserver(() => {
-      decorateProjectMentions();
+      decorateMentionChips();
     });
     observer.observe(editable, {
       subtree: true,
@@ -835,7 +922,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
       characterData: true,
     });
     return () => observer.disconnect();
-  }, [decorateProjectMentions, value]);
+  }, [decorateMentionChips, value]);
 
   const selectMention = useCallback(
     (option: AutocompleteOption) => {
@@ -856,7 +943,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
         const editable = containerRef.current?.querySelector('[contenteditable="true"]');
         if (!(editable instanceof HTMLElement)) return;
 
-        decorateProjectMentions();
+        decorateMentionChips();
         editable.focus();
 
         const target = findClosestAutocompleteAnchor(editable, option, state);
@@ -877,7 +964,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
       setMentionState(null);
       return true;
     },
-    [decorateProjectMentions, onChange],
+    [decorateMentionChips, onChange],
   );
 
   const handleAutocompletePress = useCallback((
@@ -1121,16 +1208,37 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
       />
 
       {/* Mention dropdown — rendered via portal so it isn't clipped by overflow containers */}
-      {mentionActive && filteredMentions.length > 0 &&
+      {mentionActive && mentionMenuPosition &&
         createPortal(
           <div
-            className="fixed z-[9999] min-w-[180px] max-w-[calc(100vw-16px)] max-h-[200px] overflow-y-auto rounded-md border border-border bg-popover shadow-md"
+            className="fixed z-[9999] min-w-[280px] max-w-[calc(100vw-16px)] max-h-[240px] overflow-hidden rounded-md border border-border bg-popover shadow-md"
             style={{
-              top: Math.min(mentionState.viewportTop + 4, window.innerHeight - 208),
-              left: Math.max(8, Math.min(mentionState.viewportLeft, window.innerWidth - 188)),
+              top: mentionMenuPosition.top,
+              left: mentionMenuPosition.left,
             }}
           >
-            {filteredMentions.map((option, i) => (
+            <div className="border-b border-border">
+              <div className="flex items-center gap-1 overflow-x-auto px-2 py-1.5 text-xs text-muted-foreground">
+                {MENTION_DOMAIN_TABS.map((tab) => (
+                  <div
+                    key={tab.kind}
+                    className={cn(
+                      "shrink-0 rounded-sm px-2 py-1",
+                      mentionState.mentionKind === tab.kind
+                        ? "bg-accent text-foreground"
+                        : "opacity-70",
+                    )}
+                  >
+                    {tab.label}
+                  </div>
+                ))}
+              </div>
+              <div className="border-t border-border px-3 py-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+                {mentionPromptLabel(mentionState)}
+              </div>
+            </div>
+            <div className="max-h-[170px] overflow-y-auto">
+            {filteredMentions.length > 0 ? filteredMentions.map((option, i) => (
               <button
                 key={option.id}
                 type="button"
@@ -1150,11 +1258,12 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
               >
                 {option.kind === "skill" ? (
                   <Boxes className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                ) : option.kind === "issue" ? (
+                  <CircleDot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                ) : option.kind === "deliverable" ? (
+                  <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 ) : option.kind === "project" && option.projectId ? (
-                  <span
-                    className="inline-flex h-2 w-2 rounded-full border border-border/50"
-                    style={{ backgroundColor: option.projectColor ?? "#64748b" }}
-                  />
+                  <FolderKanban className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 ) : option.kind === "user" ? (
                   <User className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 ) : (
@@ -1163,10 +1272,31 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
                     className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
                   />
                 )}
-                <span>{option.kind === "skill" ? `/${option.slug}` : option.name}</span>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate">
+                    {option.kind === "skill"
+                      ? `/${option.slug}`
+                      : option.kind === "issue" && option.issueIdentifier
+                        ? `${option.issueIdentifier} ${option.name}`
+                        : option.name}
+                  </div>
+                  {option.kind === "deliverable" && option.deliverableContextLabel ? (
+                    <div className="truncate text-[11px] text-muted-foreground">{option.deliverableContextLabel}</div>
+                  ) : null}
+                </div>
                 {option.kind === "project" && option.projectId && (
                   <span className="ml-auto text-[10px] uppercase tracking-wide text-muted-foreground">
                     Project
+                  </span>
+                )}
+                {option.kind === "issue" && (
+                  <span className="ml-auto text-[10px] uppercase tracking-wide text-muted-foreground">
+                    Issue
+                  </span>
+                )}
+                {option.kind === "deliverable" && (
+                  <span className="ml-auto text-[10px] uppercase tracking-wide text-muted-foreground">
+                    Deliverable
                   </span>
                 )}
                 {option.kind === "user" && (
@@ -1180,7 +1310,12 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
                   </span>
                 )}
               </button>
-            ))}
+            )) : (
+              <div className="px-3 py-2 text-sm text-muted-foreground">
+                {mentionEmptyStateLabel(mentionState)}
+              </div>
+            )}
+            </div>
           </div>,
           document.body,
         )}
@@ -1201,3 +1336,44 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     </div>
   );
 });
+
+function rankMentionOption(option: MentionOption, query: string): number {
+  if (!query) return 0;
+  const normalized = query.toLowerCase();
+  if (option.kind === "issue") {
+    if (option.issueIdentifier?.toLowerCase().startsWith(normalized)) return 5;
+    if (option.issueIdentifier?.toLowerCase().includes(normalized)) return 4;
+    if (option.name.toLowerCase().includes(normalized)) return 3;
+    return 0;
+  }
+  if (option.kind === "deliverable") {
+    if (option.name.toLowerCase().includes(normalized)) return 4;
+    if (option.deliverableFilename?.toLowerCase().includes(normalized)) return 3;
+    if (option.deliverableContextLabel?.toLowerCase().includes(normalized)) return 2;
+    return 0;
+  }
+  if (option.name.toLowerCase().startsWith(normalized)) return 2;
+  if (option.name.toLowerCase().includes(normalized)) return 1;
+  return 0;
+}
+
+function mentionPromptLabel(state: MentionState): string {
+  if (state.trigger === "skill") return "Search skills";
+  switch (state.mentionKind) {
+    case "issue":
+      return "Search issues";
+    case "deliverable":
+      return "Search deliverables";
+    case "project":
+      return "Search projects";
+    case "agent":
+    default:
+      return "Search agents";
+  }
+}
+
+function mentionEmptyStateLabel(state: MentionState): string {
+  return state.query.trim()
+    ? `No matches for "${state.query.trim()}".`
+    : `${mentionPromptLabel(state)}...`;
+}

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -202,11 +202,12 @@ interface MentionMenuSize {
   height: number;
 }
 
-const MENTION_MENU_WIDTH = 188;
+const MENTION_MENU_WIDTH = 280;
 const MENTION_MENU_HEIGHT = 208;
 const MENTION_MENU_PADDING = 8;
 const MENTION_MENU_ROW_HEIGHT = 34;
-const MENTION_MENU_CHROME_HEIGHT = 8;
+const MENTION_MENU_SKILL_CHROME_HEIGHT = 28;
+const MENTION_MENU_MENTION_CHROME_HEIGHT = 58;
 const MENTION_DOMAIN_TABS = [
   { kind: "agent", label: "Members" },
   { kind: "issue", label: "Issues" },
@@ -372,13 +373,20 @@ export function computeMentionMenuPosition(
   };
 }
 
-function getMentionMenuSize(optionCount: number): MentionMenuSize {
+export function getMentionMenuSize(
+  optionCount: number,
+  trigger: "mention" | "skill" = "mention",
+): MentionMenuSize {
   const visibleRows = Math.max(1, Math.min(optionCount, 8));
+  const chromeHeight = trigger === "mention"
+    ? MENTION_MENU_MENTION_CHROME_HEIGHT
+    : MENTION_MENU_SKILL_CHROME_HEIGHT;
+
   return {
     width: MENTION_MENU_WIDTH,
     height: Math.min(
       MENTION_MENU_HEIGHT,
-      visibleRows * MENTION_MENU_ROW_HEIGHT + MENTION_MENU_CHROME_HEIGHT,
+      visibleRows * MENTION_MENU_ROW_HEIGHT + chromeHeight,
     ),
   };
 }
@@ -1004,7 +1012,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
     ? computeMentionMenuPosition(
         mentionState,
         getMentionMenuViewport(),
-        getMentionMenuSize(filteredMentions.length),
+        getMentionMenuSize(filteredMentions.length, mentionState.trigger),
       )
     : null;
 

--- a/ui/src/components/NewIssueDialog.test.tsx
+++ b/ui/src/components/NewIssueDialog.test.tsx
@@ -38,6 +38,7 @@ const toastState = vi.hoisted(() => ({
 }));
 
 const mockIssuesApi = vi.hoisted(() => ({
+  list: vi.fn(),
   create: vi.fn(),
   upsertDocument: vi.fn(),
   uploadAttachment: vi.fn(),
@@ -48,6 +49,10 @@ const mockExecutionWorkspacesApi = vi.hoisted(() => ({
 }));
 
 const mockProjectsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockDeliverablesApi = vi.hoisted(() => ({
   list: vi.fn(),
 }));
 
@@ -90,6 +95,10 @@ vi.mock("../api/execution-workspaces", () => ({
 
 vi.mock("../api/projects", () => ({
   projectsApi: mockProjectsApi,
+}));
+
+vi.mock("../api/deliverables", () => ({
+  deliverablesApi: mockDeliverablesApi,
 }));
 
 vi.mock("../api/agents", () => ({
@@ -251,6 +260,7 @@ describe("NewIssueDialog", () => {
     dialogState.closeNewIssue.mockReset();
     toastState.pushToast.mockReset();
     mockIssuesApi.create.mockReset();
+    mockIssuesApi.list.mockResolvedValue([]);
     mockIssuesApi.upsertDocument.mockReset();
     mockIssuesApi.uploadAttachment.mockReset();
     mockExecutionWorkspacesApi.list.mockResolvedValue([]);
@@ -263,6 +273,7 @@ describe("NewIssueDialog", () => {
         color: "#445566",
       },
     ]);
+    mockDeliverablesApi.list.mockResolvedValue({ items: [], limit: 200, offset: 0 });
     mockAgentsApi.list.mockResolvedValue([]);
     mockAgentsApi.adapterModels.mockResolvedValue([]);
     mockAuthApi.getSession.mockResolvedValue({ user: { id: "user-1" } });

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -4,6 +4,7 @@ import { pickTextColorForSolidBg } from "@/lib/color-contrast";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { executionWorkspacesApi } from "../api/execution-workspaces";
+import { deliverablesApi } from "../api/deliverables";
 import { issuesApi } from "../api/issues";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { projectsApi } from "../api/projects";
@@ -338,6 +339,16 @@ export function NewIssueDialog() {
     queryFn: () => projectsApi.list(effectiveCompanyId!),
     enabled: !!effectiveCompanyId && newIssueOpen,
   });
+  const { data: issueOptions } = useQuery({
+    queryKey: effectiveCompanyId ? ["issues", effectiveCompanyId, "autocomplete", 200] : ["issues", "new-issue", "pending"],
+    queryFn: () => issuesApi.list(effectiveCompanyId!, { limit: 200 }),
+    enabled: !!effectiveCompanyId && newIssueOpen,
+  });
+  const { data: deliverableOptions } = useQuery({
+    queryKey: effectiveCompanyId ? queryKeys.deliverables.list(effectiveCompanyId, { limit: 200 }) : ["deliverables", "new-issue", "pending"],
+    queryFn: () => deliverablesApi.list(effectiveCompanyId!, { limit: 200 }),
+    enabled: !!effectiveCompanyId && newIssueOpen,
+  });
   const { data: reusableExecutionWorkspaces } = useQuery({
     queryKey: queryKeys.executionWorkspaces.list(effectiveCompanyId!, {
       projectId,
@@ -389,10 +400,12 @@ export function NewIssueDialog() {
   const mentionOptions = useMemo<MentionOption[]>(() => {
     return buildMarkdownMentionOptions({
       agents,
+      issues: issueOptions,
+      deliverables: deliverableOptions?.items,
       projects: orderedProjects,
       members: companyMembers?.users,
     });
-  }, [agents, companyMembers?.users, orderedProjects]);
+  }, [agents, companyMembers?.users, deliverableOptions?.items, issueOptions, orderedProjects]);
 
   const { data: assigneeAdapterModels } = useQuery({
     queryKey:

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -3,6 +3,8 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { accessApi } from "../api/access";
+import { deliverablesApi } from "../api/deliverables";
+import { issuesApi } from "../api/issues";
 import { projectsApi } from "../api/projects";
 import { agentsApi } from "../api/agents";
 import { goalsApi } from "../api/goals";
@@ -76,6 +78,21 @@ export function NewProjectDialog() {
     queryFn: () => agentsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId && newProjectOpen,
   });
+  const { data: projects } = useQuery({
+    queryKey: queryKeys.projects.list(selectedCompanyId!),
+    queryFn: () => projectsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId && newProjectOpen,
+  });
+  const { data: issueOptions } = useQuery({
+    queryKey: selectedCompanyId ? ["issues", selectedCompanyId, "autocomplete", 200] : ["issues", "new-project", "pending"],
+    queryFn: () => issuesApi.list(selectedCompanyId!, { limit: 200 }),
+    enabled: !!selectedCompanyId && newProjectOpen,
+  });
+  const { data: deliverableOptions } = useQuery({
+    queryKey: selectedCompanyId ? queryKeys.deliverables.list(selectedCompanyId, { limit: 200 }) : ["deliverables", "new-project", "pending"],
+    queryFn: () => deliverablesApi.list(selectedCompanyId!, { limit: 200 }),
+    enabled: !!selectedCompanyId && newProjectOpen,
+  });
 
   const { data: companyMembers } = useQuery({
     queryKey: queryKeys.access.companyUserDirectory(selectedCompanyId!),
@@ -86,9 +103,12 @@ export function NewProjectDialog() {
   const mentionOptions = useMemo<MentionOption[]>(() => {
     return buildMarkdownMentionOptions({
       agents,
+      issues: issueOptions,
+      deliverables: deliverableOptions?.items,
+      projects,
       members: companyMembers?.users,
     });
-  }, [agents, companyMembers?.users]);
+  }, [agents, companyMembers?.users, deliverableOptions?.items, issueOptions, projects]);
 
   const createProject = useMutation({
     mutationFn: (data: Record<string, unknown>) =>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -502,14 +502,42 @@ a.paperclip-mention-chip::before {
 
 .paperclip-mdxeditor-content a.paperclip-mention-chip[data-mention-kind="project"]::before,
 a.paperclip-mention-chip[data-mention-kind="project"]::before {
-  width: 0.45rem;
-  height: 0.45rem;
-  border-radius: 999px;
+  width: 0.75rem;
+  height: 0.75rem;
   background-color: var(--paperclip-mention-project-color, currentColor);
+  -webkit-mask-image: var(--paperclip-mention-icon-mask);
+  mask-image: var(--paperclip-mention-icon-mask);
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
 }
 
 .paperclip-mdxeditor-content a.paperclip-mention-chip[data-mention-kind="agent"]::before,
 a.paperclip-mention-chip[data-mention-kind="agent"]::before {
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: currentColor;
+  -webkit-mask-image: var(--paperclip-mention-icon-mask);
+  mask-image: var(--paperclip-mention-icon-mask);
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
+.paperclip-mdxeditor-content a.paperclip-mention-chip[data-mention-kind="issue"]::before,
+.paperclip-mdxeditor-content a.paperclip-mention-chip[data-mention-kind="deliverable"]::before,
+.paperclip-mdxeditor-content a.paperclip-mention-chip[data-mention-kind="user"]::before,
+.paperclip-mdxeditor-content a.paperclip-mention-chip[data-mention-kind="skill"]::before,
+a.paperclip-mention-chip[data-mention-kind="issue"]::before,
+a.paperclip-mention-chip[data-mention-kind="deliverable"]::before,
+a.paperclip-mention-chip[data-mention-kind="user"]::before,
+a.paperclip-mention-chip[data-mention-kind="skill"]::before {
   width: 0.75rem;
   height: 0.75rem;
   background-color: currentColor;

--- a/ui/src/lib/company-members.test.ts
+++ b/ui/src/lib/company-members.test.ts
@@ -72,12 +72,38 @@ describe("company-members helpers", () => {
     const options = buildMarkdownMentionOptions({
       members: [activeMember({ principalId: "user-1", user: { id: "user-1", name: "Taylor", email: "taylor@example.com", image: null } })],
       agents: [{ id: "agent-1", name: "CodexCoder", status: "active", icon: "code" }],
+      issues: [{ id: "issue-1", identifier: "PAP-12", title: "Tighten wake context" }],
+      deliverables: [{
+        id: "deliverable-1",
+        title: "Final Report",
+        originalFilename: "report.pdf",
+        childIssue: { id: "issue-1", identifier: "PAP-12", title: "Tighten wake context", status: "done" },
+        rootIssue: null,
+      }],
       projects: [{ id: "project-1", name: "Paperclip App", color: "#336699" }],
+      includeUsers: true,
     });
 
     expect(options).toEqual([
       { id: "user:user-1", name: "Taylor", kind: "user", userId: "user-1" },
       { id: "agent:agent-1", name: "CodexCoder", kind: "agent", agentId: "agent-1", agentIcon: "code" },
+      {
+        id: "issue:issue-1",
+        name: "Tighten wake context",
+        kind: "issue",
+        issueId: "issue-1",
+        issueIdentifier: "PAP-12",
+        searchText: "PAP-12 Tighten wake context",
+      },
+      {
+        id: "deliverable:deliverable-1",
+        name: "Final Report",
+        kind: "deliverable",
+        deliverableId: "deliverable-1",
+        deliverableContextLabel: "PAP-12 Tighten wake context",
+        deliverableFilename: "report.pdf",
+        searchText: "Final Report report.pdf PAP-12 Tighten wake context",
+      },
       { id: "project:project-1", name: "Paperclip App", kind: "project", projectId: "project-1", projectColor: "#336699" },
     ]);
   });
@@ -98,7 +124,7 @@ describe("company-members helpers", () => {
         searchText: "Taylor taylor@example.com user-1",
       },
     ]);
-    expect(buildMarkdownMentionOptions({ members: users })).toEqual([
+    expect(buildMarkdownMentionOptions({ members: users, includeUsers: true })).toEqual([
       { id: "user:user-1", name: "Taylor", kind: "user", userId: "user-1" },
     ]);
   });

--- a/ui/src/lib/company-members.test.ts
+++ b/ui/src/lib/company-members.test.ts
@@ -81,7 +81,6 @@ describe("company-members helpers", () => {
         rootIssue: null,
       }],
       projects: [{ id: "project-1", name: "Paperclip App", color: "#336699" }],
-      includeUsers: true,
     });
 
     expect(options).toEqual([
@@ -124,8 +123,24 @@ describe("company-members helpers", () => {
         searchText: "Taylor taylor@example.com user-1",
       },
     ]);
-    expect(buildMarkdownMentionOptions({ members: users, includeUsers: true })).toEqual([
+    expect(buildMarkdownMentionOptions({ members: users })).toEqual([
       { id: "user:user-1", name: "Taylor", kind: "user", userId: "user-1" },
     ]);
+  });
+
+  it("skips malformed deliverables with no context issue", () => {
+    const malformedDeliverable = {
+      id: "deliverable-bad",
+      title: "Broken deliverable",
+      originalFilename: "broken.pdf",
+      childIssue: null,
+      rootIssue: null,
+    } as unknown as NonNullable<Parameters<typeof buildMarkdownMentionOptions>[0]["deliverables"]>[number];
+
+    const options = buildMarkdownMentionOptions({
+      deliverables: [malformedDeliverable],
+    });
+
+    expect(options).toEqual([]);
   });
 });

--- a/ui/src/lib/company-members.test.ts
+++ b/ui/src/lib/company-members.test.ts
@@ -107,6 +107,30 @@ describe("company-members helpers", () => {
     ]);
   });
 
+  it("uses the issue title once when a deliverable context issue has no identifier", () => {
+    const options = buildMarkdownMentionOptions({
+      deliverables: [{
+        id: "deliverable-1",
+        title: "Final Report",
+        originalFilename: "report.pdf",
+        childIssue: { id: "issue-1", identifier: null, title: "Refactor auth", status: "done" },
+        rootIssue: null,
+      }],
+    });
+
+    expect(options).toEqual([
+      {
+        id: "deliverable:deliverable-1",
+        name: "Final Report",
+        kind: "deliverable",
+        deliverableId: "deliverable-1",
+        deliverableContextLabel: "Refactor auth",
+        deliverableFilename: "report.pdf",
+        searchText: "Final Report report.pdf Refactor auth",
+      },
+    ]);
+  });
+
   it("accepts read-only directory entries for assignee and mention helpers", () => {
     const users: CompanyUserDirectoryEntry[] = [
       {

--- a/ui/src/lib/company-members.ts
+++ b/ui/src/lib/company-members.ts
@@ -119,14 +119,13 @@ export function buildMarkdownMentionOptions(args: {
       .flatMap((deliverable) => {
         const contextIssue = deliverable.rootIssue ?? deliverable.childIssue ?? null;
         if (!contextIssue) return [];
-        const contextIdentifier = contextIssue.identifier ?? contextIssue.title;
         return [{
           id: `deliverable:${deliverable.id}`,
           name: deliverable.title,
           kind: "deliverable" as const,
           deliverableId: deliverable.id,
-          deliverableContextLabel: contextIdentifier
-            ? `${contextIdentifier} ${contextIssue.title}`.trim()
+          deliverableContextLabel: contextIssue.identifier
+            ? `${contextIssue.identifier} ${contextIssue.title}`.trim()
             : contextIssue.title,
           deliverableFilename: deliverable.originalFilename ?? null,
           searchText: [

--- a/ui/src/lib/company-members.ts
+++ b/ui/src/lib/company-members.ts
@@ -1,7 +1,7 @@
 import type { CompanyMember, CompanyUserDirectoryEntry } from "@/api/access";
 import type { InlineEntityOption } from "@/components/InlineEntitySelector";
 import type { MentionOption } from "@/components/MarkdownEditor";
-import type { Agent, Project } from "@paperclipai/shared";
+import type { Agent, DeliverableListItem, Issue, Project } from "@paperclipai/shared";
 
 export interface CompanyUserProfile {
   label: string;
@@ -86,11 +86,14 @@ export function buildCompanyUserMentionOptions(
 
 export function buildMarkdownMentionOptions(args: {
   agents?: Array<Pick<Agent, "id" | "name" | "status" | "icon">> | null | undefined;
+  issues?: Array<Pick<Issue, "id" | "identifier" | "title">> | null | undefined;
+  deliverables?: Array<Pick<DeliverableListItem, "id" | "title" | "originalFilename" | "childIssue" | "rootIssue">> | null | undefined;
   projects?: Array<Pick<Project, "id" | "name" | "color">> | null | undefined;
   members?: CompanyUserRecord[] | null | undefined;
+  includeUsers?: boolean;
 }): MentionOption[] {
   const options: MentionOption[] = [
-    ...buildCompanyUserMentionOptions(args.members),
+    ...(args.includeUsers ? buildCompanyUserMentionOptions(args.members) : []),
     ...[...(args.agents ?? [])]
       .filter((agent) => agent.status !== "terminated")
       .sort((left, right) => left.name.localeCompare(right.name))
@@ -101,6 +104,39 @@ export function buildMarkdownMentionOptions(args: {
         agentId: agent.id,
         agentIcon: agent.icon,
       })),
+    ...[...(args.issues ?? [])]
+      .filter((issue) => Boolean(issue.identifier))
+      .sort((left, right) => (left.identifier ?? left.title).localeCompare(right.identifier ?? right.title))
+      .map((issue) => ({
+        id: `issue:${issue.id}`,
+        name: issue.title,
+        kind: "issue" as const,
+        issueId: issue.id,
+        issueIdentifier: issue.identifier ?? issue.id,
+        searchText: [issue.identifier, issue.title].filter(Boolean).join(" "),
+      })),
+    ...[...(args.deliverables ?? [])]
+      .sort((left, right) => left.title.localeCompare(right.title))
+      .map((deliverable) => {
+        const contextIssue = deliverable.rootIssue ?? deliverable.childIssue;
+        const contextIdentifier = contextIssue.identifier ?? contextIssue.title;
+        return {
+          id: `deliverable:${deliverable.id}`,
+          name: deliverable.title,
+          kind: "deliverable" as const,
+          deliverableId: deliverable.id,
+          deliverableContextLabel: contextIdentifier
+            ? `${contextIdentifier} ${contextIssue.title}`.trim()
+            : contextIssue.title,
+          deliverableFilename: deliverable.originalFilename ?? null,
+          searchText: [
+            deliverable.title,
+            deliverable.originalFilename,
+            contextIssue.identifier,
+            contextIssue.title,
+          ].filter(Boolean).join(" "),
+        };
+      }),
     ...[...(args.projects ?? [])]
       .sort((left, right) => left.name.localeCompare(right.name))
       .map((project) => ({

--- a/ui/src/lib/company-members.ts
+++ b/ui/src/lib/company-members.ts
@@ -104,14 +104,14 @@ export function buildMarkdownMentionOptions(args: {
         agentIcon: agent.icon,
       })),
     ...[...(args.issues ?? [])]
-      .filter((issue) => Boolean(issue.identifier))
+      .filter((issue): issue is Pick<Issue, "id" | "identifier" | "title"> & { identifier: string } => Boolean(issue.identifier))
       .sort((left, right) => (left.identifier ?? left.title).localeCompare(right.identifier ?? right.title))
       .map((issue) => ({
         id: `issue:${issue.id}`,
         name: issue.title,
         kind: "issue" as const,
         issueId: issue.id,
-        issueIdentifier: issue.identifier ?? issue.id,
+        issueIdentifier: issue.identifier,
         searchText: [issue.identifier, issue.title].filter(Boolean).join(" "),
       })),
     ...[...(args.deliverables ?? [])]

--- a/ui/src/lib/company-members.ts
+++ b/ui/src/lib/company-members.ts
@@ -90,10 +90,9 @@ export function buildMarkdownMentionOptions(args: {
   deliverables?: Array<Pick<DeliverableListItem, "id" | "title" | "originalFilename" | "childIssue" | "rootIssue">> | null | undefined;
   projects?: Array<Pick<Project, "id" | "name" | "color">> | null | undefined;
   members?: CompanyUserRecord[] | null | undefined;
-  includeUsers?: boolean;
 }): MentionOption[] {
   const options: MentionOption[] = [
-    ...(args.includeUsers ? buildCompanyUserMentionOptions(args.members) : []),
+    ...buildCompanyUserMentionOptions(args.members),
     ...[...(args.agents ?? [])]
       .filter((agent) => agent.status !== "terminated")
       .sort((left, right) => left.name.localeCompare(right.name))
@@ -117,10 +116,11 @@ export function buildMarkdownMentionOptions(args: {
       })),
     ...[...(args.deliverables ?? [])]
       .sort((left, right) => left.title.localeCompare(right.title))
-      .map((deliverable) => {
-        const contextIssue = deliverable.rootIssue ?? deliverable.childIssue;
+      .flatMap((deliverable) => {
+        const contextIssue = deliverable.rootIssue ?? deliverable.childIssue ?? null;
+        if (!contextIssue) return [];
         const contextIdentifier = contextIssue.identifier ?? contextIssue.title;
-        return {
+        return [{
           id: `deliverable:${deliverable.id}`,
           name: deliverable.title,
           kind: "deliverable" as const,
@@ -135,7 +135,7 @@ export function buildMarkdownMentionOptions(args: {
             contextIssue.identifier,
             contextIssue.title,
           ].filter(Boolean).join(" "),
-        };
+        }];
       }),
     ...[...(args.projects ?? [])]
       .sort((left, right) => left.name.localeCompare(right.name))

--- a/ui/src/lib/mention-chips.ts
+++ b/ui/src/lib/mention-chips.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import {
   parseAgentMentionHref,
+  parseDeliverableReferenceHref,
   parseIssueReferenceHref,
   parseProjectMentionHref,
   parseSkillMentionHref,
@@ -18,6 +19,10 @@ export type ParsedMentionChip =
   | {
       kind: "issue";
       identifier: string;
+    }
+  | {
+      kind: "deliverable";
+      deliverableId: string;
     }
   | {
       kind: "project";
@@ -42,6 +47,14 @@ export function parseMentionChipHref(href: string): ParsedMentionChip | null {
     return {
       kind: "issue",
       identifier: issue.identifier,
+    };
+  }
+
+  const deliverable = parseDeliverableReferenceHref(href);
+  if (deliverable) {
+    return {
+      kind: "deliverable",
+      deliverableId: deliverable.deliverableId,
     };
   }
 
@@ -92,11 +105,11 @@ export function mentionChipInlineStyle(mention: ParsedMentionChip): CSSPropertie
     style["--paperclip-mention-project-color"] = mention.color;
   }
 
-  if (mention.kind === "agent") {
-    const iconMask = buildAgentIconMask(mention.icon);
-    if (iconMask) {
-      style["--paperclip-mention-icon-mask"] = iconMask;
-    }
+  const iconMask = mention.kind === "agent"
+    ? buildAgentIconMask(mention.icon)
+    : buildMentionKindIconMask(mention.kind);
+  if (iconMask) {
+    style["--paperclip-mention-icon-mask"] = iconMask;
   }
 
   return Object.keys(style).length > 0 ? (style as CSSProperties) : undefined;
@@ -130,6 +143,7 @@ export function clearMentionChipDecoration(element: HTMLElement) {
     "paperclip-mention-chip",
     "paperclip-mention-chip--agent",
     "paperclip-mention-chip--issue",
+    "paperclip-mention-chip--deliverable",
     "paperclip-mention-chip--project",
     "paperclip-mention-chip--user",
     "paperclip-mention-chip--skill",
@@ -178,6 +192,30 @@ function buildAgentIconMask(iconName: string | null): string | null {
   iconMaskCache.set(cacheKey, url);
   return url;
 }
+
+function buildMentionKindIconMask(kind: Exclude<ParsedMentionChip["kind"], "agent">): string | null {
+  const cacheKey = `kind:${kind}`;
+  const cached = iconMaskCache.get(cacheKey);
+  if (cached) return cached;
+
+  const body = mentionKindIconSvg[kind];
+  if (!body) return null;
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" ` +
+    `fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" ` +
+    `stroke-linejoin="round">${body}</svg>`;
+  const url = `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
+  iconMaskCache.set(cacheKey, url);
+  return url;
+}
+
+const mentionKindIconSvg: Record<Exclude<ParsedMentionChip["kind"], "agent">, string> = {
+  issue: '<circle cx="12" cy="12" r="9"></circle><circle cx="12" cy="12" r="2"></circle>',
+  deliverable: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><path d="M14 2v6h6"></path><path d="M16 13H8"></path><path d="M16 17H8"></path><path d="M10 9H8"></path>',
+  project: '<path d="M3 7.5A1.5 1.5 0 0 1 4.5 6h5.379a1.5 1.5 0 0 1 1.06.44l1.121 1.12A1.5 1.5 0 0 0 13.121 8H19.5A1.5 1.5 0 0 1 21 9.5v8A1.5 1.5 0 0 1 19.5 19h-15A1.5 1.5 0 0 1 3 17.5z"></path>',
+  user: '<path d="M19 21a7 7 0 0 0-14 0"></path><circle cx="12" cy="8" r="4"></circle>',
+  skill: '<path d="M3 7l9-4 9 4-9 4z"></path><path d="M3 17l9 4 9-4"></path><path d="M3 12l9 4 9-4"></path>',
+};
 
 function resolveLucideIconNode(
   icon: unknown,

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1133,14 +1133,14 @@ export function IssueDetail() {
     enabled: !!selectedCompanyId,
   });
   const { data: issueOptions } = useQuery({
-    queryKey: resolvedCompanyId ? ["issues", resolvedCompanyId, "autocomplete", 200] : ["issues", "detail", "pending"],
-    queryFn: () => issuesApi.list(resolvedCompanyId!, { limit: 200 }),
-    enabled: !!resolvedCompanyId,
+    queryKey: selectedCompanyId ? ["issues", selectedCompanyId, "autocomplete", 200] : ["issues", "detail", "pending"],
+    queryFn: () => issuesApi.list(selectedCompanyId!, { limit: 200 }),
+    enabled: !!selectedCompanyId,
   });
   const { data: deliverableOptions } = useQuery({
-    queryKey: resolvedCompanyId ? queryKeys.deliverables.list(resolvedCompanyId, { limit: 200 }) : ["deliverables", "detail", "pending"],
-    queryFn: () => deliverablesApi.list(resolvedCompanyId!, { limit: 200 }),
-    enabled: !!resolvedCompanyId,
+    queryKey: selectedCompanyId ? queryKeys.deliverables.list(selectedCompanyId, { limit: 200 }) : ["deliverables", "detail", "pending"],
+    queryFn: () => deliverablesApi.list(selectedCompanyId!, { limit: 200 }),
+    enabled: !!selectedCompanyId,
   });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
   const { data: feedbackVotes } = useQuery({

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -11,6 +11,7 @@ import { instanceSettingsApi } from "../api/instanceSettings";
 import { accessApi } from "../api/access";
 import { agentsApi } from "../api/agents";
 import { authApi } from "../api/auth";
+import { deliverablesApi } from "../api/deliverables";
 import { projectsApi } from "../api/projects";
 import { useCompany } from "../context/CompanyContext";
 import { useDialog } from "../context/DialogContext";
@@ -1131,6 +1132,16 @@ export function IssueDetail() {
     queryFn: () => projectsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId,
   });
+  const { data: issueOptions } = useQuery({
+    queryKey: resolvedCompanyId ? ["issues", resolvedCompanyId, "autocomplete", 200] : ["issues", "detail", "pending"],
+    queryFn: () => issuesApi.list(resolvedCompanyId!, { limit: 200 }),
+    enabled: !!resolvedCompanyId,
+  });
+  const { data: deliverableOptions } = useQuery({
+    queryKey: resolvedCompanyId ? queryKeys.deliverables.list(resolvedCompanyId, { limit: 200 }) : ["deliverables", "detail", "pending"],
+    queryFn: () => deliverablesApi.list(resolvedCompanyId!, { limit: 200 }),
+    enabled: !!resolvedCompanyId,
+  });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
   const { data: feedbackVotes } = useQuery({
     queryKey: queryKeys.issues.feedbackVotes(issueId!),
@@ -1182,10 +1193,12 @@ export function IssueDetail() {
   const mentionOptions = useMemo<MentionOption[]>(() => {
     return buildMarkdownMentionOptions({
       agents,
+      issues: issueOptions,
+      deliverables: deliverableOptions?.items,
       projects: orderedProjects,
       members: companyMembers?.users,
     });
-  }, [agents, companyMembers?.users, orderedProjects]);
+  }, [agents, companyMembers?.users, deliverableOptions?.items, issueOptions, orderedProjects]);
 
   const resolvedProject = useMemo(
     () => (issue?.projectId ? orderedProjects.find((project) => project.id === issue.projectId) ?? issue.project ?? null : null),


### PR DESCRIPTION
## Thinking Path

> - Paperclip/Bizbox is a control plane for AI-agent companies, so work references inside operator writing surfaces need to map cleanly onto first-class company entities.
> - The relevant subsystem is the shared markdown editor and mention-chip rendering used by issue comments, issue descriptions, and creation flows.
> - The gap was that `@` only supported the older mixed mention behavior, while Issues, Deliverables, and Projects did not have a seamless, scoped tagging workflow.
> - That made cross-entity referencing slower and inconsistent with the product direction toward first-class work products and richer issue navigation.
> - This pull request extends the editor’s public autocomplete contract to support prefix-switched tagging for agents, issues, deliverables, and projects.
> - It also adds canonical deliverable references plus chip rendering so inserted selections round-trip through markdown storage and display.
> - The benefit is faster entity tagging in the highest-value V1 surfaces without replacing existing issue-reference compatibility.

## What Changed

- Added shared deliverable reference helpers and tests so deliverables have a canonical detail-link format alongside existing issue references.
- Extended `MarkdownEditor` to switch domains by repeated `@` count, close on five `@` characters, show all four domain tabs, and insert clean issue/deliverable/project pills without raw trigger prefixes.
- Updated mention chip parsing and markdown rendering so deliverable links render as first-class pills and continue routing to the correct entity pages.
- Expanded mention option building to include issues and deliverables, including scoped search metadata and domain-specific ranking.
- Wired issue and deliverable autocomplete data into the approved V1 surfaces: issue detail, new issue, and new project flows.
- Added and updated focused tests for shared references, mention option building, markdown rendering, editor behavior, and the new issue dialog.

## Verification

- `pnpm vitest run packages/shared/src/deliverable-references.test.ts ui/src/lib/company-members.test.ts ui/src/components/MarkdownEditor.test.tsx ui/src/components/MarkdownBody.test.tsx ui/src/components/NewIssueDialog.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm -r typecheck`
- `pnpm test` was run, but the suite reported unrelated existing failures in `src/__tests__/company-portability-routes.test.ts` and `src/__tests__/issue-agent-mutation-ownership-routes.test.ts`.

## Risks

- Editor autocomplete is shared across multiple markdown surfaces, so regressions could affect non-V1 surfaces that still pass `mentions` into `MarkdownEditor`.
- Issue and deliverable autocomplete currently use bounded client-side lists (`limit: 200`), so very large companies may eventually need dedicated server-backed search.
- This changes visible chip labels for issue, deliverable, and project selections, so any downstream UI assumptions about raw `@@`/`@@@` label text would need follow-up.

> I checked `ROADMAP.md`. This does not duplicate a planned roadmap feature; it is a scoped editor and entity-reference improvement within existing core surfaces.

## Model Used

- OpenAI Codex based on GPT-5 with tool use and code execution in the Codex desktop app.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
