### PR TITLE
Improve filename generation for document deliverables

### DIFF
--- a/server/src/__tests__/deliverables-routes.test.ts
+++ b/server/src/__tests__/deliverables-routes.test.ts
@@ -178,6 +178,22 @@ describe("deliverables routes", () => {
       expect(mockWorkProductService.getDeliverableById).not.toHaveBeenCalled();
     });
 
+    it("uses a title-derived filename for generic document deliverables", async () => {
+      mockWorkProductService.getDeliverableDocumentContentById.mockResolvedValue({
+        id: deliverableId,
+        companyId,
+        filename: "quarterly-closeout.md",
+        title: "Quarterly Closeout",
+        contentType: "text/markdown; charset=utf-8",
+        body: "# Quarterly Closeout",
+      });
+
+      const res = await request(createApp()).get(`/api/deliverables/${deliverableId}/content`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-disposition"]).toContain("quarterly-closeout.md");
+    });
+
     it("sanitizes document filename before setting content-disposition", async () => {
       mockWorkProductService.getDeliverableDocumentContentById.mockResolvedValue({
         id: deliverableId,

--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -198,6 +198,36 @@ describe("extractHeartbeatRunIssueDocumentPromotions", () => {
       body: "# Quarterly Closeout\n\nBody copy",
     }]);
   });
+
+  it("ignores non-prose leading lines when deriving a fallback document title", () => {
+    const promotions = extractHeartbeatRunIssueDocumentPromotions({
+      summary: [
+        "## Summary",
+        "",
+        "<issue-document>",
+        "- Bullet that should stay body content",
+        "> Quoted note",
+        "| Col | Val |",
+        "Quarterly Closeout",
+        "",
+        "Body copy",
+        "</issue-document>",
+      ].join("\n"),
+    });
+
+    expect(promotions).toEqual([{
+      key: "quarterly-closeout",
+      title: "Quarterly Closeout",
+      body: [
+        "- Bullet that should stay body content",
+        "> Quoted note",
+        "| Col | Val |",
+        "Quarterly Closeout",
+        "",
+        "Body copy",
+      ].join("\n"),
+    }]);
+  });
 });
 
 describe("mergeHeartbeatRunResultJson", () => {

--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -178,6 +178,26 @@ describe("extractHeartbeatRunIssueDocumentPromotions", () => {
       body: "Tagged body",
     }]);
   });
+
+  it("derives the fallback key and title from the document body when no key or title is supplied", () => {
+    const promotions = extractHeartbeatRunIssueDocumentPromotions({
+      summary: [
+        "## Summary",
+        "",
+        "<issue-document>",
+        "# Quarterly Closeout",
+        "",
+        "Body copy",
+        "</issue-document>",
+      ].join("\n"),
+    });
+
+    expect(promotions).toEqual([{
+      key: "quarterly-closeout",
+      title: "Quarterly Closeout",
+      body: "# Quarterly Closeout\n\nBody copy",
+    }]);
+  });
 });
 
 describe("mergeHeartbeatRunResultJson", () => {

--- a/server/src/__tests__/work-products.test.ts
+++ b/server/src/__tests__/work-products.test.ts
@@ -229,6 +229,29 @@ describe("workProductService", () => {
     expect(items[0]?.originalFilename).toBe("company-requirements.md");
   });
 
+  it("prefers the deliverable title for generic document filenames", async () => {
+    const now = new Date("2026-05-02T00:00:00.000Z");
+    const execute = vi.fn().mockResolvedValue([
+      createDeliverableQueryRow({
+        id: "doc-deliverable-2",
+        deliverable_source: "document",
+        title: "Quarterly Closeout",
+        metadata: null,
+        document_key: "deliverable",
+        document_format: "markdown",
+        document_body: "# Quarterly Closeout",
+        document_byte_size: 20,
+        created_at: now,
+        updated_at: now,
+      }),
+    ]);
+
+    const svc = workProductService({ execute } as any);
+    const items = await svc.listDeliverablesForCompany("company-1", { limit: 50, offset: 0 });
+
+    expect(items[0]?.originalFilename).toBe("quarterly-closeout.md");
+  });
+
   it("truncates inline document previews by UTF-8 byte length", async () => {
     const execute = vi
       .fn()

--- a/server/src/lib/document-filenames.ts
+++ b/server/src/lib/document-filenames.ts
@@ -1,0 +1,16 @@
+function slugifyFilenamePart(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : null;
+}
+
+export function buildDocumentFilename(key: string | null | undefined, title: string | null | undefined) {
+  const normalizedKey = key?.trim() || "document";
+  const titleSlug = slugifyFilenamePart(title);
+  const shouldPreferTitle = (normalizedKey === "document" || normalizedKey === "deliverable") && titleSlug;
+  return `${shouldPreferTitle ? titleSlug : normalizedKey}.md`;
+}

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -112,6 +112,23 @@ export interface ClickUpChatMessageReaction {
   count: number;
 }
 
+function slugifyFilenamePart(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : null;
+}
+
+function buildDocumentReviewFilename(key: string | null | undefined, title: string | null | undefined) {
+  const normalizedKey = key?.trim() || "document";
+  const titleSlug = slugifyFilenamePart(title);
+  const shouldPreferTitle = (normalizedKey === "document" || normalizedKey === "deliverable") && titleSlug;
+  return `${shouldPreferTitle ? titleSlug : normalizedKey}.md`;
+}
+
 export interface ClickUpAwaitingHumanApprovalResult {
   status: ClickUpApiStatus | "approved" | "forward_reply";
   detail: string;
@@ -582,7 +599,7 @@ export async function resolveAwaitingHumanReviewFile(
     source: "document",
     deliverableId: document.deliverable_id,
     title: document.title?.trim() || key,
-    filename: `${key}.md`,
+    filename: buildDocumentReviewFilename(document.key, document.title),
     contentType: document.format === "markdown" ? "text/markdown; charset=utf-8" : "text/plain; charset=utf-8",
     byteSize: Number(document.byte_size) || 0,
     contentPath,

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -3,6 +3,7 @@ import { Readable } from "node:stream";
 import { and, eq, inArray, lt, lte, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { awaitingHumanNotificationOutbox } from "@paperclipai/db";
+import { buildDocumentFilename } from "../lib/document-filenames.js";
 import type { StorageService } from "../storage/types.js";
 import { getStorageService } from "../storage/index.js";
 
@@ -112,21 +113,8 @@ export interface ClickUpChatMessageReaction {
   count: number;
 }
 
-function slugifyFilenamePart(value: string | null | undefined): string | null {
-  if (typeof value !== "string") return null;
-  const slug = value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return slug.length > 0 ? slug : null;
-}
-
 function buildDocumentReviewFilename(key: string | null | undefined, title: string | null | undefined) {
-  const normalizedKey = key?.trim() || "document";
-  const titleSlug = slugifyFilenamePart(title);
-  const shouldPreferTitle = (normalizedKey === "document" || normalizedKey === "deliverable") && titleSlug;
-  return `${shouldPreferTitle ? titleSlug : normalizedKey}.md`;
+  return buildDocumentFilename(key, title);
 }
 
 export interface ClickUpAwaitingHumanApprovalResult {

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -42,6 +42,10 @@ function normalizeDocumentTitle(value: string | null | undefined) {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function looksLikeDocumentTitleLine(line: string) {
+  return !/^(?:[#>*-]|\d+\.\s|\|)/.test(line);
+}
+
 function extractDocumentBodyTitle(body: string) {
   const headingMatch = body.match(/^\s*#\s+(.+?)\s*$/m);
   if (headingMatch?.[1]) {
@@ -51,7 +55,7 @@ function extractDocumentBodyTitle(body: string) {
   const firstContentLine = body
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .find(Boolean);
+    .find((line) => line.length > 0 && looksLikeDocumentTitleLine(line));
   return normalizeDocumentTitle(firstContentLine ?? null);
 }
 

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -42,6 +42,19 @@ function normalizeDocumentTitle(value: string | null | undefined) {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function extractDocumentBodyTitle(body: string) {
+  const headingMatch = body.match(/^\s*#\s+(.+?)\s*$/m);
+  if (headingMatch?.[1]) {
+    return normalizeDocumentTitle(headingMatch[1]);
+  }
+
+  const firstContentLine = body
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  return normalizeDocumentTitle(firstContentLine ?? null);
+}
+
 function dedupePromotions(
   promotions: HeartbeatRunIssueDocumentPromotion[],
 ): HeartbeatRunIssueDocumentPromotion[] {
@@ -65,7 +78,7 @@ function extractTaggedIssueDocuments(summary: string): HeartbeatRunIssueDocument
     if (!body) continue;
     const keyAttr = /(?:^|\s)key="([^"]+)"/i.exec(attrs)?.[1] ?? null;
     const titleAttr = /(?:^|\s)title="([^"]+)"/i.exec(attrs)?.[1] ?? null;
-    const title = normalizeDocumentTitle(titleAttr);
+    const title = normalizeDocumentTitle(titleAttr) ?? extractDocumentBodyTitle(body);
     const key = slugifyDocumentKey(keyAttr ?? title ?? "deliverable");
     promotions.push({ key, title, body });
   }

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -13,6 +13,7 @@ import {
   parseIssueArtifactWorkProductMetadata,
   deriveAgentUrlKey,
 } from "@paperclipai/shared";
+import { buildDocumentFilename } from "../lib/document-filenames.js";
 import { getStorageService } from "../storage/index.js";
 
 type IssueWorkProductRow = typeof issueWorkProducts.$inferSelect;
@@ -687,21 +688,8 @@ async function readStreamToBuffer(stream: Readable): Promise<Buffer> {
   return Buffer.concat(chunks);
 }
 
-function slugifyDeliverableFilenamePart(value: string | null | undefined) {
-  if (typeof value !== "string") return null;
-  const slug = value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return slug.length > 0 ? slug : null;
-}
-
 function buildDocumentDeliverableFilename(key: string | null | undefined, title: string | null | undefined) {
-  const normalizedKey = key?.trim() || "document";
-  const titleSlug = slugifyDeliverableFilenamePart(title);
-  const shouldPreferTitle = (normalizedKey === "document" || normalizedKey === "deliverable") && titleSlug;
-  return `${shouldPreferTitle ? titleSlug : normalizedKey}.md`;
+  return buildDocumentFilename(key, title);
 }
 
 function rowToDeliverableListItem(row: DeliverableQueryRow): DeliverableListItem | null {

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -546,8 +546,7 @@ export function workProductService(db: Db) {
       }>(rows)[0];
       if (!row) return null;
       const body = row.body ?? "";
-      const normalizedKey = row.key.trim().length > 0 ? row.key.trim() : "document";
-      const filename = `${normalizedKey}.md`;
+      const filename = buildDocumentDeliverableFilename(row.key, row.title);
       return {
         id: row.id,
         companyId: row.company_id,
@@ -688,6 +687,23 @@ async function readStreamToBuffer(stream: Readable): Promise<Buffer> {
   return Buffer.concat(chunks);
 }
 
+function slugifyDeliverableFilenamePart(value: string | null | undefined) {
+  if (typeof value !== "string") return null;
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : null;
+}
+
+function buildDocumentDeliverableFilename(key: string | null | undefined, title: string | null | undefined) {
+  const normalizedKey = key?.trim() || "document";
+  const titleSlug = slugifyDeliverableFilenamePart(title);
+  const shouldPreferTitle = (normalizedKey === "document" || normalizedKey === "deliverable") && titleSlug;
+  return `${shouldPreferTitle ? titleSlug : normalizedKey}.md`;
+}
+
 function rowToDeliverableListItem(row: DeliverableQueryRow): DeliverableListItem | null {
   let contentPath: string;
   let contentType: string;
@@ -717,8 +733,7 @@ function rowToDeliverableListItem(row: DeliverableQueryRow): DeliverableListItem
       ? "text/markdown; charset=utf-8"
       : "text/plain; charset=utf-8";
     byteSize = Number.isFinite(sqlByteSize) ? sqlByteSize : Buffer.byteLength(body, "utf8");
-    const key = (row.document_key ?? "document").trim() || "document";
-    originalFilename = `${key}.md`;
+    originalFilename = buildDocumentDeliverableFilename(row.document_key, row.title);
   }
 
   const rootIsSelf = row.ri_id === null || row.ri_id === row.ci_id;


### PR DESCRIPTION
This pull request improves how filenames are generated for generic document deliverables by preferring a filename derived from the document's title when available, instead of always using a generic key. It also ensures that document titles are extracted from the body when not explicitly provided, and adds comprehensive tests for these behaviors.

**Filename generation improvements:**
- Added helper functions `slugifyDeliverableFilenamePart` and `buildDocumentDeliverableFilename` to generate more descriptive filenames for document deliverables, preferring a slugified version of the title when the key is generic (e.g., "document" or "deliverable") (`server/src/services/work-products.ts`, `server/src/services/awaiting-human-notifications.ts`). [[1]](diffhunk://#diff-b77dc28dc9dfcbb80c7937d37b3effdf98897d407eb54b7150af0a607df2e462R690-R706) [[2]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4R115-R131)
- Updated all relevant code paths to use the new filename generation logic, including deliverable list items and document review files (`server/src/services/work-products.ts`, `server/src/services/awaiting-human-notifications.ts`). [[1]](diffhunk://#diff-b77dc28dc9dfcbb80c7937d37b3effdf98897d407eb54b7150af0a607df2e462L720-R736) [[2]](diffhunk://#diff-b77dc28dc9dfcbb80c7937d37b3effdf98897d407eb54b7150af0a607df2e462L549-R549) [[3]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4L585-R602)

**Document title extraction:**
- Added `extractDocumentBodyTitle` to extract a title from the first heading or non-empty line of the document body when no title is provided, and integrated this into the document promotion extraction logic (`server/src/services/heartbeat-run-summary.ts`). [[1]](diffhunk://#diff-fc471192b6f2da8e297c05b0291ce3c5bf92fe99cfde6c7e1e9e958a5b94c09bR45-R57) [[2]](diffhunk://#diff-fc471192b6f2da8e297c05b0291ce3c5bf92fe99cfde6c7e1e9e958a5b94c09bL68-R81)

**Testing enhancements:**
- Added and expanded tests to verify that the new filename logic is used for generic document deliverables and that titles are correctly derived from the document body when missing (`server/src/__tests__/work-products.test.ts`, `server/src/__tests__/deliverables-routes.test.ts`, `server/src/__tests__/heartbeat-run-summary.test.ts`). [[1]](diffhunk://#diff-6c1e18046d8b1876f1aa95d3f6eb0ec1313310f2035eabcc327d5376516fa2a1R232-R254) [[2]](diffhunk://#diff-ca63ed52879358ba0b4a895310c6a6d237558bd9c4aa4ccbd4ffcb99d4775945R181-R196) [[3]](diffhunk://#diff-95fb6a68862f921f3382db38062b895738fdef8b52ed22d66b9b7900ee2a2d04R181-R200)