### PR TITLE
fix(google-adk): strip frontmatter from AGENTS.md instructions

### DIFF
--- a/packages/adapters/google-adk/src/server/execute.test.ts
+++ b/packages/adapters/google-adk/src/server/execute.test.ts
@@ -6,22 +6,45 @@ describe("splitInstructionsMarkdown", () => {
     const result = splitInstructionsMarkdown(
       [
         "---",
-        "name: social_media_specialist",
-        "channels:",
-        "  - twitter",
-        "  - linkedin",
+        "name: example_agent",
+        "capabilities:",
+        "  - research",
+        "  - planning",
         "---",
-        "Write social content.",
+        "Follow the instructions.",
         "",
       ].join("\n"),
     );
 
     expect(result).toEqual({
       frontmatter: {
-        name: "social_media_specialist",
-        channels: ["twitter", "linkedin"],
+        name: "example_agent",
+        capabilities: ["research", "planning"],
       },
-      body: "Write social content.\n",
+      body: "Follow the instructions.\n",
+    });
+  });
+
+  it("passes through markdown without frontmatter", () => {
+    expect(splitInstructionsMarkdown("Follow the instructions.\n")).toEqual({
+      frontmatter: {},
+      body: "Follow the instructions.\n",
+    });
+  });
+
+  it("handles an empty frontmatter block", () => {
+    expect(
+      splitInstructionsMarkdown(
+        [
+          "---",
+          "---",
+          "Follow the instructions.",
+          "",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      frontmatter: {},
+      body: "Follow the instructions.\n",
     });
   });
 });
@@ -29,12 +52,16 @@ describe("splitInstructionsMarkdown", () => {
 describe("buildInstructionsPrefix", () => {
   it("keeps the body text and the file-path note together", () => {
     expect(
-      buildInstructionsPrefix("Write social content.", "/tmp/agents/AGENTS.md"),
+      buildInstructionsPrefix("Follow the instructions.", "/tmp/agents/AGENTS.md"),
     ).toBe(
       [
-        "Write social content.",
+        "Follow the instructions.",
         "The above agent instructions were loaded from /tmp/agents/AGENTS.md. Resolve any relative file references from /tmp/agents/.",
       ].join("\n\n"),
     );
+  });
+
+  it("returns an empty string when there is no body", () => {
+    expect(buildInstructionsPrefix("", "/tmp/agents/AGENTS.md")).toBe("");
   });
 });

--- a/packages/adapters/google-adk/src/server/execute.test.ts
+++ b/packages/adapters/google-adk/src/server/execute.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildInstructionsPrefix, splitInstructionsMarkdown } from "./instructions.js";
+
+describe("splitInstructionsMarkdown", () => {
+  it("splits YAML frontmatter from the markdown body", () => {
+    const result = splitInstructionsMarkdown(
+      [
+        "---",
+        "name: social_media_specialist",
+        "channels:",
+        "  - twitter",
+        "  - linkedin",
+        "---",
+        "Write social content.",
+        "",
+      ].join("\n"),
+    );
+
+    expect(result).toEqual({
+      frontmatter: {
+        name: "social_media_specialist",
+        channels: ["twitter", "linkedin"],
+      },
+      body: "Write social content.\n",
+    });
+  });
+});
+
+describe("buildInstructionsPrefix", () => {
+  it("keeps the body text and the file-path note together", () => {
+    expect(
+      buildInstructionsPrefix("Write social content.", "/tmp/agents/AGENTS.md"),
+    ).toBe(
+      [
+        "Write social content.",
+        "The above agent instructions were loaded from /tmp/agents/AGENTS.md. Resolve any relative file references from /tmp/agents/.",
+      ].join("\n\n"),
+    );
+  });
+});

--- a/packages/adapters/google-adk/src/server/execute.ts
+++ b/packages/adapters/google-adk/src/server/execute.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_GOOGLE_ADK_COMMAND,
   DEFAULT_GOOGLE_ADK_MODEL,
 } from "../index.js";
+import { buildInstructionsPrefix, splitInstructionsMarkdown } from "./instructions.js";
 import { parseGoogleAdkJsonl } from "./parse.js";
 
 function paperclipHome(): string {
@@ -39,19 +40,15 @@ function artifactUri(dirPath: string): string {
   return pathToFileURL(path.resolve(dirPath)).toString();
 }
 
-async function readInstructionsPrefix(
+export async function readInstructionsPrefix(
   instructionsFilePath: string,
   onLog: AdapterExecutionContext["onLog"],
 ): Promise<string> {
   if (!instructionsFilePath) return "";
   try {
     const contents = await fs.readFile(instructionsFilePath, "utf8");
-    const instructionsDir = `${path.dirname(instructionsFilePath)}/`;
-    return (
-      `${contents}\n\n` +
-      `The above agent instructions were loaded from ${instructionsFilePath}. ` +
-      `Resolve any relative file references from ${instructionsDir}.\n`
-    );
+    const instructionsMarkdown = splitInstructionsMarkdown(contents);
+    return buildInstructionsPrefix(instructionsMarkdown.body, instructionsFilePath);
   } catch (err) {
     await onLog(
       "stdout",

--- a/packages/adapters/google-adk/src/server/instructions.ts
+++ b/packages/adapters/google-adk/src/server/instructions.ts
@@ -26,8 +26,23 @@ function parseFrontmatterValue(rawValue: string): unknown {
 
 export function splitInstructionsMarkdown(markdown: string): InstructionsMarkdown {
   const normalized = markdown.replace(/\r\n/g, "\n");
-  const match = normalized.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-  if (!match) {
+  const lines = normalized.split("\n");
+  if (lines[0] !== "---") {
+    return {
+      frontmatter: {},
+      body: normalized,
+    };
+  }
+
+  let endIndex = -1;
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index] === "---") {
+      endIndex = index;
+      break;
+    }
+  }
+
+  if (endIndex === -1) {
     return {
       frontmatter: {},
       body: normalized,
@@ -35,13 +50,13 @@ export function splitInstructionsMarkdown(markdown: string): InstructionsMarkdow
   }
 
   const frontmatter: Record<string, unknown> = {};
-  const rawFrontmatter = match[1];
-  const body = match[2].trimStart();
+  const rawFrontmatter = lines.slice(1, endIndex);
+  const body = lines.slice(endIndex + 1).join("\n").trimStart();
 
   let currentKey: string | null = null;
   let currentList: unknown[] | null = null;
 
-  for (const line of rawFrontmatter.split("\n")) {
+  for (const line of rawFrontmatter) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) continue;
 
@@ -82,9 +97,11 @@ export function splitInstructionsMarkdown(markdown: string): InstructionsMarkdow
 }
 
 export function buildInstructionsPrefix(body: string, instructionsFilePath: string): string {
+  const trimmedBody = body.trim();
+  if (!trimmedBody) return "";
   const instructionsDir = `${path.dirname(instructionsFilePath)}/`;
-  return [body, `The above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsDir}.`]
-    .map((value) => (typeof value === "string" ? value.trim() : ""))
-    .filter(Boolean)
-    .join("\n\n");
+  return [
+    trimmedBody,
+    `The above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsDir}.`,
+  ].join("\n\n");
 }

--- a/packages/adapters/google-adk/src/server/instructions.ts
+++ b/packages/adapters/google-adk/src/server/instructions.ts
@@ -1,0 +1,90 @@
+import path from "node:path";
+
+export interface InstructionsMarkdown {
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+function parseFrontmatterValue(rawValue: string): unknown {
+  const trimmed = rawValue.trim();
+  if (trimmed === "") return "";
+  if (trimmed === "null" || trimmed === "~") return null;
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed === "[]") return [];
+  if (trimmed === "{}") return {};
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  if (trimmed.startsWith("\"") || trimmed.startsWith("[") || trimmed.startsWith("{")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+  return trimmed;
+}
+
+export function splitInstructionsMarkdown(markdown: string): InstructionsMarkdown {
+  const normalized = markdown.replace(/\r\n/g, "\n");
+  const match = normalized.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) {
+    return {
+      frontmatter: {},
+      body: normalized,
+    };
+  }
+
+  const frontmatter: Record<string, unknown> = {};
+  const rawFrontmatter = match[1];
+  const body = match[2].trimStart();
+
+  let currentKey: string | null = null;
+  let currentList: unknown[] | null = null;
+
+  for (const line of rawFrontmatter.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    if (trimmed.startsWith("- ") && currentKey) {
+      if (!currentList) currentList = [];
+      currentList.push(parseFrontmatterValue(trimmed.slice(2).trim()));
+      continue;
+    }
+
+    if (currentKey && currentList) {
+      frontmatter[currentKey] = currentList;
+      currentList = null;
+      currentKey = null;
+    }
+
+    const kvMatch = trimmed.match(/^([a-zA-Z_][\w-]*)\s*:\s*(.*)$/);
+    if (!kvMatch) continue;
+
+    const key = kvMatch[1];
+    const rawValue = kvMatch[2].trim();
+    if (rawValue.length === 0) {
+      currentKey = key;
+      continue;
+    }
+
+    frontmatter[key] = parseFrontmatterValue(rawValue);
+    currentKey = null;
+  }
+
+  if (currentKey && currentList) {
+    frontmatter[currentKey] = currentList;
+  }
+
+  return {
+    frontmatter,
+    body,
+  };
+}
+
+export function buildInstructionsPrefix(body: string, instructionsFilePath: string): string {
+  const instructionsDir = `${path.dirname(instructionsFilePath)}/`;
+  return [body, `The above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsDir}.`]
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/packages/adapters/google-adk/vitest.config.ts
+++ b/packages/adapters/google-adk/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "packages/db",
       "packages/adapter-utils",
       "packages/adapters/codex-local",
+      "packages/adapters/google-adk",
       "packages/adapters/opencode-local",
       "server",
       "ui",


### PR DESCRIPTION
## Thinking Path

> - BizBox uses `AGENTS.md` as the canonical instructions surface for the Google ADK company package.
> - YAML frontmatter needs to stay in that file for metadata and discovery.
> - The Google ADK adapter turns the instructions file into the prompt passed to `adk run`.
> - The adapter was reading the file verbatim, so the frontmatter leaked into the CLI input.
> - `adk run` treated the leading `---` block as invalid input and exited before any work started.
> - This pull request adds a narrow frontmatter/body split in the adapter prompt path.
> - The markdown body still flows into `adk run` with the existing file-path guidance preserved.
> - The benefit is that BizBox can keep metadata in `AGENTS.md` without breaking the Google ADK run.

## What Changed

- Added `splitInstructionsMarkdown()` and `buildInstructionsPrefix()` in `packages/adapters/google-adk/src/server/instructions.ts` to separate YAML frontmatter from the markdown body.
- Updated `packages/adapters/google-adk/src/server/execute.ts` so `readInstructionsPrefix()` strips frontmatter before building the prompt passed to `adk run`.
- Added a focused regression test in `packages/adapters/google-adk/src/server/execute.test.ts` for frontmatter stripping and the file-path note.
- Added `packages/adapters/google-adk/vitest.config.ts` and registered the package in the root `vitest.config.ts` so the adapter tests run in the repo suite.

## Verification

- `pnpm exec vitest run packages/adapters/google-adk/src/server/execute.test.ts`
- Focused Google ADK adapter typecheck
- `git diff --check`
- `pnpm test` reaches the new Google ADK tests successfully, but the full suite still fails on two unrelated existing tests: `server/src/__tests__/openclaw-invite-prompt-route.test.ts` and `server/src/__tests__/user-profile-routes.test.ts`.

## Risks

- Low risk. The change is limited to parsing an initial YAML frontmatter block in adapter instruction files.
- The parser is intentionally narrow and keeps the implementation simple for the current `AGENTS.md` shape.
- If a future instructions file uses more complex YAML frontmatter, the helper will still preserve the markdown body and will not pass the metadata block to `adk run`.

## Model Used

- OpenAI GPT-5 via Codex desktop, tool-enabled coding agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
