### PR TITLE
Enhance filename generation using markdown H1 for null titles

### DIFF
--- a/server/src/__tests__/awaiting-human-notifications.test.ts
+++ b/server/src/__tests__/awaiting-human-notifications.test.ts
@@ -658,6 +658,7 @@ describe("resolveAwaitingHumanReviewFile", () => {
         key: "review-notes",
         title: "Review notes",
         format: "markdown",
+        body: "# Review notes",
         byte_size: 12,
       }],
     ]);
@@ -673,6 +674,32 @@ describe("resolveAwaitingHumanReviewFile", () => {
       filename: "review-notes.md",
       contentType: "text/markdown; charset=utf-8",
       deliverableUrl: "https://bizbox.example/api/deliverables/44444444-4444-4444-8444-444444444444/content",
+    });
+  });
+
+  it("uses the markdown H1 for human deliverable document filenames when the stored title is null", async () => {
+    const db = dbWithExecuteResults([
+      [],
+      [{
+        deliverable_id: "55555555-5555-4555-8555-555555555555",
+        key: "deliverable",
+        title: null,
+        format: "markdown",
+        body: "# Review Packet",
+        byte_size: 14,
+      }],
+    ]);
+
+    const file = await resolveAwaitingHumanReviewFile(db, {
+      companyId: "company-1",
+      issueId: "issue-1",
+      sourceLink: "https://bizbox.example/issues/BIZ-35",
+    });
+
+    expect(file).toMatchObject({
+      source: "document",
+      filename: "review-packet.md",
+      deliverableUrl: "https://bizbox.example/api/deliverables/55555555-5555-4555-8555-555555555555/content",
     });
   });
 

--- a/server/src/__tests__/awaiting-human-notifications.test.ts
+++ b/server/src/__tests__/awaiting-human-notifications.test.ts
@@ -698,6 +698,7 @@ describe("resolveAwaitingHumanReviewFile", () => {
 
     expect(file).toMatchObject({
       source: "document",
+      title: "Review Packet",
       filename: "review-packet.md",
       deliverableUrl: "https://bizbox.example/api/deliverables/55555555-5555-4555-8555-555555555555/content",
     });

--- a/server/src/__tests__/document-titles.test.ts
+++ b/server/src/__tests__/document-titles.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { extractMarkdownH1, resolveDocumentTitle } from "../lib/document-titles.js";
+
+describe("extractMarkdownH1", () => {
+  it("strips inline markdown syntax from the inferred H1 title", () => {
+    expect(extractMarkdownH1("# **Quarterly Closeout** [Status Update](https://example.com)")).toBe(
+      "Quarterly Closeout Status Update",
+    );
+  });
+
+  it("ignores headings indented as code blocks", () => {
+    expect(extractMarkdownH1("    # Not A Heading\n# Actual Heading")).toBe("Actual Heading");
+  });
+});
+
+describe("resolveDocumentTitle", () => {
+  it("falls back to a sanitized markdown H1 when the stored title is null", () => {
+    expect(resolveDocumentTitle(null, "markdown", "# `Sprint Summary`")).toBe("Sprint Summary");
+  });
+});

--- a/server/src/__tests__/documents-service.test.ts
+++ b/server/src/__tests__/documents-service.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { desc, eq } from "drizzle-orm";
 import {
   companies,
   createDb,
@@ -144,5 +145,84 @@ describeEmbeddedPostgres("documentService system issue documents", () => {
 
     const stored = await svc.getIssueDocumentByKey(issueId, "plan");
     expect(stored?.audience).toBe("human");
+  });
+
+  it("infers the stored title from the first markdown H1 when creating with a null title", async () => {
+    const { issueId } = await createIssueWithDocuments();
+
+    const created = await svc.upsertIssueDocument({
+      issueId,
+      key: "deliverable",
+      title: null,
+      format: "markdown",
+      body: "# Quarterly Closeout\n\nBody copy",
+    });
+
+    expect(created.document.title).toBe("Quarterly Closeout");
+
+    const storedDocument = await svc.getIssueDocumentByKey(issueId, "deliverable");
+    expect(storedDocument?.title).toBe("Quarterly Closeout");
+
+    const [revision] = await db
+      .select({ title: documentRevisions.title })
+      .from(documentRevisions)
+      .where(eq(documentRevisions.documentId, created.document.id))
+      .orderBy(desc(documentRevisions.revisionNumber))
+      .limit(1);
+    expect(revision?.title).toBe("Quarterly Closeout");
+  });
+
+  it("infers the stored title from the first markdown H1 when updating with a null title", async () => {
+    const { issueId } = await createIssueWithDocuments();
+    const existing = await svc.getIssueDocumentByKey(issueId, "plan");
+
+    const updated = await svc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      title: null,
+      format: "markdown",
+      body: "# Refined Plan\n\nNext steps",
+      baseRevisionId: existing?.latestRevisionId ?? null,
+    });
+
+    expect(updated.document.title).toBe("Refined Plan");
+
+    const storedDocument = await svc.getIssueDocumentByKey(issueId, "plan");
+    expect(storedDocument?.title).toBe("Refined Plan");
+
+    const [revision] = await db
+      .select({ title: documentRevisions.title })
+      .from(documentRevisions)
+      .where(eq(documentRevisions.id, updated.document.latestRevisionId))
+      .limit(1);
+    expect(revision?.title).toBe("Refined Plan");
+  });
+
+  it("does not infer a title for markdown documents without an H1", async () => {
+    const { issueId } = await createIssueWithDocuments();
+
+    const created = await svc.upsertIssueDocument({
+      issueId,
+      key: "notes",
+      title: null,
+      format: "markdown",
+      body: "No heading here\n\nJust body copy",
+    });
+
+    expect(created.document.title).toBeNull();
+  });
+
+  it("does not infer a title for non-markdown documents", async () => {
+    const { issueId } = await createIssueWithDocuments();
+
+    const created = await svc.upsertIssueDocument({
+      issueId,
+      key: "notes",
+      title: null,
+      format: "text",
+      body: "# Looks like a heading but is plain text",
+    });
+
+    expect(created.document.title).toBeNull();
   });
 });

--- a/server/src/__tests__/work-products.test.ts
+++ b/server/src/__tests__/work-products.test.ts
@@ -252,6 +252,50 @@ describe("workProductService", () => {
     expect(items[0]?.originalFilename).toBe("quarterly-closeout.md");
   });
 
+  it("falls back to the markdown H1 for generic document filenames when the stored title is null", async () => {
+    const now = new Date("2026-05-02T00:00:00.000Z");
+    const execute = vi.fn().mockResolvedValue([
+      createDeliverableQueryRow({
+        id: "doc-deliverable-3",
+        deliverable_source: "document",
+        title: null,
+        metadata: null,
+        document_key: "deliverable",
+        document_format: "markdown",
+        document_body: "# Legacy Closeout\n\nBody copy",
+        document_byte_size: 26,
+        created_at: now,
+        updated_at: now,
+      }),
+    ]);
+
+    const svc = workProductService({ execute } as any);
+    const items = await svc.listDeliverablesForCompany("company-1", { limit: 50, offset: 0 });
+
+    expect(items[0]?.originalFilename).toBe("legacy-closeout.md");
+  });
+
+  it("uses the markdown H1 for generic document download filenames when the stored title is null", async () => {
+    const now = new Date("2026-05-02T00:00:00.000Z");
+    const execute = vi.fn().mockResolvedValue([{
+      id: "doc-deliverable-4",
+      company_id: "company-1",
+      key: "document",
+      format: "markdown",
+      body: "# Legacy Download\n\nBody copy",
+      title: null,
+    }]);
+
+    const svc = workProductService({ execute } as any);
+    const document = await svc.getDeliverableDocumentContentById("doc-deliverable-4");
+
+    expect(document).toMatchObject({
+      id: "doc-deliverable-4",
+      filename: "legacy-download.md",
+      title: null,
+    });
+  });
+
   it("truncates inline document previews by UTF-8 byte length", async () => {
     const execute = vi
       .fn()

--- a/server/src/lib/document-filenames.ts
+++ b/server/src/lib/document-filenames.ts
@@ -1,3 +1,5 @@
+import { resolveDocumentTitle } from "./document-titles.js";
+
 function slugifyFilenamePart(value: string | null | undefined): string | null {
   if (typeof value !== "string") return null;
   const slug = value
@@ -8,9 +10,14 @@ function slugifyFilenamePart(value: string | null | undefined): string | null {
   return slug.length > 0 ? slug : null;
 }
 
-export function buildDocumentFilename(key: string | null | undefined, title: string | null | undefined) {
+export function buildDocumentFilename(
+  key: string | null | undefined,
+  title: string | null | undefined,
+  format?: string | null | undefined,
+  body?: string | null | undefined,
+) {
   const normalizedKey = key?.trim() || "document";
-  const titleSlug = slugifyFilenamePart(title);
+  const titleSlug = slugifyFilenamePart(resolveDocumentTitle(title, format, body));
   const shouldPreferTitle = (normalizedKey === "document" || normalizedKey === "deliverable") && titleSlug;
   return `${shouldPreferTitle ? titleSlug : normalizedKey}.md`;
 }

--- a/server/src/lib/document-titles.ts
+++ b/server/src/lib/document-titles.ts
@@ -1,0 +1,22 @@
+export function normalizeDocumentTitle(value: string | null | undefined) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function extractMarkdownH1(body: string | null | undefined) {
+  if (typeof body !== "string") return null;
+  const headingMatch = body.match(/^\s*#\s+(.+?)\s*$/m);
+  return normalizeDocumentTitle(headingMatch?.[1] ?? null);
+}
+
+export function resolveDocumentTitle(
+  title: string | null | undefined,
+  format: string | null | undefined,
+  body: string | null | undefined,
+) {
+  const normalizedTitle = normalizeDocumentTitle(title);
+  if (normalizedTitle) return normalizedTitle;
+  if (format !== "markdown") return null;
+  return extractMarkdownH1(body);
+}

--- a/server/src/lib/document-titles.ts
+++ b/server/src/lib/document-titles.ts
@@ -4,10 +4,22 @@ export function normalizeDocumentTitle(value: string | null | undefined) {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function stripInlineMarkdown(value: string) {
+  return value
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/(\*|_)(.*?)\1/g, "$2")
+    .replace(/~~(.*?)~~/g, "$1")
+    .replace(/\\([\\`*_{}\[\]()#+\-.!])/g, "$1")
+    .replace(/<\/?[^>]+>/g, "");
+}
+
 export function extractMarkdownH1(body: string | null | undefined) {
   if (typeof body !== "string") return null;
-  const headingMatch = body.match(/^\s*#\s+(.+?)\s*$/m);
-  return normalizeDocumentTitle(headingMatch?.[1] ?? null);
+  const headingMatch = body.match(/^[ ]{0,3}#\s+(.+?)(?:\s+#+\s*)?$/m);
+  return normalizeDocumentTitle(stripInlineMarkdown(headingMatch?.[1] ?? ""));
 }
 
 export function resolveDocumentTitle(

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -113,10 +113,6 @@ export interface ClickUpChatMessageReaction {
   count: number;
 }
 
-function buildDocumentReviewFilename(key: string | null | undefined, title: string | null | undefined) {
-  return buildDocumentFilename(key, title);
-}
-
 export interface ClickUpAwaitingHumanApprovalResult {
   status: ClickUpApiStatus | "approved" | "forward_reply";
   detail: string;
@@ -563,6 +559,7 @@ export async function resolveAwaitingHumanReviewFile(
       idoc.key,
       d.title,
       d.format,
+      d.latest_body AS body,
       COALESCE(octet_length(d.latest_body), 0)::integer AS byte_size
     FROM issue_documents idoc
     JOIN documents d ON d.id = idoc.document_id
@@ -578,6 +575,7 @@ export async function resolveAwaitingHumanReviewFile(
     key: string;
     title: string | null;
     format: string;
+    body: string | null;
     byte_size: number;
   }>(documentRows)[0];
   if (!document) return null;
@@ -587,7 +585,7 @@ export async function resolveAwaitingHumanReviewFile(
     source: "document",
     deliverableId: document.deliverable_id,
     title: document.title?.trim() || key,
-    filename: buildDocumentReviewFilename(document.key, document.title),
+    filename: buildDocumentFilename(document.key, document.title, document.format, document.body),
     contentType: document.format === "markdown" ? "text/markdown; charset=utf-8" : "text/plain; charset=utf-8",
     byteSize: Number(document.byte_size) || 0,
     contentPath,

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -4,6 +4,7 @@ import { and, eq, inArray, lt, lte, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { awaitingHumanNotificationOutbox } from "@paperclipai/db";
 import { buildDocumentFilename } from "../lib/document-filenames.js";
+import { resolveDocumentTitle } from "../lib/document-titles.js";
 import type { StorageService } from "../storage/types.js";
 import { getStorageService } from "../storage/index.js";
 
@@ -584,7 +585,7 @@ export async function resolveAwaitingHumanReviewFile(
   return {
     source: "document",
     deliverableId: document.deliverable_id,
-    title: document.title?.trim() || key,
+    title: resolveDocumentTitle(document.title, document.format, document.body) ?? key,
     filename: buildDocumentFilename(document.key, document.title, document.format, document.body),
     contentType: document.format === "markdown" ? "text/markdown; charset=utf-8" : "text/plain; charset=utf-8",
     byteSize: Number(document.byte_size) || 0,

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -8,6 +8,7 @@ import {
   type DeliverableAudience,
 } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
+import { resolveDocumentTitle } from "../lib/document-titles.js";
 
 function normalizeDocumentKey(key: string) {
   const normalized = key.trim().toLowerCase();
@@ -190,6 +191,7 @@ export function documentService(db: Db) {
       createdByRunId?: string | null;
     }) => {
       const key = normalizeDocumentKey(input.key);
+      const effectiveTitle = resolveDocumentTitle(input.title ?? null, input.format, input.body);
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)
@@ -245,7 +247,7 @@ export function documentService(db: Db) {
                 companyId: issue.companyId,
                 documentId: existing.id,
                 revisionNumber: nextRevisionNumber,
-                title: input.title ?? null,
+                title: effectiveTitle,
                 format: input.format,
                 body: input.body,
                 changeSummary: input.changeSummary ?? null,
@@ -259,7 +261,7 @@ export function documentService(db: Db) {
             await tx
               .update(documents)
               .set({
-                title: input.title ?? null,
+                title: effectiveTitle,
                 format: input.format,
                 latestBody: input.body,
                 latestRevisionId: revision.id,
@@ -279,7 +281,7 @@ export function documentService(db: Db) {
               created: false as const,
               document: {
                 ...existing,
-                title: input.title ?? null,
+                title: effectiveTitle,
                 format: input.format,
                 body: input.body,
                 audience,
@@ -301,7 +303,7 @@ export function documentService(db: Db) {
             .insert(documents)
             .values({
               companyId: issue.companyId,
-              title: input.title ?? null,
+              title: effectiveTitle,
               format: input.format,
               latestBody: input.body,
               latestRevisionId: null,
@@ -321,7 +323,7 @@ export function documentService(db: Db) {
               companyId: issue.companyId,
               documentId: document.id,
               revisionNumber: 1,
-              title: input.title ?? null,
+              title: effectiveTitle,
               format: input.format,
               body: input.body,
               changeSummary: input.changeSummary ?? null,

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -1,3 +1,5 @@
+import { normalizeDocumentTitle } from "../lib/document-titles.js";
+
 export const HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS = 500;
 export const HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS = 4_096;
 export const HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES = 64 * 1024;
@@ -34,12 +36,6 @@ function slugifyDocumentKey(value: string) {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   return normalized || "deliverable";
-}
-
-function normalizeDocumentTitle(value: string | null | undefined) {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
 }
 
 function looksLikeDocumentTitleLine(line: string) {

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -547,7 +547,7 @@ export function workProductService(db: Db) {
       }>(rows)[0];
       if (!row) return null;
       const body = row.body ?? "";
-      const filename = buildDocumentDeliverableFilename(row.key, row.title);
+      const filename = buildDocumentDeliverableFilename(row.key, row.title, row.format, body);
       return {
         id: row.id,
         companyId: row.company_id,
@@ -688,8 +688,13 @@ async function readStreamToBuffer(stream: Readable): Promise<Buffer> {
   return Buffer.concat(chunks);
 }
 
-function buildDocumentDeliverableFilename(key: string | null | undefined, title: string | null | undefined) {
-  return buildDocumentFilename(key, title);
+function buildDocumentDeliverableFilename(
+  key: string | null | undefined,
+  title: string | null | undefined,
+  format?: string | null | undefined,
+  body?: string | null | undefined,
+) {
+  return buildDocumentFilename(key, title, format, body);
 }
 
 function rowToDeliverableListItem(row: DeliverableQueryRow): DeliverableListItem | null {
@@ -721,7 +726,7 @@ function rowToDeliverableListItem(row: DeliverableQueryRow): DeliverableListItem
       ? "text/markdown; charset=utf-8"
       : "text/plain; charset=utf-8";
     byteSize = Number.isFinite(sqlByteSize) ? sqlByteSize : Buffer.byteLength(body, "utf8");
-    originalFilename = buildDocumentDeliverableFilename(row.document_key, row.title);
+    originalFilename = buildDocumentDeliverableFilename(row.document_key, row.title, row.document_format, body);
   }
 
   const rootIsSelf = row.ri_id === null || row.ri_id === row.ci_id;


### PR DESCRIPTION
This pull request introduces improved handling of document titles and filenames, especially for markdown documents where the stored title is null. When a title is not provided, the system now infers the title from the first Markdown H1 heading in the document body. This inferred title is used for storage, display, and to generate more meaningful filenames. The changes also ensure that non-markdown documents or markdown documents without an H1 do not infer a title. Comprehensive tests have been added to cover these scenarios.

**Document Title Inference and Storage:**

- Added logic to infer the document title from the first Markdown H1 heading when creating or updating a document with a null title. This inferred title is stored in both the document and its revision records. Non-markdown documents or markdown documents without an H1 will not infer a title. [[1]](diffhunk://#diff-88258f385c73d20867ee0c28f98b8daed4d146479f43f763cd167e3f60f56399R194) [[2]](diffhunk://#diff-88258f385c73d20867ee0c28f98b8daed4d146479f43f763cd167e3f60f56399L248-R250) [[3]](diffhunk://#diff-88258f385c73d20867ee0c28f98b8daed4d146479f43f763cd167e3f60f56399L262-R264) [[4]](diffhunk://#diff-88258f385c73d20867ee0c28f98b8daed4d146479f43f763cd167e3f60f56399L282-R284) [[5]](diffhunk://#diff-88258f385c73d20867ee0c28f98b8daed4d146479f43f763cd167e3f60f56399L304-R306) [[6]](diffhunk://#diff-88258f385c73d20867ee0c28f98b8daed4d146479f43f763cd167e3f60f56399L324-R326) [[7]](diffhunk://#diff-c38f68b5041d4846b08b3263ba99eec955070aeebf644baf88784131260cabb4R1-R22) [[8]](diffhunk://#diff-bf972858b5decfe62bfb96ffd406e353a382268c7ffa173f07152e9a8be09634R149-R227)

**Filename Generation Improvements:**

- Updated filename generation functions (`buildDocumentFilename`, `buildDocumentDeliverableFilename`) to use the inferred title (from H1) when the stored title is null, resulting in more descriptive filenames for markdown documents. [[1]](diffhunk://#diff-7a6a4c69a3a72b4713d437fcae0e2db82f4fff46c7c91602df0c07642aa8d98bR1-R2) [[2]](diffhunk://#diff-7a6a4c69a3a72b4713d437fcae0e2db82f4fff46c7c91602df0c07642aa8d98bL11-R20) [[3]](diffhunk://#diff-b77dc28dc9dfcbb80c7937d37b3effdf98897d407eb54b7150af0a607df2e462L550-R550) [[4]](diffhunk://#diff-b77dc28dc9dfcbb80c7937d37b3effdf98897d407eb54b7150af0a607df2e462L691-R697) [[5]](diffhunk://#diff-b77dc28dc9dfcbb80c7937d37b3effdf98897d407eb54b7150af0a607df2e462L724-R729) [[6]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4L590-R588)
- Adjusted the document review file and deliverable filename logic to pass format and body, enabling the use of inferred titles. [[1]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4L590-R588) [[2]](diffhunk://#diff-b77dc28dc9dfcbb80c7937d37b3effdf98897d407eb54b7150af0a607df2e462L550-R550) [[3]](diffhunk://#diff-b77dc28dc9dfcbb80c7937d37b3effdf98897d407eb54b7150af0a607df2e462L724-R729)

**Testing Enhancements:**

- Added and extended tests to verify that the system correctly infers titles from Markdown H1 headings, refrains from inferring titles when inappropriate, and generates expected filenames in these scenarios. [[1]](diffhunk://#diff-bf972858b5decfe62bfb96ffd406e353a382268c7ffa173f07152e9a8be09634R149-R227) [[2]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69R680-R705) [[3]](diffhunk://#diff-6c1e18046d8b1876f1aa95d3f6eb0ec1313310f2035eabcc327d5376516fa2a1R255-R298)

**Refactoring and Cleanup:**

- Refactored and centralized document title normalization and inference logic in `document-titles.ts` for reuse across services. [[1]](diffhunk://#diff-c38f68b5041d4846b08b3263ba99eec955070aeebf644baf88784131260cabb4R1-R22) [[2]](diffhunk://#diff-fc471192b6f2da8e297c05b0291ce3c5bf92fe99cfde6c7e1e9e958a5b94c09bR1-R2) [[3]](diffhunk://#diff-fc471192b6f2da8e297c05b0291ce3c5bf92fe99cfde6c7e1e9e958a5b94c09bL39-L44)
- Removed redundant or now-unnecessary helper functions, such as the old `buildDocumentReviewFilename` and local `normalizeDocumentTitle` implementations. [[1]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4L116-L119) [[2]](diffhunk://#diff-fc471192b6f2da8e297c05b0291ce3c5bf92fe99cfde6c7e1e9e958a5b94c09bL39-L44)

**Service and Query Updates:**

- Updated service and query layers to ensure the document body is available where needed for title inference and filename generation, and that all relevant fields are passed through. [[1]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4R562) [[2]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4R578) F7ac25c5L7ac25c5L8R8)

These changes collectively make document handling more robust and user-friendly, especially for markdown documents without explicit titles.