### PR TITLE
Add handling for awaiting human message IDs in heartbeat service

### DIFF
--- a/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
+++ b/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
@@ -578,4 +578,50 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
       .then((rows) => rows[0] ?? null);
     expect(interaction?.status).toBe("accepted");
   });
+
+  it("does not use outbox ClickUp message ids from non-sent delivery rows", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const seeded = await seedAwaitingHumanConfirmation({ externalId: null });
+    await db.insert(awaitingHumanNotificationOutbox).values({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      dedupeKey: "handoff-1",
+      handoffKind: "request_confirmation",
+      status: "retrying",
+      notification: {},
+      clickupMessageId: "message-stale",
+    });
+    await db
+      .update(activityLog)
+      .set({
+        details: {
+          interactionId: seeded.interactionId,
+          dedupeKey: "handoff-1",
+          notificationDelivery: {
+            status: "enqueued",
+            channel: "clickup-chat",
+            detail: "enqueued",
+            externalId: null,
+          },
+        },
+      })
+      .where(eq(activityLog.action, "issue.awaiting_human.entered"));
+
+    globalThis.fetch = vi.fn() as typeof fetch;
+
+    const result = await heartbeat.reconcileAwaitingHumanApprovals();
+
+    expect(result.approved).toBe(0);
+    expect(result.checked).toBe(0);
+    expect(result.skipped).toBeGreaterThan(0);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    const interaction = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, seeded.interactionId))
+      .then((rows) => rows[0] ?? null);
+    expect(interaction?.status).toBe("pending");
+  });
 });

--- a/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
+++ b/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
@@ -5,6 +5,7 @@ import {
   activityLog,
   agents,
   agentWakeupRequests,
+  awaitingHumanNotificationOutbox,
   companies,
   createDb,
   goals,
@@ -525,5 +526,56 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
       .where(eq(issueThreadInteractions.id, seeded.interactionId))
       .then((rows) => rows[0] ?? null);
     expect(interaction?.status).toBe("pending");
+  });
+
+  it("falls back to the outbox ClickUp message id when the awaiting_human activity was logged before delivery completed", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const seeded = await seedAwaitingHumanConfirmation({ externalId: null });
+    await db.insert(awaitingHumanNotificationOutbox).values({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      dedupeKey: "handoff-1",
+      handoffKind: "request_confirmation",
+      status: "sent",
+      notification: {},
+      clickupMessageId: "message-42",
+    });
+    await db
+      .update(activityLog)
+      .set({
+        details: {
+          interactionId: seeded.interactionId,
+          dedupeKey: "handoff-1",
+          notificationDelivery: {
+            status: "enqueued",
+            channel: "clickup-chat",
+            detail: "enqueued",
+            externalId: null,
+          },
+        },
+      })
+      .where(eq(activityLog.action, "issue.awaiting_human.entered"));
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ reaction: "heavy_check_mark", count: 1 }] }),
+      }) as typeof fetch;
+
+    const result = await heartbeat.reconcileAwaitingHumanApprovals();
+
+    expect(result.approved).toBe(1);
+    const interaction = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, seeded.interactionId))
+      .then((rows) => rows[0] ?? null);
+    expect(interaction?.status).toBe("accepted");
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5410,6 +5410,7 @@ export function heartbeatService(db: Db) {
             eq(awaitingHumanNotificationOutbox.companyId, input.companyId),
             eq(awaitingHumanNotificationOutbox.issueId, input.issueId),
             eq(awaitingHumanNotificationOutbox.dedupeKey, dedupeKey),
+            eq(awaitingHumanNotificationOutbox.status, "sent"),
           ),
         )
         .limit(1)
@@ -5458,16 +5459,20 @@ export function heartbeatService(db: Db) {
 
       const details = parseObject(handoff?.details);
       const delivery = parseObject(details.notificationDelivery);
+      if (
+        delivery.channel !== "clickup-chat"
+        || (delivery.status !== "sent" && delivery.status !== "enqueued")
+      ) {
+        result.skipped += 1;
+        continue;
+      }
+
       const messageId = await resolveAwaitingHumanMessageId({
         companyId: candidate.companyId,
         issueId: candidate.issueId,
         handoffDetails: details,
       });
-      if (
-        delivery.channel !== "clickup-chat"
-        || (delivery.status !== "sent" && delivery.status !== "enqueued")
-        || !messageId
-      ) {
+      if (!messageId) {
         result.skipped += 1;
         continue;
       }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -24,6 +24,7 @@ import {
   agentTaskSessions,
   agentWakeupRequests,
   activityLog,
+  awaitingHumanNotificationOutbox,
   clickupBridges,
   companySkills as companySkillsTable,
   documentRevisions,
@@ -5389,6 +5390,34 @@ export function heartbeatService(db: Db) {
       return row?.status ?? null;
     }
 
+    async function resolveAwaitingHumanMessageId(input: {
+      companyId: string;
+      issueId: string;
+      handoffDetails: Record<string, unknown>;
+    }) {
+      const delivery = parseObject(input.handoffDetails.notificationDelivery);
+      const activityMessageId = readNonEmptyString(delivery.externalId);
+      if (activityMessageId) return activityMessageId;
+
+      const dedupeKey = readNonEmptyString(input.handoffDetails.dedupeKey);
+      if (!dedupeKey) return null;
+
+      const row = await db
+        .select({ clickupMessageId: awaitingHumanNotificationOutbox.clickupMessageId })
+        .from(awaitingHumanNotificationOutbox)
+        .where(
+          and(
+            eq(awaitingHumanNotificationOutbox.companyId, input.companyId),
+            eq(awaitingHumanNotificationOutbox.issueId, input.issueId),
+            eq(awaitingHumanNotificationOutbox.dedupeKey, dedupeKey),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+
+      return readNonEmptyString(row?.clickupMessageId);
+    }
+
     const candidateIssueIds = [...new Set(candidates.map((candidate) => candidate.issueId))];
     const candidateCompanyIds = [...new Set(candidates.map((candidate) => candidate.companyId))];
     const candidateInteractionKeys = new Set(
@@ -5429,10 +5458,14 @@ export function heartbeatService(db: Db) {
 
       const details = parseObject(handoff?.details);
       const delivery = parseObject(details.notificationDelivery);
-      const messageId = readNonEmptyString(delivery.externalId);
+      const messageId = await resolveAwaitingHumanMessageId({
+        companyId: candidate.companyId,
+        issueId: candidate.issueId,
+        handoffDetails: details,
+      });
       if (
         delivery.channel !== "clickup-chat"
-        || delivery.status !== "sent"
+        || (delivery.status !== "sent" && delivery.status !== "enqueued")
         || !messageId
       ) {
         result.skipped += 1;


### PR DESCRIPTION
This pull request improves how the system reconciles awaiting human approvals for ClickUp by ensuring that the correct message ID is used, even if the activity log was written before the notification was delivered. The main changes add a fallback to retrieve the ClickUp message ID from the `awaitingHumanNotificationOutbox` table and update the approval logic to handle this case. A new test is also added to verify the fallback behavior.

**Core logic improvements:**

* Added a new function `resolveAwaitingHumanMessageId` in `heartbeat.ts` to retrieve the ClickUp message ID from `handoffDetails` or, if missing, fall back to the `awaitingHumanNotificationOutbox` table using the `dedupeKey`.
* Updated the approval reconciliation logic in `heartbeatService` to use the new fallback mechanism for message IDs and to handle both "sent" and "enqueued" delivery statuses.

**Testing enhancements:**

* Added a test in `heartbeat-awaiting-human-approvals.test.ts` to verify that the fallback to the outbox ClickUp message ID works when the activity log is created before notification delivery completes.

**Dependency updates:**

* Updated imports in both `heartbeat.ts` and `heartbeat-awaiting-human-approvals.test.ts` to include `awaitingHumanNotificationOutbox`. [[1]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R27) [[2]](diffhunk://#diff-8595c209bf44ccd9071e9d86d322f02dbb51af98d52561adc43cadf75d323328R8)