### PR TITLE
Enhance heartbeat service for recovery outcomes and timeouts

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1659,6 +1659,252 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakes.some((row) => row.reason === "run_liveness_continuation")).toBe(false);
   });
 
+  it("treats terminal ok payloads as succeeded and does not queue stale recovery or duplicate completion comments", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Finalize successful OpenClaw work",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    mockAdapterExecute.mockImplementationOnce(async (ctx: { runId: string }) => {
+      await db.insert(issueComments).values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        createdByRunId: ctx.runId,
+        body: "Finished both deliverables.",
+      });
+      return {
+        exitCode: 17,
+        signal: null,
+        timedOut: false,
+        errorMessage: "gateway closed after delivering terminal result",
+        errorCode: "openclaw_gateway_request_failed",
+        summary: "Finished both deliverables.",
+        resultJson: {
+          status: "ok",
+          summary: "Finished both deliverables.",
+        },
+        provider: "openclaw",
+        model: "test-model",
+      };
+    });
+
+    const heartbeat = heartbeatService(db);
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+    expect(wake?.id).toBeTruthy();
+    if (wake?.id) {
+      await waitForRunToSettle(heartbeat, wake.id, 5_000);
+    }
+    await waitForHeartbeatIdle(db, 5_000);
+
+    const finalizedRun = wake?.id ? await heartbeat.getRun(wake.id, { unsafeFullResultJson: true }) : null;
+    expect(finalizedRun?.status).toBe("succeeded");
+    expect(finalizedRun?.errorCode).toBeNull();
+    expect(finalizedRun?.error).toBeNull();
+    expect(finalizedRun?.resultJson).toMatchObject({
+      status: "ok",
+      stopReason: "completed",
+      timeoutFired: false,
+      authoritativeSuccessOverride: {
+        reason: "adapter_result_status_ok",
+        ignoredExitCode: 17,
+        ignoredErrorCode: "openclaw_gateway_request_failed",
+      },
+    });
+
+    const allRuns = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(allRuns).toHaveLength(1);
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
+    expect(wakeups[0]?.reason).toBe("issue_assigned");
+
+    const comments = await db
+      .select({
+        body: issueComments.body,
+        createdByRunId: issueComments.createdByRunId,
+      })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(comments).toEqual([
+      expect.objectContaining({
+        body: "Finished both deliverables.",
+        createdByRunId: finalizedRun?.id ?? null,
+      }),
+    ]);
+  });
+
+  it("skips stranded continuation recovery for historical false failures with ok payloads and durable evidence", async () => {
+    const { agentId, issueId, runId, companyId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+    });
+    const heartbeat = heartbeatService(db);
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        errorCode: "adapter_failed",
+        error: "gateway closed after delivering terminal result",
+        resultJson: {
+          status: "ok",
+          summary: "Finished both deliverables.",
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      createdByRunId: runId,
+      body: "Finished both deliverables.",
+    });
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("keeps genuine gateway timeouts as timed_out failures", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Preserve real OpenClaw timeouts",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    mockAdapterExecute.mockResolvedValueOnce({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: "gateway websocket open timeout",
+      errorCode: "openclaw_gateway_wait_timeout",
+      resultJson: {
+        status: "timeout",
+      },
+      provider: "openclaw",
+      model: "test-model",
+    });
+
+    const heartbeat = heartbeatService(db);
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+    expect(wake?.id).toBeTruthy();
+    if (wake?.id) {
+      await waitForRunToSettle(heartbeat, wake.id, 5_000);
+    }
+    await waitForHeartbeatIdle(db, 5_000);
+
+    const timedOutRun = wake?.id ? await heartbeat.getRun(wake.id, { unsafeFullResultJson: true }) : null;
+    expect(timedOutRun?.status).toBe("timed_out");
+    expect(timedOutRun?.errorCode).toBe("timeout");
+    expect(timedOutRun?.resultJson).toMatchObject({
+      status: "timeout",
+      stopReason: "timeout",
+      timeoutFired: true,
+    });
+  });
+
   it("continues promoting later documents and posts the run comment when one promotion fails", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4127,7 +4127,7 @@ export function heartbeatService(db: Db) {
   }
 
   async function buildRunLivenessInput(
-    run: typeof heartbeatRuns.$inferSelect,
+    run: RecoveryAnalysisRun,
     resultJson: Record<string, unknown> | null | undefined,
   ): Promise<RunLivenessClassificationInput> {
     const context = parseObject(run.contextSnapshot);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -68,6 +68,7 @@ import {
 } from "./heartbeat-stop-metadata.js";
 import {
   classifyRunLiveness,
+  hasConcreteActionEvidence,
   type RunLivenessClassificationInput,
 } from "./run-liveness.js";
 import {
@@ -929,20 +930,75 @@ function summarizeRunFailureForIssueComment(
   return null;
 }
 
-function didAutomaticRecoveryFail(
-  latestRun: Pick<typeof heartbeatRuns.$inferSelect, "status" | "contextSnapshot"> | null,
-  expectedRetryReason: "assignment_recovery" | "issue_continuation_needed",
-) {
-  if (!latestRun) return false;
+function readHeartbeatResultStatus(resultJson: unknown) {
+  return readNonEmptyString(parseObject(resultJson).status)?.trim().toLowerCase() ?? null;
+}
 
-  const latestContext = parseObject(latestRun.contextSnapshot);
-  const latestRetryReason = readNonEmptyString(latestContext.retryReason);
-  return (
-    latestRetryReason === expectedRetryReason &&
-    UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
-      latestRun.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
-    )
-  );
+function isHeartbeatResultTimedOutStatus(status: string | null) {
+  return status === "timeout";
+}
+
+function isHeartbeatResultSuccessfulStatus(status: string | null) {
+  return status === "ok";
+}
+
+function isExplicitGatewayTimeoutErrorCode(errorCode: string | null | undefined) {
+  return errorCode === "timeout"
+    || errorCode === "openclaw_gateway_timeout"
+    || errorCode === "openclaw_gateway_wait_timeout";
+}
+
+function buildAuthoritativeSuccessResultJson(input: {
+  resultJson: Record<string, unknown> | null | undefined;
+  exitCode: number | null | undefined;
+  errorCode: string | null | undefined;
+  errorMessage: string | null | undefined;
+}) {
+  const baseResultJson = input.resultJson ?? null;
+  const hasIgnoredFailureSignal =
+    (typeof input.exitCode === "number" && input.exitCode !== 0)
+    || !!readNonEmptyString(input.errorCode)
+    || !!readNonEmptyString(input.errorMessage);
+  if (!baseResultJson || !hasIgnoredFailureSignal) return baseResultJson;
+
+  return {
+    ...baseResultJson,
+    authoritativeSuccessOverride: {
+      reason: "adapter_result_status_ok",
+      ignoredExitCode: input.exitCode ?? null,
+      ignoredErrorCode: input.errorCode ?? null,
+      ignoredErrorMessage: input.errorMessage ?? null,
+    },
+  };
+}
+
+async function deriveHeartbeatRunOutcome(params: {
+  latestRun: typeof heartbeatRuns.$inferSelect | null;
+  adapterResult: AdapterExecutionResult;
+}) {
+  const { latestRun, adapterResult } = params;
+  if (isHeartbeatRunTerminalStatus(latestRun?.status)) {
+    return latestRun.status;
+  }
+
+  const resultStatus = readHeartbeatResultStatus(adapterResult.resultJson);
+  if (
+    adapterResult.timedOut
+    || isHeartbeatResultTimedOutStatus(resultStatus)
+    || isExplicitGatewayTimeoutErrorCode(adapterResult.errorCode)
+  ) {
+    return "timed_out" as const;
+  }
+
+  if (isHeartbeatResultSuccessfulStatus(resultStatus)) {
+    return "succeeded" as const;
+  }
+
+  if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
+    return "succeeded" as const;
+  }
+
+  return "failed" as const;
 }
 
 function normalizeLedgerBillingType(value: unknown): BillingType {
@@ -2007,6 +2063,21 @@ function resolveNextSessionState(input: {
 }
 
 export function heartbeatService(db: Db) {
+  type RecoveryAnalysisRun = Pick<
+    typeof heartbeatRuns.$inferSelect,
+    | "id"
+    | "companyId"
+    | "agentId"
+    | "status"
+    | "error"
+    | "errorCode"
+    | "contextSnapshot"
+    | "resultJson"
+    | "stdoutExcerpt"
+    | "stderrExcerpt"
+    | "continuationAttempt"
+  >;
+
   const instanceSettings = instanceSettingsService(db);
   const getCurrentUserRedactionOptions = async () => ({
     enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
@@ -4186,6 +4257,58 @@ export function heartbeatService(db: Db) {
     };
   }
 
+  async function runHasConcreteProgressEvidence(
+    run: RecoveryAnalysisRun,
+    resultJson?: Record<string, unknown> | null,
+  ) {
+    const livenessInput = await buildRunLivenessInput(run, resultJson ?? parseObject(run.resultJson));
+    return hasConcreteActionEvidence(livenessInput.evidence);
+  }
+
+  async function runRepresentsAuthoritativeSuccess(
+    run: RecoveryAnalysisRun | null,
+  ) {
+    if (!run) return false;
+    if (run.status === "succeeded") return true;
+    if (run.status === "cancelled" || run.status === "timed_out") return false;
+
+    const resultStatus = readHeartbeatResultStatus(run.resultJson);
+    if (!isHeartbeatResultSuccessfulStatus(resultStatus)) return false;
+
+    return runHasConcreteProgressEvidence(run, parseObject(run.resultJson));
+  }
+
+  async function shouldSuppressAutomaticRecoveryForRun(
+    run: RecoveryAnalysisRun | null,
+    issueStatus: string | null | undefined,
+  ) {
+    if (!run) return issueStatus === "done" || issueStatus === "cancelled";
+    if (issueStatus === "done" || issueStatus === "cancelled") return true;
+    if (!UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
+      run.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
+    )) {
+      return false;
+    }
+    return runRepresentsAuthoritativeSuccess(run);
+  }
+
+  async function didAutomaticRecoveryFail(
+    latestRun: RecoveryAnalysisRun | null,
+    expectedRetryReason: "assignment_recovery" | "issue_continuation_needed",
+  ) {
+    if (!latestRun) return false;
+    if (await runRepresentsAuthoritativeSuccess(latestRun)) return false;
+
+    const latestContext = parseObject(latestRun.contextSnapshot);
+    const latestRetryReason = readNonEmptyString(latestContext.retryReason);
+    return (
+      latestRetryReason === expectedRetryReason &&
+      UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
+        latestRun.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
+      )
+    );
+  }
+
   async function classifyAndPersistRunLiveness(
     run: typeof heartbeatRuns.$inferSelect,
     resultJson?: Record<string, unknown> | null,
@@ -4344,10 +4467,16 @@ export function heartbeatService(db: Db) {
     return db
       .select({
         id: heartbeatRuns.id,
+        companyId: heartbeatRuns.companyId,
+        agentId: heartbeatRuns.agentId,
         status: heartbeatRuns.status,
         error: heartbeatRuns.error,
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
+        resultJson: heartbeatRuns.resultJson,
+        stdoutExcerpt: heartbeatRuns.stdoutExcerpt,
+        stderrExcerpt: heartbeatRuns.stderrExcerpt,
+        continuationAttempt: heartbeatRuns.continuationAttempt,
       })
       .from(heartbeatRuns)
       .where(
@@ -4724,7 +4853,12 @@ export function heartbeatService(db: Db) {
           continue;
         }
 
-        if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
+        if (await shouldSuppressAutomaticRecoveryForRun(latestRun, issue.status)) {
+          result.skipped += 1;
+          continue;
+        }
+
+        if (await didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
           const failureSummary = summarizeRunFailureForIssueComment(latestRun);
           const updated = await escalateStrandedAssignedIssue({
             issue,
@@ -4765,7 +4899,11 @@ export function heartbeatService(db: Db) {
         result.skipped += 1;
         continue;
       }
-      if (didAutomaticRecoveryFail(latestRun, "issue_continuation_needed")) {
+      if (await shouldSuppressAutomaticRecoveryForRun(latestRun, issue.status)) {
+        result.skipped += 1;
+        continue;
+      }
+      if (await didAutomaticRecoveryFail(latestRun, "issue_continuation_needed")) {
         const failureSummary = summarizeRunFailureForIssueComment(latestRun);
         const updated = await escalateStrandedAssignedIssue({
           issue,
@@ -6456,17 +6594,11 @@ export function heartbeatService(db: Db) {
       });
       const normalizedUsage = sessionUsageResolution.normalizedUsage;
 
-      let outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
       const latestRun = await getRun(run.id);
-      if (isHeartbeatRunTerminalStatus(latestRun?.status)) {
-        outcome = latestRun.status;
-      } else if (adapterResult.timedOut) {
-        outcome = "timed_out";
-      } else if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
-        outcome = "succeeded";
-      } else {
-        outcome = "failed";
-      }
+      const outcome = await deriveHeartbeatRunOutcome({
+        latestRun,
+        adapterResult,
+      });
       const runErrorMessage =
         outcome === "cancelled"
           ? (latestRun?.error ?? adapterResult.errorMessage ?? "Cancelled")
@@ -6527,7 +6659,15 @@ export function heartbeatService(db: Db) {
 
       const persistedResultJson = mergeHeartbeatRunResultJson(
         mergeRunStopMetadataForAgent(agent, outcome, {
-          resultJson: adapterResult.resultJson ?? null,
+          resultJson:
+            outcome === "succeeded" && isHeartbeatResultSuccessfulStatus(readHeartbeatResultStatus(adapterResult.resultJson))
+              ? buildAuthoritativeSuccessResultJson({
+                  resultJson: parseObject(adapterResult.resultJson),
+                  exitCode: adapterResult.exitCode,
+                  errorCode: adapterResult.errorCode,
+                  errorMessage: adapterResult.errorMessage,
+                })
+              : adapterResult.resultJson ?? null,
           errorCode: runErrorCode,
           errorMessage: runErrorMessage,
         }),
@@ -7111,7 +7251,7 @@ export function heartbeatService(db: Db) {
         issue.assigneeAgentId === run.agentId &&
         (run.status === "failed" || run.status === "timed_out" || run.status === "cancelled");
 
-      if (!issueNeedsImmediateRecovery) {
+      if (!issueNeedsImmediateRecovery || await shouldSuppressAutomaticRecoveryForRun(run, issue.status)) {
         return { kind: "released" as const };
       }
 
@@ -7135,7 +7275,10 @@ export function heartbeatService(db: Db) {
       const shouldBlockImmediately =
         !recoveryAgentInvokable ||
         !recoveryAgent ||
-        didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
+        await didAutomaticRecoveryFail(
+          run,
+          issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed",
+        );
       if (shouldBlockImmediately) {
         const comment = buildImmediateExecutionPathRecoveryComment({
           status: issue.status as "todo" | "in_progress",


### PR DESCRIPTION
This pull request improves the handling of terminal "ok" payloads and gateway timeouts in the heartbeat process recovery logic, ensuring that successful results are correctly recognized and that unnecessary recovery actions are avoided. The changes also enhance the test coverage for these scenarios.

**Improvements to terminal run status handling:**

- Added new logic to treat terminal "ok" payloads as authoritative successes, even if the adapter returned a non-zero exit code or error message, as long as there is concrete evidence of success. This suppresses unnecessary recovery attempts and prevents duplicate completion comments. [[1]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L932-R1001) [[2]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R4260-R4311) [[3]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L4727-R4861) [[4]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L4768-R4906) [[5]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L6459-R6601) [[6]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L6530-R6670) [[7]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L7114-R7254) [[8]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L7138-R7281)

- Gateway timeouts are now reliably classified as "timed_out" failures, preserving the correct status and avoiding false positives for successful runs. [[1]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L932-R1001) [[2]](diffhunk://#diff-dad769737ae07e59e6ea81ee9b0666970d9b50ac1cfc99cd5905af9fc0c30b78R1662-R1907)

**Test coverage:**

- Added comprehensive tests for:
  - Recognizing terminal "ok" payloads as succeeded and ensuring no duplicate recovery or comments are queued.
  - Skipping recovery for historical false failures with "ok" payloads and durable evidence.
  - Preserving genuine gateway timeouts as timed_out failures.

**Internal refactoring and utility improvements:**

- Refactored status and result handling into utility functions for clarity and reusability, such as `readHeartbeatResultStatus`, `isHeartbeatResultSuccessfulStatus`, and `buildAuthoritativeSuccessResultJson`.
- Extended the shape of recovery analysis runs to include all necessary fields for improved analysis. [[1]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R2066-R2080) [[2]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R4470-R4479)
- Integrated new evidence-checking logic using `hasConcreteActionEvidence` to ensure only runs with real progress are treated as successes. [[1]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R4260-R4311) [[2]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R71)

These changes make the heartbeat recovery process more robust and accurate, reducing noise from false failures and ensuring only genuine issues trigger recovery actions.