### PR TITLE
Enhance ClickUp approval handling for non-approval replies

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -128,6 +128,7 @@ For `awaiting_human` ClickUp notifications:
 - Bizbox still falls back to `CLICKUP_ENGINEERING_CHANNEL_ID` / `CLICKUP_ENGINEERING_CHANNEL_NAME` when the new vars are unset.
 - If neither name variable is set, Bizbox now defaults the lookup target to `bizbox-feed`.
 - Inbound approval polling still follows the tracked ClickUp message id, so renaming the approval channel does not change reconciliation behavior.
+- Positive replies/reactions accept the pending confirmation. Non-approval replies reject the confirmation and are forwarded into the issue as comments. Explicit negative reactions such as `thumbsdown` reject without forwarding comment text.
 
 A review-driven regression briefly treated `clickupAgentUserId` as a hard inbound author gate and caused stuck live ClickUp polls. Keep the fields separate.
 

--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -175,7 +175,7 @@ Supported `kind` values:
 - `ask_user_questions`: ask structured questions and store selected answers
 - `request_confirmation`: ask the board/user to accept or reject a proposal
 
-For `request_confirmation`, `continuationPolicy: "wake_assignee"` wakes the assignee only after acceptance. Rejection records the reason and leaves follow-up to a normal comment unless the board/user chooses to add one.
+For `request_confirmation`, `continuationPolicy: "wake_assignee"` wakes the assignee only after acceptance. Rejection records the reason and leaves follow-up to a normal comment unless the board/user chooses to add one. In the ClickUp `awaiting_human` bridge, any non-approval reply is treated as a rejection and forwarded back into the issue as a comment, while explicit negative reactions such as `thumbsdown` reject without adding comment text.
 
 ### Resolve Interaction
 

--- a/docs/guides/agent-developer/task-workflow.md
+++ b/docs/guides/agent-developer/task-workflow.md
@@ -89,7 +89,7 @@ POST /api/issues/{issueId}/interactions
 }
 ```
 
-Use `continuationPolicy: "wake_assignee"` when acceptance should wake you to continue. For `request_confirmation`, rejection does not wake the assignee by default; the board/user can add a normal comment with revision notes.
+Use `continuationPolicy: "wake_assignee"` when acceptance should wake you to continue. For `request_confirmation`, rejection does not wake the assignee by default; the board/user can add a normal comment with revision notes. When the request is bridged through ClickUp `awaiting_human`, a non-approval reply now counts as rejection and is mirrored back into the issue as a comment so the agent sees the requested changes, while explicit negative reactions reject without extra comment text.
 
 ## Plan Approval Pattern
 

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -434,14 +434,24 @@ describe("renderPaperclipWakePrompt", () => {
 });
 
 describe("ensurePathInEnv", () => {
-  it("prepends NVM_BIN when PATH omits it", () => {
-    const env = ensurePathInEnv({
-      HOME: "/Users/tester",
-      PATH: "/usr/bin:/bin",
-      NVM_BIN: "/Users/tester/.nvm/versions/node/v24.0.0/bin",
-    });
+  it("prepends env and process NVM_BIN entries ahead of PATH", () => {
+    const previousNvmBin = process.env.NVM_BIN;
+    process.env.NVM_BIN = "/Users/tester/.nvm/versions/node/v24.1.0/bin";
 
-    expect(env.PATH).toBe("/Users/tester/.nvm/versions/node/v24.0.0/bin:/usr/bin:/bin");
+    try {
+      const env = ensurePathInEnv({
+        HOME: "/Users/tester",
+        PATH: "/usr/bin:/bin",
+        NVM_BIN: "/Users/tester/.nvm/versions/node/v24.0.0/bin",
+      });
+
+      expect(env.PATH).toBe(
+        "/Users/tester/.nvm/versions/node/v24.0.0/bin:/Users/tester/.nvm/versions/node/v24.1.0/bin:/usr/bin:/bin",
+      );
+    } finally {
+      if (previousNvmBin === undefined) delete process.env.NVM_BIN;
+      else process.env.NVM_BIN = previousNvmBin;
+    }
   });
 });
 

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   appendWithByteCap,
   DEFAULT_BIZBOX_AGENT_PROMPT_TEMPLATE,
+  ensurePathInEnv,
   renderPaperclipWakePrompt,
   runningProcesses,
   runChildProcess,
@@ -429,6 +430,18 @@ describe("renderPaperclipWakePrompt", () => {
     expect(prompt).toContain("Do not treat this like issue execution unless visible work is created.");
     expect(prompt).toContain("CTO");
     expect(prompt).toContain("make 3 follow-up issues");
+  });
+});
+
+describe("ensurePathInEnv", () => {
+  it("prepends NVM_BIN when PATH omits it", () => {
+    const env = ensurePathInEnv({
+      HOME: "/Users/tester",
+      PATH: "/usr/bin:/bin",
+      NVM_BIN: "/Users/tester/.nvm/versions/node/v24.0.0/bin",
+    });
+
+    expect(env.PATH).toBe("/Users/tester/.nvm/versions/node/v24.0.0/bin:/usr/bin:/bin");
   });
 });
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -940,6 +940,26 @@ export function defaultPathForPlatform() {
   return "/usr/local/bin:/opt/homebrew/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin";
 }
 
+function pathEntries(value: string | undefined | null): string[] {
+  if (typeof value !== "string" || value.trim().length === 0) return [];
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  return value
+    .split(delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function uniquePathEntries(entries: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of entries) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    out.push(entry);
+  }
+  return out;
+}
+
 function windowsPathExts(env: NodeJS.ProcessEnv): string[] {
   return (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean);
 }
@@ -1024,9 +1044,20 @@ async function resolveSpawnTarget(
 }
 
 export function ensurePathInEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  if (typeof env.PATH === "string" && env.PATH.length > 0) return env;
-  if (typeof env.Path === "string" && env.Path.length > 0) return env;
-  return { ...env, PATH: defaultPathForPlatform() };
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  const existingPath = typeof env.PATH === "string" && env.PATH.length > 0
+    ? env.PATH
+    : typeof env.Path === "string" && env.Path.length > 0
+      ? env.Path
+      : defaultPathForPlatform();
+  const mergedPath = uniquePathEntries([
+    ...pathEntries(env.NVM_BIN),
+    ...pathEntries(process.env.NVM_BIN),
+    ...pathEntries(existingPath),
+  ]).join(delimiter);
+
+  if (env.PATH === mergedPath) return env;
+  return { ...env, PATH: mergedPath };
 }
 
 export async function ensureAbsoluteDirectory(

--- a/server/src/__tests__/awaiting-human-notifications.test.ts
+++ b/server/src/__tests__/awaiting-human-notifications.test.ts
@@ -28,6 +28,7 @@ afterEach(() => {
   delete process.env.CLICKUP_ENGINEERING_CHANNEL_NAME;
   delete process.env.CLICKUP_AWAITING_HUMAN_REVIEW_LIST_ID;
   delete process.env.CLICKUP_APPROVAL_POSITIVE_REACTIONS;
+  delete process.env.CLICKUP_APPROVAL_NEGATIVE_REACTIONS;
   delete process.env.CLICKUP_APPROVAL_POSITIVE_REPLY_KEYWORDS;
 });
 
@@ -456,7 +457,7 @@ describe("sendAwaitingHumanNotification", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not treat negative or ambiguous replies as approval", async () => {
+  it("treats non-approval replies as rejection with forwarded context", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
 
@@ -479,13 +480,14 @@ describe("sendAwaitingHumanNotification", () => {
     const result = await detectClickUpAwaitingHumanApproval("message-42");
 
     expect(result).toEqual({
-      status: "forward_reply",
+      status: "rejected",
       detail: "non-approval-reply-detected",
       resolutionSource: "clickup_reply",
       replies: [
         { id: "reply-1", content: "No, please revise this" },
         { id: "reply-2", content: "Can you clarify the rollout plan?" },
       ],
+      rejectionReason: "No, please revise this",
     });
   });
 
@@ -513,7 +515,7 @@ describe("sendAwaitingHumanNotification", () => {
     const result = await detectClickUpAwaitingHumanApproval("message-42");
 
     expect(result).toEqual({
-      status: "forward_reply",
+      status: "rejected",
       detail: "non-approval-reply-detected",
       resolutionSource: "clickup_reply",
       replies: [
@@ -521,6 +523,7 @@ describe("sendAwaitingHumanNotification", () => {
         { id: "reply-2", content: "don't go ahead" },
         { id: "reply-3", content: "not approved" },
       ],
+      rejectionReason: "not okay",
     });
   });
 
@@ -575,7 +578,7 @@ describe("sendAwaitingHumanNotification", () => {
     });
   });
 
-  it("returns forwardable replies when the reactions lookup fails after replies were collected", async () => {
+  it("rejects with forwarded replies when the reactions lookup fails after replies were collected", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
 
@@ -596,10 +599,11 @@ describe("sendAwaitingHumanNotification", () => {
     const result = await detectClickUpAwaitingHumanApproval("message-42");
 
     expect(result).toEqual({
-      status: "forward_reply",
+      status: "rejected",
       detail: "non-approval-reply-detected",
       resolutionSource: "clickup_reply",
       replies: [{ id: "reply-1", content: "Please fix the rollout title first." }],
+      rejectionReason: "Please fix the rollout title first.",
     });
   });
 
@@ -706,7 +710,7 @@ describe("sendAwaitingHumanNotification", () => {
     });
   });
 
-  it("ignores neutral or noisy reactions when detecting approval", async () => {
+  it("treats configured negative reactions as rejection", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
 
@@ -721,6 +725,37 @@ describe("sendAwaitingHumanNotification", () => {
           data: [
             { reaction: "eyes", count: 2 },
             { reaction: "thumbsdown", count: 1 },
+          ],
+        }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await detectClickUpAwaitingHumanApproval("message-42");
+
+    expect(result).toEqual({
+      status: "rejected",
+      detail: "negative-reaction-detected",
+      resolutionSource: "clickup_reaction",
+      clickupReaction: "thumbsdown",
+      rejectionReason: "Rejected in ClickUp with :thumbsdown: reaction.",
+    });
+  });
+
+  it("ignores neutral reactions when detecting approval", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { reaction: "eyes", count: 2 },
+            { reaction: "thinking_face", count: 1 },
           ],
         }),
       });

--- a/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
+++ b/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
@@ -98,6 +98,7 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
     delete process.env.CLICKUP_PERSONAL_TOKEN;
     delete process.env.CLICKUP_WORKSPACE_ID;
     delete process.env.CLICKUP_APPROVAL_POSITIVE_REACTIONS;
+    delete process.env.CLICKUP_APPROVAL_NEGATIVE_REACTIONS;
     await db.delete(activityLog);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
@@ -291,7 +292,7 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
     });
   });
 
-  it("forwards non-approval ClickUp replies into issue comments and wakes the creator agent", async () => {
+  it("rejects non-approval ClickUp replies, forwards them into issue comments, and wakes the creator agent", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
 
@@ -322,7 +323,9 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
     const second = await heartbeat.reconcileAwaitingHumanApprovals();
 
     expect(first.approved).toBe(0);
+    expect(first.rejected).toBe(1);
     expect(second.approved).toBe(0);
+    expect(second.rejected).toBe(0);
 
     const comments = await db
       .select()
@@ -338,7 +341,14 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
       .from(issueThreadInteractions)
       .where(eq(issueThreadInteractions.id, seeded.interactionId))
       .then((rows) => rows[0] ?? null);
-    expect(interaction?.status).toBe("pending");
+    expect(interaction?.status).toBe("rejected");
+
+    const updatedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, seeded.issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(updatedIssue?.status).toBe("todo");
 
     const wakes = await waitForWakeup(seeded.agentId);
     expect(wakes).toHaveLength(1);
@@ -353,6 +363,18 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
       clickupMessageId: "message-42",
       clickupReplyId: "reply-1",
       commentId: comments[0]?.id,
+    });
+
+    const rejectedActivity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.thread_interaction_rejected"));
+    expect(rejectedActivity).toHaveLength(1);
+    expect(rejectedActivity[0]?.details).toMatchObject({
+      interactionId: seeded.interactionId,
+      resolutionSource: "clickup_reply",
+      clickupMessageId: "message-42",
+      rejectionReason: "Please change the rollout title first.",
     });
   });
 
@@ -478,7 +500,7 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
     expect(wakes).toHaveLength(0);
   });
 
-  it("does not accept a pending confirmation for neutral or negative reactions", async () => {
+  it("rejects a pending confirmation for explicit negative reactions", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
 
@@ -496,10 +518,47 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
     const result = await heartbeat.reconcileAwaitingHumanApprovals();
 
     expect(result.approved).toBe(0);
+    expect(result.rejected).toBe(1);
     expect(result.checked).toBe(1);
-    expect(result.noApproval).toBe(1);
+    expect(result.noApproval).toBe(0);
     expect(result.failed).toBe(0);
     expect(result.skipped).toBe(0);
+    const interaction = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, seeded.interactionId))
+      .then((rows) => rows[0] ?? null);
+    expect(interaction?.status).toBe("rejected");
+
+    const updatedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, seeded.issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(updatedIssue?.status).toBe("todo");
+  });
+
+  it("still ignores neutral reactions with no approval or rejection signal", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const seeded = await seedAwaitingHumanConfirmation();
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ reaction: "eyes", count: 2 }] }),
+      }) as typeof fetch;
+
+    const result = await heartbeat.reconcileAwaitingHumanApprovals();
+
+    expect(result.approved).toBe(0);
+    expect(result.rejected).toBe(0);
+    expect(result.checked).toBe(1);
+    expect(result.noApproval).toBe(1);
     const interaction = await db
       .select()
       .from(issueThreadInteractions)

--- a/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
+++ b/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
@@ -131,7 +131,10 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
       .where(eq(agentWakeupRequests.agentId, agentId));
   }
 
-  async function seedAwaitingHumanConfirmation(opts?: { externalId?: string | null }) {
+  async function seedAwaitingHumanConfirmation(opts?: {
+    continuationPolicy?: "wake_assignee" | "wake_assignee_on_accept";
+    externalId?: string | null;
+  }) {
     const companyId = randomUUID();
     const goalId = randomUUID();
     const issueId = randomUUID();
@@ -181,7 +184,7 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
       companyId,
     }, {
       kind: "request_confirmation",
-      continuationPolicy: "wake_assignee_on_accept",
+      continuationPolicy: opts?.continuationPolicy ?? "wake_assignee_on_accept",
       payload: {
         version: 1,
         prompt: "Approve this plan?",
@@ -350,9 +353,6 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
       .then((rows) => rows[0] ?? null);
     expect(updatedIssue?.status).toBe("todo");
 
-    const wakes = await waitForWakeup(seeded.agentId);
-    expect(wakes).toHaveLength(1);
-
     const commentActivities = await db
       .select()
       .from(activityLog)
@@ -424,8 +424,6 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
       "ClickUp reply received:\n\nAlso add the rollback note.",
     ]);
 
-    const wakes = await waitForWakeup(seeded.agentId);
-    expect(wakes).toHaveLength(2);
   });
 
   it("does not enqueue a wake when the issue moved to backlog before forwarding the ClickUp reply", async () => {

--- a/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
+++ b/server/src/__tests__/heartbeat-awaiting-human-approvals.test.ts
@@ -101,11 +101,11 @@ describeEmbeddedPostgres("heartbeat awaiting_human ClickUp approvals", () => {
     delete process.env.CLICKUP_APPROVAL_NEGATIVE_REACTIONS;
     await db.delete(activityLog);
     await db.delete(heartbeatRuns);
-    await db.delete(agentWakeupRequests);
     await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(issues);
     await db.delete(goals);
+    await db.delete(agentWakeupRequests);
     await db.delete(agents);
     await db.delete(instanceSettings);
     await db.delete(companies);

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -117,7 +117,7 @@ export interface ClickUpChatMessageReaction {
 }
 
 export interface ClickUpAwaitingHumanApprovalResult {
-  status: ClickUpApiStatus | "approved" | "forward_reply" | "rejected";
+  status: ClickUpApiStatus | "approved" | "rejected";
   detail: string;
   resolutionSource?: "clickup_reply" | "clickup_reaction";
   clickupReaction?: string | null;

--- a/server/src/services/awaiting-human-notifications.ts
+++ b/server/src/services/awaiting-human-notifications.ts
@@ -20,6 +20,7 @@ const STALE_OUTBOX_PROCESSING_MS = 5 * 60 * 1000;
 const DEFAULT_CLICKUP_TIMEOUT_SEC = 30;
 const CLICKUP_ATTACHMENT_FILE_FIELD = "attachment[0]";
 const DEFAULT_CLICKUP_APPROVAL_POSITIVE_REACTIONS = ["thumbsup", "white_check_mark", "heavy_check_mark"] as const;
+const DEFAULT_CLICKUP_APPROVAL_NEGATIVE_REACTIONS = ["thumbsdown"] as const;
 const DEFAULT_CLICKUP_APPROVAL_POSITIVE_REPLY_KEYWORDS = [
   "approve",
   "approved",
@@ -99,6 +100,7 @@ type ClickUpChatConfig = {
   channelName: string;
   reviewListId: string;
   approvalPositiveReactions: string[];
+  approvalNegativeReactions: string[];
   approvalPositiveReplyKeywords: string[];
 };
 
@@ -115,11 +117,12 @@ export interface ClickUpChatMessageReaction {
 }
 
 export interface ClickUpAwaitingHumanApprovalResult {
-  status: ClickUpApiStatus | "approved" | "forward_reply";
+  status: ClickUpApiStatus | "approved" | "forward_reply" | "rejected";
   detail: string;
   resolutionSource?: "clickup_reply" | "clickup_reaction";
   clickupReaction?: string | null;
   replies?: ClickUpChatMessageReply[];
+  rejectionReason?: string | null;
 }
 
 function truncateText(value: string, maxLength: number) {
@@ -228,6 +231,10 @@ function readClickUpChatConfig(): ClickUpChatConfig {
     .split(",")
     .map((value) => value.trim().toLowerCase())
     .filter(Boolean);
+  const negativeReactions = (process.env.CLICKUP_APPROVAL_NEGATIVE_REACTIONS ?? "")
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
   const positiveReplyKeywords = (process.env.CLICKUP_APPROVAL_POSITIVE_REPLY_KEYWORDS ?? "")
     .split(",")
     .map((value) => compactWhitespace(value.trim().toLowerCase()))
@@ -247,6 +254,9 @@ function readClickUpChatConfig(): ClickUpChatConfig {
     approvalPositiveReactions: positiveReactions.length > 0
       ? [...new Set(positiveReactions)]
       : [...DEFAULT_CLICKUP_APPROVAL_POSITIVE_REACTIONS],
+    approvalNegativeReactions: negativeReactions.length > 0
+      ? [...new Set(negativeReactions)]
+      : [...DEFAULT_CLICKUP_APPROVAL_NEGATIVE_REACTIONS],
     approvalPositiveReplyKeywords: positiveReplyKeywords.length > 0
       ? [...new Set(positiveReplyKeywords)]
       : [...DEFAULT_CLICKUP_APPROVAL_POSITIVE_REPLY_KEYWORDS],
@@ -1216,15 +1226,17 @@ export async function detectClickUpAwaitingHumanApproval(
     };
   }
   const forwardableReplies = availableReplies.filter((reply) => normalizeReplyContent(reply.content).length > 0);
+  const rejectionReason = forwardableReplies[0]?.content?.trim() ?? null;
 
   const reactionsResult = await getClickUpChatMessageReactions(messageId);
   if (reactionsResult.status === "failed" || reactionsResult.status === "skipped") {
     if (forwardableReplies.length > 0) {
       return {
-        status: "forward_reply",
+        status: "rejected",
         detail: "non-approval-reply-detected",
         resolutionSource: "clickup_reply",
         replies: forwardableReplies,
+        rejectionReason,
       };
     }
     if (repliesResult.status === "failed") {
@@ -1251,12 +1263,29 @@ export async function detectClickUpAwaitingHumanApproval(
       clickupReaction: matchingReaction.name,
     };
   }
+
+  const negativeSet = new Set(config.approvalNegativeReactions);
+  const rejectingReaction = reactionsResult.reactions.find((reaction) =>
+    reaction.count > 0 && negativeSet.has(reaction.name)
+  );
+  if (rejectingReaction) {
+    return {
+      status: "rejected",
+      detail: "negative-reaction-detected",
+      resolutionSource: "clickup_reaction",
+      clickupReaction: rejectingReaction.name,
+      replies: forwardableReplies.length > 0 ? forwardableReplies : undefined,
+      rejectionReason: rejectionReason ?? `Rejected in ClickUp with :${rejectingReaction.name}: reaction.`,
+    };
+  }
+
   if (forwardableReplies.length > 0) {
     return {
-      status: "forward_reply",
+      status: "rejected",
       detail: "non-approval-reply-detected",
       resolutionSource: "clickup_reply",
       replies: forwardableReplies,
+      rejectionReason,
     };
   }
   if (repliesResult.status === "failed") {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -136,7 +136,11 @@ import {
 import { extractSkillMentionIds } from "@paperclipai/shared";
 import { getStorageService } from "../storage/index.js";
 import { issueThreadInteractionService } from "./issue-thread-interactions.js";
-import { finalizeAcceptedInteractionResolution, isClosedIssueStatus } from "./issue-interaction-resolution-effects.js";
+import {
+  finalizeAcceptedInteractionResolution,
+  isClosedIssueStatus,
+  queueResolvedInteractionContinuationWakeup,
+} from "./issue-interaction-resolution-effects.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const MAX_PERSISTED_LOG_CHUNK_CHARS = 64 * 1024;
@@ -5337,6 +5341,7 @@ export function heartbeatService(db: Db) {
     const result = {
       checked: 0,
       approved: 0,
+      rejected: 0,
       failed: 0,
       skipped: 0,
       noApproval: 0,
@@ -5373,6 +5378,111 @@ export function heartbeatService(db: Db) {
 
     function buildForwardedClickUpReplyComment(replyBody: string) {
       return `ClickUp reply received:\n\n${replyBody}`;
+    }
+
+    async function forwardClickUpRepliesIntoIssueComments(input: {
+      candidate: typeof candidates[number];
+      messageId: string;
+      replies: { id: string | null; content: string | null }[];
+    }) {
+      let forwardedAny = false;
+      for (const reply of input.replies) {
+        const replyId = readNonEmptyString(reply.id);
+        const replyBody = readNonEmptyString(reply.content);
+        const wakeAgentId = input.candidate.assigneeAgentId ?? input.candidate.createdByAgentId ?? null;
+        if (!replyId || !replyBody) continue;
+        if (await hasForwardedClickUpReply({
+          companyId: input.candidate.companyId,
+          issueId: input.candidate.issueId,
+          interactionId: input.candidate.interactionId,
+          clickupMessageId: input.messageId,
+          clickupReplyId: replyId,
+        })) {
+          continue;
+        }
+
+        try {
+          const comment = await db.transaction(async (tx) => {
+            const [createdComment] = await tx
+              .insert(issueComments)
+              .values({
+                companyId: input.candidate.companyId,
+                issueId: input.candidate.issueId,
+                authorAgentId: null,
+                authorUserId: null,
+                createdByRunId: null,
+                body: buildForwardedClickUpReplyComment(replyBody),
+              })
+              .returning();
+
+            await tx
+              .update(issues)
+              .set({ updatedAt: new Date() })
+              .where(eq(issues.id, input.candidate.issueId));
+
+            await logActivity(tx as unknown as Db, {
+              companyId: input.candidate.companyId,
+              actorType: "system",
+              actorId: "clickup_approval_poller",
+              action: "issue.comment_added",
+              entityType: "issue",
+              entityId: input.candidate.issueId,
+              details: {
+                commentId: createdComment.id,
+                bodySnippet: createdComment.body.slice(0, 120),
+                identifier: input.candidate.identifier,
+                issueTitle: input.candidate.title,
+                interactionId: input.candidate.interactionId,
+                forwardingOrigin: "clickup.awaiting_human.reply_forwarded",
+                clickupMessageId: input.messageId,
+                clickupReplyId: replyId,
+              },
+            });
+
+            return createdComment;
+          });
+
+          forwardedAny = true;
+
+          const currentIssueStatus = await getCurrentIssueStatus(input.candidate.companyId, input.candidate.issueId);
+          if (wakeAgentId && currentIssueStatus !== "backlog" && !isClosedIssueStatus(currentIssueStatus)) {
+            await enqueueWakeup(wakeAgentId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: "issue_commented",
+              payload: {
+                issueId: input.candidate.issueId,
+                commentId: comment.id,
+                mutation: "comment",
+              },
+              requestedByActorType: "system",
+              requestedByActorId: "clickup_approval_poller",
+              contextSnapshot: {
+                issueId: input.candidate.issueId,
+                taskId: input.candidate.issueId,
+                commentId: comment.id,
+                wakeCommentId: comment.id,
+                source: "clickup.awaiting_human.reply_forwarded",
+                wakeReason: "issue_commented",
+                interactionId: input.candidate.interactionId,
+                clickupMessageId: input.messageId,
+                clickupReplyId: replyId,
+              },
+            });
+          }
+        } catch (error) {
+          result.failed += 1;
+          logger.warn({
+            err: error,
+            issueId: input.candidate.issueId,
+            interactionId: input.candidate.interactionId,
+            clickupMessageId: input.messageId,
+            clickupReplyId: replyId,
+          }, "failed to forward awaiting_human ClickUp reply into issue comment");
+        }
+      }
+
+      return forwardedAny;
     }
 
     async function getCurrentIssueStatus(companyId: string, issueId: string) {
@@ -5490,104 +5600,91 @@ export function heartbeatService(db: Db) {
         continue;
       }
       if (approval.status === "forward_reply") {
-        let forwardedAny = false;
-        for (const reply of approval.replies ?? []) {
-          const replyId = readNonEmptyString(reply.id);
-          const replyBody = readNonEmptyString(reply.content);
-          const wakeAgentId = candidate.assigneeAgentId ?? candidate.createdByAgentId ?? null;
-          if (!replyId || !replyBody) continue;
-          if (await hasForwardedClickUpReply({
+        const forwardedAny = await forwardClickUpRepliesIntoIssueComments({
+          candidate,
+          messageId,
+          replies: approval.replies ?? [],
+        });
+        if (!forwardedAny) {
+          result.skipped += 1;
+        }
+        continue;
+      }
+      if (approval.status === "rejected") {
+        try {
+          const interaction = await interactionsSvc.rejectInteraction({
+            id: candidate.issueId,
             companyId: candidate.companyId,
+          }, candidate.interactionId, {
+            reason: approval.rejectionReason ?? "Rejected from ClickUp awaiting_human flow.",
+          }, {
+            actorType: "system",
+            userId: null,
+            agentId: null,
+          });
+
+          await logActivity(db, {
+            companyId: candidate.companyId,
+            actorType: "system",
+            actorId: "clickup_approval_poller",
+            action: interaction.status === "expired"
+              ? "issue.thread_interaction_expired"
+              : "issue.thread_interaction_rejected",
+            entityType: "issue",
+            entityId: candidate.issueId,
+            details: {
+              interactionId: interaction.id,
+              interactionKind: interaction.kind,
+              interactionStatus: interaction.status,
+              rejectionReason:
+                interaction.kind === "suggest_tasks"
+                  ? (interaction.result?.rejectionReason ?? null)
+                  : interaction.kind === "request_confirmation"
+                    ? (interaction.result?.reason ?? null)
+                    : null,
+              resolutionSource: approval.resolutionSource,
+              clickupMessageId: messageId,
+              clickupReaction: approval.clickupReaction ?? null,
+            },
+          });
+
+          const currentIssueStatus = await getCurrentIssueStatus(candidate.companyId, candidate.issueId);
+          queueResolvedInteractionContinuationWakeup({
+            heartbeat: { wakeup: enqueueWakeup },
+            issue: {
+              id: candidate.issueId,
+              assigneeAgentId: candidate.assigneeAgentId,
+              status: currentIssueStatus ?? candidate.status,
+            },
+            interaction,
+            actor: {
+              actorType: "system",
+              actorId: "clickup_approval_poller",
+            },
+            source: "clickup.awaiting_human.rejection",
+          });
+
+          const forwardedAny = await forwardClickUpRepliesIntoIssueComments({
+            candidate,
+            messageId,
+            replies: approval.replies ?? [],
+          });
+          if (!forwardedAny && (approval.replies?.length ?? 0) > 0) {
+            result.skipped += 1;
+          }
+
+          result.rejected += 1;
+          result.issueIds.push(candidate.issueId);
+          result.interactionIds.push(candidate.interactionId);
+        } catch (error) {
+          result.failed += 1;
+          logger.warn({
+            err: error,
             issueId: candidate.issueId,
             interactionId: candidate.interactionId,
             clickupMessageId: messageId,
-            clickupReplyId: replyId,
-          })) {
-            continue;
-          }
-
-          try {
-            const comment = await db.transaction(async (tx) => {
-              const [createdComment] = await tx
-                .insert(issueComments)
-                .values({
-                  companyId: candidate.companyId,
-                  issueId: candidate.issueId,
-                  authorAgentId: null,
-                  authorUserId: null,
-                  createdByRunId: null,
-                  body: buildForwardedClickUpReplyComment(replyBody),
-                })
-                .returning();
-
-              await tx
-                .update(issues)
-                .set({ updatedAt: new Date() })
-                .where(eq(issues.id, candidate.issueId));
-
-              await logActivity(tx as unknown as Db, {
-                companyId: candidate.companyId,
-                actorType: "system",
-                actorId: "clickup_approval_poller",
-                action: "issue.comment_added",
-                entityType: "issue",
-                entityId: candidate.issueId,
-                details: {
-                  commentId: createdComment.id,
-                  bodySnippet: createdComment.body.slice(0, 120),
-                  identifier: candidate.identifier,
-                  issueTitle: candidate.title,
-                  interactionId: candidate.interactionId,
-                  forwardingOrigin: "clickup.awaiting_human.reply_forwarded",
-                  clickupMessageId: messageId,
-                  clickupReplyId: replyId,
-                },
-              });
-
-              return createdComment;
-            });
-
-            forwardedAny = true;
-
-            const currentIssueStatus = await getCurrentIssueStatus(candidate.companyId, candidate.issueId);
-            if (wakeAgentId && currentIssueStatus !== "backlog" && !isClosedIssueStatus(currentIssueStatus)) {
-              await enqueueWakeup(wakeAgentId, {
-                source: "automation",
-                triggerDetail: "system",
-                reason: "issue_commented",
-                payload: {
-                  issueId: candidate.issueId,
-                  commentId: comment.id,
-                  mutation: "comment",
-                },
-                requestedByActorType: "system",
-                requestedByActorId: "clickup_approval_poller",
-                contextSnapshot: {
-                  issueId: candidate.issueId,
-                  taskId: candidate.issueId,
-                  commentId: comment.id,
-                  wakeCommentId: comment.id,
-                  source: "clickup.awaiting_human.reply_forwarded",
-                  wakeReason: "issue_commented",
-                  interactionId: candidate.interactionId,
-                  clickupMessageId: messageId,
-                  clickupReplyId: replyId,
-                },
-              });
-            }
-          } catch (error) {
-            result.failed += 1;
-            logger.warn({
-              err: error,
-              issueId: candidate.issueId,
-              interactionId: candidate.interactionId,
-              clickupMessageId: messageId,
-              clickupReplyId: replyId,
-            }, "failed to forward awaiting_human ClickUp reply into issue comment");
-          }
-        }
-        if (!forwardedAny) {
-          result.skipped += 1;
+            detail: approval.detail,
+          }, "failed to reject ClickUp awaiting_human interaction");
         }
         continue;
       }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5384,7 +5384,9 @@ export function heartbeatService(db: Db) {
       candidate: typeof candidates[number];
       messageId: string;
       replies: { id: string | null; content: string | null }[];
+      wakeAssignee?: boolean;
     }) {
+      const wakeAssignee = input.wakeAssignee ?? true;
       let forwardedAny = false;
       for (const reply of input.replies) {
         const replyId = readNonEmptyString(reply.id);
@@ -5445,7 +5447,12 @@ export function heartbeatService(db: Db) {
           forwardedAny = true;
 
           const currentIssueStatus = await getCurrentIssueStatus(input.candidate.companyId, input.candidate.issueId);
-          if (wakeAgentId && currentIssueStatus !== "backlog" && !isClosedIssueStatus(currentIssueStatus)) {
+          if (
+            wakeAssignee
+            && wakeAgentId
+            && currentIssueStatus !== "backlog"
+            && !isClosedIssueStatus(currentIssueStatus)
+          ) {
             await enqueueWakeup(wakeAgentId, {
               source: "automation",
               triggerDetail: "system",
@@ -5599,17 +5606,6 @@ export function heartbeatService(db: Db) {
         }, "failed to poll ClickUp awaiting_human approval state");
         continue;
       }
-      if (approval.status === "forward_reply") {
-        const forwardedAny = await forwardClickUpRepliesIntoIssueComments({
-          candidate,
-          messageId,
-          replies: approval.replies ?? [],
-        });
-        if (!forwardedAny) {
-          result.skipped += 1;
-        }
-        continue;
-      }
       if (approval.status === "rejected") {
         try {
           const interaction = await interactionsSvc.rejectInteraction({
@@ -5668,6 +5664,7 @@ export function heartbeatService(db: Db) {
             candidate,
             messageId,
             replies: approval.replies ?? [],
+            wakeAssignee: false,
           });
           if (!forwardedAny && (approval.replies?.length ?? 0) > 0) {
             result.skipped += 1;


### PR DESCRIPTION
This pull request enhances the handling and detection of approval and rejection signals in ClickUp `awaiting_human` workflows, especially concerning replies and reactions. It introduces explicit support for negative reactions (like `thumbsdown`) as rejection, ensures that non-approval replies are mirrored as rejection (with context), and updates documentation and tests to reflect these behaviors. Additionally, it improves environment variable handling for process paths.

**ClickUp Approval/Rejection Handling:**

* Explicitly treats non-approval replies in ClickUp as rejections, forwarding them as comments into the related issue and updating the status accordingly; explicit negative reactions (e.g., `thumbsdown`) now immediately reject without forwarding comment text. [[1]](diffhunk://#diff-3e6d58e87c820a548c3943f14dd07beac67a2ffa27cf15fb650623b9e0f19f4cR131) [[2]](diffhunk://#diff-b7ea839f046e5fb47c40cc5ae9e8f7ac39d75249128c0752e1ac2dc927375f13L178-R178) [[3]](diffhunk://#diff-f7680e4cb93fd8ce8e958935dc87968da9276d288c8191ebb532745ba8d6f17bL92-R92) [[4]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4L118-R125) [[5]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4R234-R237)
* Adds support for `CLICKUP_APPROVAL_NEGATIVE_REACTIONS` environment variable and defaults to `thumbsdown`, enabling configuration of which reactions count as explicit rejection. [[1]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4R23) [[2]](diffhunk://#diff-d7058cef12d65684b6c0342c36fa5ac9e5885dfc51fc562452dc928f1c6ab2d4R103) [[3]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69R31) [[4]](diffhunk://#diff-8595c209bf44ccd9071e9d86d322f02dbb51af98d52561adc43cadf75d323328R101)
* Updates test suites to verify that non-approval replies and negative reactions properly result in rejection, correct status transitions, and appropriate activity logging. [[1]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L459-R460) [[2]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L482-R490) [[3]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L516-R526) [[4]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L578-R581) [[5]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L599-R606) [[6]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69L709-R713) [[7]](diffhunk://#diff-904b934bd26e5c479d653249e19d47e90b6a1ca3bb7af1a913cb5a219aea1e69R735-R765) [[8]](diffhunk://#diff-8595c209bf44ccd9071e9d86d322f02dbb51af98d52561adc43cadf75d323328L294-R295) [[9]](diffhunk://#diff-8595c209bf44ccd9071e9d86d322f02dbb51af98d52561adc43cadf75d323328R326-R328) [[10]](diffhunk://#diff-8595c209bf44ccd9071e9d86d322f02dbb51af98d52561adc43cadf75d323328L341-R351) [[11]](diffhunk://#diff-8595c209bf44ccd9071e9d86d322f02dbb51af98d52561adc43cadf75d323328R367-R378) [[12]](diffhunk://#diff-8595c209bf44ccd9071e9d86d322f02dbb51af98d52561adc43cadf75d323328L481-R503) [[13]](diffhunk://#diff-8595c209bf44ccd9071e9d86d322f02dbb51af98d52561adc43cadf75d323328R521-R561)

**Documentation Updates:**

* Clarifies in both API and developer documentation how non-approval replies and negative reactions are handled in ClickUp `awaiting_human` workflows, including the new rejection behaviors and mirroring of comments. [[1]](diffhunk://#diff-3e6d58e87c820a548c3943f14dd07beac67a2ffa27cf15fb650623b9e0f19f4cR131) [[2]](diffhunk://#diff-b7ea839f046e5fb47c40cc5ae9e8f7ac39d75249128c0752e1ac2dc927375f13L178-R178) [[3]](diffhunk://#diff-f7680e4cb93fd8ce8e958935dc87968da9276d288c8191ebb532745ba8d6f17bL92-R92)

**Environment Variable Handling:**

* Improves `ensurePathInEnv` to always prepend `NVM_BIN` to the `PATH` if missing, deduplicating entries and ensuring correct process execution environments; adds related tests. [[1]](diffhunk://#diff-4c6b736a2bf132d873628ae0b83824f4138aff7f43284914af38810375d94dc5R6) [[2]](diffhunk://#diff-4c6b736a2bf132d873628ae0b83824f4138aff7f43284914af38810375d94dc5R436-R447) [[3]](diffhunk://#diff-000a68e211db8ecb8f6e6b6b57ab616bd673e43a16b523d9000b804fc9cc7987R943-R962) [[4]](diffhunk://#diff-000a68e211db8ecb8f6e6b6b57ab616bd673e43a16b523d9000b804fc9cc7987L1027-R1060)

These changes improve reliability and clarity for both users and agents interacting with ClickUp approval workflows and strengthen the robustness of environment configuration for server-side processes.