### PR TITLE
Add ClickUp human approval configuration and update notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,15 @@ BIZBOX_DB_POOL_MAX=3
 BIZBOX_DB_IDLE_TIMEOUT_SECONDS=30
 BIZBOX_DB_CONNECT_TIMEOUT_SECONDS=5
 OPENCODE_ALLOW_ALL_MODELS=true
+
+# Optional ClickUp awaiting-human approval surface.
+# Prefer the approval-specific names below. Bizbox falls back to the legacy
+# engineering-named vars if these are unset. If no channel name is configured,
+# Bizbox looks for a ClickUp chat channel named `bizbox-feed`.
+# CLICKUP_PERSONAL_TOKEN=
+# CLICKUP_WORKSPACE_ID=
+# CLICKUP_AWAITING_HUMAN_CHANNEL_ID=
+# CLICKUP_AWAITING_HUMAN_CHANNEL_NAME=bizbox-feed
+# Legacy fallback:
+# CLICKUP_ENGINEERING_CHANNEL_ID=
+# CLICKUP_ENGINEERING_CHANNEL_NAME=

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -122,6 +122,13 @@ For `clickup_agent_ref`:
 - Bizbox imports non-bot ClickUp replies by default.
 - Archived `agent_thread` bridges are closed automatically so stale pollers do not remain visible as live work.
 
+For `awaiting_human` ClickUp notifications:
+
+- Configure the approval surface with `CLICKUP_AWAITING_HUMAN_CHANNEL_ID` or `CLICKUP_AWAITING_HUMAN_CHANNEL_NAME`.
+- Bizbox still falls back to `CLICKUP_ENGINEERING_CHANNEL_ID` / `CLICKUP_ENGINEERING_CHANNEL_NAME` when the new vars are unset.
+- If neither name variable is set, Bizbox now defaults the lookup target to `bizbox-feed`.
+- Inbound approval polling still follows the tracked ClickUp message id, so renaming the approval channel does not change reconciliation behavior.
+
 A review-driven regression briefly treated `clickupAgentUserId` as a hard inbound author gate and caused stuck live ClickUp polls. Keep the fields separate.
 
 ## One-Command Local Run

--- a/server/src/__tests__/awaiting-human-notifications.test.ts
+++ b/server/src/__tests__/awaiting-human-notifications.test.ts
@@ -22,6 +22,8 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
   delete process.env.CLICKUP_PERSONAL_TOKEN;
   delete process.env.CLICKUP_WORKSPACE_ID;
+  delete process.env.CLICKUP_AWAITING_HUMAN_CHANNEL_ID;
+  delete process.env.CLICKUP_AWAITING_HUMAN_CHANNEL_NAME;
   delete process.env.CLICKUP_ENGINEERING_CHANNEL_ID;
   delete process.env.CLICKUP_ENGINEERING_CHANNEL_NAME;
   delete process.env.CLICKUP_AWAITING_HUMAN_REVIEW_LIST_ID;
@@ -30,10 +32,10 @@ afterEach(() => {
 });
 
 describe("sendAwaitingHumanNotification", () => {
-  it("posts the handoff to the ClickUp engineering chat channel", async () => {
+  it("posts the handoff to the configured ClickUp approval chat channel", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
-    process.env.CLICKUP_ENGINEERING_CHANNEL_ID = "channel-9";
+    process.env.CLICKUP_AWAITING_HUMAN_CHANNEL_ID = "channel-9";
 
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
@@ -74,14 +76,21 @@ describe("sendAwaitingHumanNotification", () => {
     expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
       type: "message",
       content_format: "text/md",
-      content: expect.stringContaining("Source: https://bizbox.example/issues/BIZ-35"),
+      content: expect.stringContaining("Open in Bizbox: https://bizbox.example/issues/BIZ-35"),
     });
+    const rendered = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)).content as string;
+    expect(rendered).toContain("Could you take a quick look and respond here in ClickUp?");
+    expect(rendered).toContain("To approve: react with");
+    expect(rendered).toContain("If you want changes or have questions: reply here with what you'd like changed, added, or clarified");
+    expect(rendered).not.toContain("not approved");
+    expect(rendered).not.toContain("Context:");
+    expect(rendered).not.toContain("Labels:");
   });
 
   it("includes the Bizbox deliverable and ClickUp review task when a review file is present", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
-    process.env.CLICKUP_ENGINEERING_CHANNEL_ID = "channel-9";
+    process.env.CLICKUP_AWAITING_HUMAN_CHANNEL_ID = "channel-9";
 
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
@@ -121,17 +130,18 @@ describe("sendAwaitingHumanNotification", () => {
     expect(body.content).toContain("Bizbox deliverable: https://bizbox.example/api/attachments/33333333-3333-4333-8333-333333333333/content");
     expect(body.content).toContain("ClickUp review task: https://app.clickup.com/t/task-123");
     expect(body.content).toContain("Review file attached on the ClickUp task.");
+    expect(body.content).toContain("Open in Bizbox: https://bizbox.example/issues/BIZ-35");
   });
 
-  it("resolves the ClickUp channel id by channel name when no channel id is configured", async () => {
+  it("resolves the ClickUp channel id by the new approval channel name when no channel id is configured", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
-    process.env.CLICKUP_ENGINEERING_CHANNEL_NAME = "engineering";
+    process.env.CLICKUP_AWAITING_HUMAN_CHANNEL_NAME = "bizbox-feed";
 
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ data: [{ id: "channel-lookup-1", name: "engineering" }] }),
+        json: async () => ({ data: [{ id: "channel-lookup-1", name: "bizbox-feed" }] }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -177,7 +187,7 @@ describe("sendAwaitingHumanNotification", () => {
   it("continues channel lookup across pages before giving up", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
-    process.env.CLICKUP_ENGINEERING_CHANNEL_NAME = "engineering";
+    process.env.CLICKUP_AWAITING_HUMAN_CHANNEL_NAME = "bizbox-feed";
 
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
@@ -191,7 +201,7 @@ describe("sendAwaitingHumanNotification", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ data: [{ id: "channel-lookup-2", name: "engineering" }] }),
+        json: async () => ({ data: [{ id: "channel-lookup-2", name: "bizbox-feed" }] }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -251,6 +261,112 @@ describe("sendAwaitingHumanNotification", () => {
       channel: "clickup-chat",
       detail: "missing-credential: CLICKUP_PERSONAL_TOKEN",
     });
+  });
+
+  it("prefers the new approval channel env vars over the legacy engineering vars", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+    process.env.CLICKUP_AWAITING_HUMAN_CHANNEL_ID = "channel-new";
+    process.env.CLICKUP_ENGINEERING_CHANNEL_ID = "channel-legacy";
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: "message-45" } }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotification({
+      companyId: "company-1",
+      issueId: "issue-1",
+      handoffKind: "request_confirmation",
+      notification: {
+        title: "BIZ-35 is waiting on human input",
+        summary: "Approve the exact GitHub reply before posting.",
+        link: "https://bizbox.example/issues/BIZ-35",
+        cta: "Open BIZ-35 in Bizbox and respond there.",
+        labels: ["awaiting_human", "request_confirmation"],
+      },
+    });
+
+    expect(result.status).toBe("sent");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/channels/channel-new/messages",
+      expect.any(Object),
+    );
+  });
+
+  it("falls back to the legacy engineering env vars when the new approval vars are unset", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+    process.env.CLICKUP_ENGINEERING_CHANNEL_ID = "channel-legacy";
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: "message-46" } }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotification({
+      companyId: "company-1",
+      issueId: "issue-1",
+      handoffKind: "request_confirmation",
+      notification: {
+        title: "BIZ-35 is waiting on human input",
+        summary: "Approve the exact GitHub reply before posting.",
+        link: "https://bizbox.example/issues/BIZ-35",
+        cta: "Open BIZ-35 in Bizbox and respond there.",
+        labels: ["awaiting_human", "request_confirmation"],
+      },
+    });
+
+    expect(result.status).toBe("sent");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/channels/channel-legacy/messages",
+      expect.any(Object),
+    );
+  });
+
+  it("defaults the approval channel name to bizbox-feed when no channel env vars are set", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ id: "channel-lookup-3", name: "bizbox-feed" }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: "message-47" } }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotification({
+      companyId: "company-1",
+      issueId: "issue-1",
+      handoffKind: "ask_user_questions",
+      notification: {
+        title: "BIZ-35 is waiting on human input",
+        summary: "Need answers to 2 question(s).",
+        link: "https://bizbox.example/issues/BIZ-35",
+        cta: "Open BIZ-35 in Bizbox and respond there.",
+        labels: ["awaiting_human", "ask_user_questions"],
+      },
+    });
+
+    expect(result.status).toBe("sent");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/channels?page=1&page_size=100",
+      expect.any(Object),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/channels/channel-lookup-3/messages",
+      expect.any(Object),
+    );
   });
 
   it("retrieves ClickUp message replies for approval polling", async () => {

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -401,7 +401,7 @@ function renderClickUpMessage(notification: AwaitingHumanNotificationPayload) {
     summary,
     "",
     "Could you take a quick look and respond here in ClickUp?",
-    "- To approve: react with 👍, ✅, or ✔️, or reply with words like \"approve\", \"approved\", \"yes\", \"ok\", \"ship it\", \"lgtm\", or \"go ahead\".",
+    "- To approve: react with 👍, ✅, or ✔️, or reply with words like \"approve\", \"approved\", \"approving\", \"yes\", \"ok\", \"okay\", \"ship it\", \"lgtm\", \"looks good\", \"go ahead\", or \"+1\".",
     "- If you want changes or have questions: reply here with what you'd like changed, added, or clarified and Bizbox will carry your full feedback back.",
   ];
 
@@ -692,7 +692,7 @@ export async function sendAwaitingHumanNotification(
       return {
         status: "skipped",
         channel: "clickup-chat",
-        detail: `missing-target: CLICKUP_AWAITING_HUMAN_CHANNEL_ID or ${config.channelName}`,
+        detail: `missing-target: CLICKUP_AWAITING_HUMAN_CHANNEL_ID (or CLICKUP_ENGINEERING_CHANNEL_ID) or channel name '${config.channelName}'`,
       };
     }
 

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -9,7 +9,7 @@ import type { StorageService } from "../storage/types.js";
 import { getStorageService } from "../storage/index.js";
 
 const CLICKUP_CHAT_MESSAGE_MAX_CHARS = 1_800;
-const DEFAULT_CLICKUP_CHANNEL_NAME = "engineering";
+const DEFAULT_CLICKUP_AWAITING_HUMAN_CHANNEL_NAME = "bizbox-feed";
 const MAX_TITLE_LENGTH = 120;
 const MAX_SUMMARY_LENGTH = 280;
 const MAX_DETAIL_BULLETS = 5;
@@ -232,11 +232,17 @@ function readClickUpChatConfig(): ClickUpChatConfig {
     .split(",")
     .map((value) => compactWhitespace(value.trim().toLowerCase()))
     .filter(Boolean);
+  const channelId = process.env.CLICKUP_AWAITING_HUMAN_CHANNEL_ID?.trim()
+    || process.env.CLICKUP_ENGINEERING_CHANNEL_ID?.trim()
+    || "";
+  const channelName = process.env.CLICKUP_AWAITING_HUMAN_CHANNEL_NAME?.trim()
+    || process.env.CLICKUP_ENGINEERING_CHANNEL_NAME?.trim()
+    || DEFAULT_CLICKUP_AWAITING_HUMAN_CHANNEL_NAME;
   return {
     personalToken: process.env.CLICKUP_PERSONAL_TOKEN?.trim() ?? "",
     workspaceId: process.env.CLICKUP_WORKSPACE_ID?.trim() ?? "",
-    channelId: process.env.CLICKUP_ENGINEERING_CHANNEL_ID?.trim() ?? "",
-    channelName: process.env.CLICKUP_ENGINEERING_CHANNEL_NAME?.trim() || DEFAULT_CLICKUP_CHANNEL_NAME,
+    channelId,
+    channelName,
     reviewListId: process.env.CLICKUP_AWAITING_HUMAN_REVIEW_LIST_ID?.trim() ?? "",
     approvalPositiveReactions: positiveReactions.length > 0
       ? [...new Set(positiveReactions)]
@@ -389,28 +395,19 @@ function renderClickUpMessage(notification: AwaitingHumanNotificationPayload) {
   const title = truncateText(notification.title, MAX_TITLE_LENGTH);
   const summary = truncateText(notification.summary, MAX_SUMMARY_LENGTH);
   const bullets = extractBullets(notification.body);
-  const contextLine = [
-    notification.kind?.trim() || null,
-    notification.audience?.trim() || null,
-  ].filter((value): value is string => Boolean(value)).join(" · ");
   const lines = [
     `**${title}**`,
     "",
     summary,
+    "",
+    "Could you take a quick look and respond here in ClickUp?",
+    "- To approve: react with 👍, ✅, or ✔️, or reply with words like \"approve\", \"approved\", \"yes\", \"ok\", \"ship it\", \"lgtm\", or \"go ahead\".",
+    "- If you want changes or have questions: reply here with what you'd like changed, added, or clarified and Bizbox will carry your full feedback back.",
   ];
-
-  if (contextLine) {
-    lines.push("");
-    lines.push(`Context: ${contextLine}`);
-  }
-
-  if (notification.labels.length > 0) {
-    lines.push(`Labels: ${notification.labels.join(", ")}`);
-  }
 
   if (bullets.length > 0) {
     lines.push("");
-    lines.push("Key points:");
+    lines.push("A few details:");
     lines.push(...bullets.map((bullet) => `- ${bullet}`));
   }
 
@@ -427,11 +424,10 @@ function renderClickUpMessage(notification: AwaitingHumanNotificationPayload) {
   }
 
   lines.push("");
-  lines.push(`Source: ${notification.link.trim()}`);
-
   if (notification.cta.trim().length > 0) {
-    lines.push(`Next step: ${truncateText(notification.cta, 180)}`);
+    lines.push(truncateText(notification.cta, 180));
   }
+  lines.push(`Open in Bizbox: ${notification.link.trim()}`);
 
   return trimTotal(lines.join("\n"), CLICKUP_CHAT_MESSAGE_MAX_CHARS);
 }
@@ -696,7 +692,7 @@ export async function sendAwaitingHumanNotification(
       return {
         status: "skipped",
         channel: "clickup-chat",
-        detail: `missing-target: CLICKUP_ENGINEERING_CHANNEL_ID or ${config.channelName}`,
+        detail: `missing-target: CLICKUP_AWAITING_HUMAN_CHANNEL_ID or ${config.channelName}`,
       };
     }
 


### PR DESCRIPTION
This pull request updates the configuration and notification behavior for ClickUp "awaiting human" approval surfaces in Bizbox, introducing new environment variables for approval channels and improving both the message content and fallback logic. The changes clarify configuration, enhance the user-facing message, and ensure backward compatibility with legacy variables.

**Key changes:**

**Configuration and Fallback Logic:**
- Added new environment variables (`CLICKUP_AWAITING_HUMAN_CHANNEL_ID` and `CLICKUP_AWAITING_HUMAN_CHANNEL_NAME`) for specifying the ClickUp approval channel, with fallback to legacy engineering variables if unset, and defaulting to `bizbox-feed` when no channel name is provided. Documentation and `.env.example` are updated accordingly. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR46-R57) [[2]](diffhunk://#diff-3e6d58e87c820a548c3943f14dd07beac67a2ffa27cf15fb650623b9e0f19f4cR125-R131) [[3]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4R235-R245) [[4]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4L12-R12)
- The service now prefers the new approval channel variables over the legacy ones and includes comprehensive tests for all fallback and default behaviors. [[1]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69R266-R371) [[2]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L33-R38) [[3]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69R133-R144) [[4]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L180-R190) [[5]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L194-R204)

**Notification Content Improvements:**
- Updated the message format sent to ClickUp: clearer instructions for human responders, improved CTA, and removal of unnecessary context and label lines. The notification now emphasizes how to approve or request changes and always includes an "Open in Bizbox" link. [[1]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L77-R93) [[2]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4L392-R410) [[3]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4L430-R430)

**Testing and Cleanup:**
- Expanded and updated tests to cover all new configuration scenarios, including environment variable precedence and defaulting, ensuring robust behavior. Test cleanup now also removes the new environment variables. [[1]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69R25-R26) [[2]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69R266-R371)

**Other:**
- Minor improvements to error details and code comments for clarity and maintainability.

These updates make Bizbox's ClickUp integration more flexible, user-friendly, and easier to configure for approval workflows.