### PR TITLE
Increase VM resources to 4GB memory and 4 CPUs

### DIFF
--- a/fly.private.toml
+++ b/fly.private.toml
@@ -17,9 +17,9 @@ BIZBOX_MIGRATION_AUTO_APPLY = "true"
 OPENCODE_ALLOW_ALL_MODELS = "true"
 
 [[vm]]
-memory = "2gb"
+memory = "4gb"
 cpu_kind = "shared"
-cpus = 2
+cpus = 4
 
 [[mounts]]
 source = "paperclip_data"

--- a/fly.toml
+++ b/fly.toml
@@ -26,9 +26,9 @@ auto_start_machines = true
 min_machines_running = 1
 
 [[vm]]
-memory = "2gb"
+memory = "4gb"
 cpu_kind = "shared"
-cpus = 2
+cpus = 4
 
 [[mounts]]
 source = "paperclip_data"


### PR DESCRIPTION
This pull request increases the resource allocation for the application's virtual machines in both the `fly.private.toml` and `fly.toml` configuration files. The changes double the memory and CPU resources for each VM, which should improve performance and scalability.

Resource allocation increases:

* Increased VM memory from 2GB to 4GB in both `fly.private.toml` and `fly.toml` to support higher workloads. [[1]](diffhunk://#diff-75c52133e1961e260bb3a843939584aa4c23974006751562f3d3a023350d1a08L20-R22) [[2]](diffhunk://#diff-660f7078dc0b381a350960eae8f3e924e739994dd8657dcc0d270a28c6ff8a38L29-R31)
* Increased VM CPUs from 2 to 4 in both `fly.private.toml` and `fly.toml` for improved parallel processing and responsiveness. [[1]](diffhunk://#diff-75c52133e1961e260bb3a843939584aa4c23974006751562f3d3a023350d1a08L20-R22) [[2]](diffhunk://#diff-660f7078dc0b381a350960eae8f3e924e739994dd8657dcc0d270a28c6ff8a38L29-R31)

The upgrade from 2gb / 2 shared CPUs to 4gb / 4 shared CPUs is about +$11.83/month per running machine on Fly’s published pricing.

Current size: shared-cpu-2x with 2GB = $11.83/month / $0.0164/hour
New size: shared-cpu-4x with 4GB = $23.66/month / $0.0329/hour
Delta: +$11.83/month / +$0.0165/hour
Source: Fly’s resource pricing table in the official docs. ([fly.io](https://fly.io/docs/about/pricing/))