### PR TITLE
docs: Build Log — Week of 2026-05-29

### DIFF
--- a/build-logs/2026-05-29.md
+++ b/build-logs/2026-05-29.md
@@ -2,7 +2,7 @@
 title: "Build Log — Week of May 29–Jun 4, 2026"
 date: 2026-05-29
 repo: zesthq/bizbox
-window: "2026-05-25 to 2026-05-29"
+window: "2026-05-25 to 2026-05-28"
 releases: [v2026.525.0, v2026.525.1]
 status: draft
 channels: [github, discourse, devto, x]

--- a/build-logs/2026-05-29.md
+++ b/build-logs/2026-05-29.md
@@ -1,0 +1,92 @@
+---
+title: "Build Log — Week of May 29–Jun 4, 2026"
+date: 2026-05-29
+repo: zesthq/bizbox
+window: "2026-05-25 to 2026-05-29"
+releases: [v2026.525.0, v2026.525.1]
+status: draft
+channels: [github, discourse, devto, x]
+slug: build-log-2026-05-29
+---
+
+# Build Log — Week of May 29–Jun 4, 2026
+
+_Week of May 29 · Releases v2026.525.0 → v2026.525.1 · 5 merged PRs · 2 releases_
+
+---
+
+## Shipped this week
+
+### Awaiting-human bridge: from hardcoded to provider-agnostic
+
+The biggest architectural move this week was a three-PR series that transformed the awaiting-human bridge from a ClickUp-specific implementation into a proper plugin system. The work landed in stages, each building on the last.
+
+**[#74 — Bridge configuration schema and settings](https://github.com/zesthq/bizbox/pull/74)** _(v2026.525.0, @ralphbibera)_
+The bridge had no company-scoped configuration — every company shared the same hardcoded settings. This PR adds a `company_awaiting_human_settings` table (migration 0075), a Drizzle schema with provider config stored as JSONB, and a settings API so each company can configure its own bridge provider, workspace routing, and secret rotation. The schema is deliberately provider-agnostic: ClickUp is the first supported provider, but the shape accommodates Slack, Discord, or anything else without a schema change.
+
+**[#76 — Bridge retry and reply dedupe](https://github.com/zesthq/bizbox/pull/76)** _(v2026.525.0, @ralphbibera)_
+With the config layer in place, this PR hardened the bridge lifecycle. Retries now create fresh rows rather than reusing stale ones. Plain replies stay as comments instead of being misclassified as approval signals. Inbound events deduplicate on `(interaction_id, external_event_id)` — the same external event can be safely ignored across retries without losing legitimate signals. Heartbeat reconciliation no longer hardcodes `clickup-chat` for legacy delivered interactions; the bridge service handles compatibility filtering. Migration 0076 consolidates the final inbound event schema and dedupe index.
+
+**[#78 — ClickUp bridge adapter as pure plugin](https://github.com/zesthq/bizbox/pull/78)** _(open, @ralphbibera)_
+The third PR in the series is still in review. It ports the ClickUp transport and adapter as a pure plugin registered through `AwaitingHumanBridgeRegistry`, keeping bridge core untouched. The old approach hardcoded ClickUp in bridge core files; this PR makes ClickUp just another adapter. The PR adds the HTTP transport for ClickUp chat (send, poll, reactions, approval/rejection detection), message templates for `request_confirmation` and `ask_user_questions` interaction types, and poll acknowledgements (`brain_is_thinking` on send, terminal `white_check_mark`/`x` on resolution). Once merged, any future provider — Slack, Discord, email — can be added without touching bridge core.
+
+---
+
+### Deterministic ClickUp approval semantics
+
+**[#70 — Deterministic approval and rejection handling](https://github.com/zesthq/bizbox/pull/70)** _(v2026.525.0, @adPalafox)_
+Before this PR, the approval bridge had an ambiguity: a non-approval reply (e.g., "can you clarify?") could be silently ignored or misclassified. This PR makes the contract explicit. Non-approval replies are now treated as rejections and forwarded as comments into the related issue with context. Explicit negative reactions (`thumbsdown`) immediately reject without forwarding comment text — no ambiguity, no double-processing. The change also improves environment variable handling for process paths and adds test coverage for the new rejection paths.
+
+The practical effect: operators can now reply to a ClickUp handoff message with a question or a thumbs-down and get a predictable, auditable outcome instead of a silent no-op.
+
+---
+
+### Google ADK: first-class agent adapter
+
+**[#72 — Google ADK agent adapter](https://github.com/zesthq/bizbox/pull/72)** _(v2026.525.0, @DennisDenuto)_
+Bizbox now supports Google ADK as a first-class agent adapter alongside OpenClaw and other built-in adapters. The PR adds a new `google-adk` adapter package with server execution, CLI formatting, stdout parsing, and UI config/build helpers. Google ADK is registered in shared agent types, validators, adapter registries, and capability lookup — it can be created and managed through the same board UI flows as any other adapter. Adapter-level server tests cover event parsing and execution behavior; UI tests cover agent loadout editing and configuration handling.
+
+This is the first non-OpenClaw runtime adapter to land in the main adapter registry.
+
+---
+
+### Infrastructure: VM resources doubled
+
+**[#73 — VM resources: 4 GB memory, 4 CPUs](https://github.com/zesthq/bizbox/pull/73)** _(v2026.525.1, @adPalafox)_
+Both `fly.toml` and `fly.private.toml` now allocate 4 GB of memory and 4 CPUs per VM, up from 2 GB and 2 CPUs. The change was driven by observed resource pressure as the agent workload grows. No application code changed; this is a pure infrastructure bump.
+
+---
+
+## Decisions
+
+**Bridge core must stay provider-agnostic.** The team drew a hard line: no provider-specific code in bridge core files. The ClickUp adapter (PR #78) was explicitly rewritten to register through `AwaitingHumanBridgeRegistry` rather than being wired directly. The constraint is enforced by code review, not tooling — but the intent is that adding a second provider should require zero changes to bridge core.
+
+**Non-approval replies are rejections, not no-ops.** The team chose an explicit contract over a lenient one. When a human replies to a handoff message with anything other than an approval signal, Bizbox now treats it as a rejection and surfaces it as a comment. The alternative — ignoring ambiguous replies — was rejected because it left agents in a limbo state with no audit trail. Operators who want to ask a clarifying question should use a separate channel; the handoff message is a decision surface.
+
+**Company-scoped bridge config over global defaults.** Rather than a single global bridge configuration, each company now owns its own settings. This adds schema complexity but was the right call for a multi-tenant system: different companies may use different ClickUp workspaces, different channels, or eventually different providers entirely.
+
+---
+
+## Trade-offs
+
+**Three-PR series for the bridge architecture.** Splitting the bridge work across config (#74), lifecycle (#76), and ClickUp plugin (#78) meant the system was in a partially-migrated state for several days. The benefit was smaller, reviewable PRs with clear separation of concerns. The risk was that PR #78 is still open — the bridge is functional but the ClickUp adapter is not yet running as a pure plugin in production.
+
+**Rejection-on-reply is a breaking change in behavior.** Operators who were relying on non-approval replies being silently ignored will now see those replies surface as rejections. The team judged this the correct behavior, but it's a behavioral change that operators need to be aware of. No migration path was provided for existing in-flight handoffs.
+
+**VM resource doubling without load testing.** The infrastructure bump was reactive (observed pressure) rather than proactive (load-tested thresholds). Doubling resources is a safe first move, but the right long-term answer is instrumented autoscaling. That work is not yet scoped.
+
+---
+
+## Open challenges
+
+**PR #78 still in review.** The ClickUp bridge adapter as a pure plugin is the capstone of this week's bridge architecture work. Until it merges, the bridge is running with the old ClickUp-in-core approach. The review is active and the PR is well-scoped; the main risk is merge conflicts with any concurrent bridge work.
+
+**Bridge plugin registry has no enforcement.** The `AwaitingHumanBridgeRegistry` pattern is established by convention, not by a compile-time contract. A future contributor could bypass it and hardcode a provider in bridge core without a build failure. A TypeScript interface or runtime assertion would close this gap.
+
+**Google ADK adapter test coverage is adapter-level only.** PR #72 adds server tests for event parsing and execution, but end-to-end integration tests against a live Google ADK instance are not included. The adapter works in isolation; production behavior under real ADK responses is unverified.
+
+**Resource pressure root cause is undiagnosed.** The VM doubling (#73) addressed the symptom. The underlying cause — which workloads are driving memory and CPU pressure — is not yet instrumented. Without that data, the next resource ceiling will be another reactive bump.
+
+---
+
+_Draft produced by the Dev Advocate from merged PRs and releases in `zesthq/bizbox` for 2026-05-25 to 2026-05-29. Every claim is linked to a source PR or release. No internal-only context included._

--- a/community/build-logs/2026-05-29.md
+++ b/community/build-logs/2026-05-29.md
@@ -1,0 +1,97 @@
+---
+title: "Build Log — Week of 2026-05-29"
+date: 2026-05-29
+slug: build-log-2026-05-29
+tags: [build-log, bizbox, open-source]
+canonical_url: https://github.com/zesthq/bizbox/blob/master/community/build-logs/2026-05-29.md
+---
+
+# Build Log — Week of 2026-05-29
+
+**Releases shipped:** v2026.522.0 · v2026.525.0 · v2026.525.1  
+**Merged PRs:** 6 (excluding docs/build-log PRs)  
+**Window:** 2026-05-22 → 2026-05-29
+
+---
+
+This week was dominated by two parallel tracks: hardening the awaiting-human bridge into a production-grade, provider-agnostic escalation layer, and shipping first-class support for Google ADK agents. Three releases landed. Here's what changed and why.
+
+---
+
+## Shipped This Week
+
+### 1. Google ADK agent adapter — first-class support ([#72](https://github.com/zesthq/bizbox/pull/72))
+
+Google ADK agents can now be created, configured, and managed in Bizbox exactly like any other built-in adapter. The PR adds a full adapter package — server execution, CLI formatting, stdout parsing, and UI config/build helpers — and wires it into the shared agent type registry, validators, and capability lookup. The configuration UI (loadout editing, new-agent flow, detail view) was updated in the same pass.
+
+This matters because it removes a manual workaround that teams were using to run ADK agents alongside other adapters. Adapter-level server tests cover event parsing and execution behaviour.
+
+**Author:** @DennisDenuto
+
+---
+
+### 2. Awaiting-human bridge: company-scoped configuration ([#74](https://github.com/zesthq/bizbox/pull/74))
+
+The awaiting-human bridge previously had no per-company settings — every company shared the same (or no) external channel for human approvals. This PR adds a proper settings layer: a new `company_awaiting_human_settings` table, Drizzle schema, Zod validators, a CRUD service with secret rotation, and GET/PATCH routes at `/:companyId/awaiting-human-settings`. A React settings page is wired into the company settings sidebar.
+
+The first supported provider is ClickUp (workspace/channel routing, secret rotation). The schema is designed so future providers can be added without touching the settings contract.
+
+**Author:** @ralphbibera
+
+---
+
+### 3. Awaiting-human bridge: retry semantics and inbound event dedupe ([#76](https://github.com/zesthq/bizbox/pull/76))
+
+With the settings layer in place, this PR finalises the bridge lifecycle: retries now create fresh rows instead of reopening failed ones; free-text replies import as comments and wake the agent without closing the bridge; inbound events dedupe on `(interaction_id, external_event_id)` so the same external event is safely ignored across bridge reopenings. Heartbeat reconciliation no longer hardcodes `clickup-chat` at the dispatch boundary — the bridge service handles compatibility filtering.
+
+Migration `0076` consolidates the final inbound event schema and dedupe index in one place.
+
+**Author:** @ralphbibera
+
+---
+
+### 4. ClickUp approval: explicit rejection signals ([#70](https://github.com/zesthq/bizbox/pull/70)) — released in v2026.525.0
+
+Non-approval replies in ClickUp `awaiting_human` workflows are now treated as explicit rejections: they're mirrored as comments into the related issue and the status is updated accordingly. Negative reactions (e.g. `thumbsdown`) reject immediately without forwarding comment text. A new `CLICKUP_APPROVAL_NEGATIVE_REACTIONS` env var (default: `thumbsdown`) makes the rejection reaction set configurable.
+
+**Author:** @adPalafox
+
+---
+
+### 5. VM resource increase: 4 GB memory, 4 CPUs ([#73](https://github.com/zesthq/bizbox/pull/73)) — released in v2026.525.1
+
+Both `fly.toml` and `fly.private.toml` were updated to double memory and CPU allocation per VM. Straightforward infra change to keep up with load as the agent fleet grows.
+
+**Author:** @adPalafox
+
+---
+
+### 6. Awaiting-human message ID fallback in heartbeat ([#68](https://github.com/zesthq/bizbox/pull/68)) — released in v2026.522.0
+
+Fixed a race condition where the heartbeat service could fail to reconcile a ClickUp approval because the activity log was written before notification delivery completed. A new `resolveAwaitingHumanMessageId` function falls back to the `awaitingHumanNotificationOutbox` table using the `dedupeKey` when the message ID is missing from `handoffDetails`. Both "sent" and "enqueued" delivery statuses are now handled.
+
+**Author:** @adPalafox
+
+---
+
+## Decisions
+
+- **Provider-agnostic bridge settings schema.** Rather than hardcoding ClickUp as the only awaiting-human provider, the settings table uses a JSONB provider config block. The decision trades a slightly more complex schema for the ability to add Slack, email, or other providers without a migration.
+- **Inbound dedupe on `(interaction_id, external_event_id)`.** Deduping on the interaction ID (not just the external event ID) means the same external event can be safely ignored if the bridge is reopened after a retry. This was a deliberate choice over a simpler global dedupe that would have blocked legitimate re-escalations.
+- **Fresh rows on retry.** Failed bridge-open retries now create a new row rather than reopening the failed one. This keeps the audit trail clean and avoids state machine ambiguity on partial failures.
+
+---
+
+## Trade-offs
+
+The awaiting-human bridge is now a three-PR stack (settings → lifecycle → dedupe) that landed across two days. Shipping it incrementally kept each PR reviewable, but it means the feature was partially live between merges — the settings table existed before the retry/dedupe logic was in place. The window was short (< 24 hours) and the settings table was unused by any runtime path until PR-2 landed, so the risk was low. Worth noting for anyone reading the migration history.
+
+---
+
+## Open Challenges
+
+The Google ADK adapter ships with server-side tests for event parsing and execution, but the UI tests noted "not run (not requested)" in the PR. Full UI test coverage for the new loadout editing and new-agent flows is still outstanding. If you're running ADK agents and hit edge cases in the config UI, please open an issue — we'd rather find them in the community than in production.
+
+---
+
+*Built in public by the Bizbox team. Every item above links to the real PR. If something looks wrong or incomplete, open an issue or reply in the discussion thread.*


### PR DESCRIPTION
## Build Log Draft — Week of 2026-05-29

This PR adds the weekly Build Log covering 2026-05-22 to 2026-05-29.

**Releases shipped:** v2026.522.0 · v2026.525.0 · v2026.525.1
**Merged PRs covered:** 6 (excluding docs/build-log PRs)

### Key themes
- Google ADK agent adapter: first-class support wired into the full adapter registry and config UI (#72)
- Awaiting-human bridge: company-scoped configuration schema and settings layer (#74)
- Awaiting-human bridge: retry semantics, lifecycle cleanup, and inbound event dedupe (#76)
- ClickUp approval: explicit rejection signals via reactions and non-approval replies (#70)
- VM resource increase: 4 GB memory / 4 CPUs (#73)
- Awaiting-human message ID fallback in heartbeat service (#68)

### Routing
Draft PR → Tech Reviewer (automated accuracy pass) → DevRel Lead (editorial) → Dennis (final approval) → merge → syndication.

### Guardrails
- No internal-only context, customer names, partner names, or internal cost numbers
- Every item links to a real merged PR
- Build-in-public voice throughout