### PR TITLE
Enhance issue origin handling with deduplication and tasks

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -196,7 +196,7 @@ export const ISSUE_THREAD_INTERACTION_CONTINUATION_POLICIES = [
 export type IssueThreadInteractionContinuationPolicy =
   (typeof ISSUE_THREAD_INTERACTION_CONTINUATION_POLICIES)[number];
 
-export const ISSUE_ORIGIN_KINDS = ["manual", "routine_execution"] as const;
+export const ISSUE_ORIGIN_KINDS = ["manual", "routine_execution", "suggested_task"] as const;
 export type BuiltInIssueOriginKind = (typeof ISSUE_ORIGIN_KINDS)[number];
 export type PluginIssueOriginKind = `plugin:${string}`;
 export type IssueOriginKind = BuiltInIssueOriginKind | PluginIssueOriginKind;

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -193,6 +193,111 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     expect(childrenAfterDuplicateAccept).toHaveLength(1);
   });
 
+  it("reuses existing child issues when the same suggested task bundle is accepted again", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Persist thread interactions",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+      requestDepth: 2,
+    });
+
+    const payload = {
+      version: 1 as const,
+      tasks: [
+        {
+          clientKey: "root",
+          title: "Create the root follow-up",
+        },
+        {
+          clientKey: "child",
+          parentClientKey: "root",
+          title: "Create the nested follow-up",
+        },
+      ],
+    };
+
+    const firstInteraction = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "suggest_tasks",
+      continuationPolicy: "wake_assignee",
+      payload,
+    }, {
+      userId: "local-board",
+    });
+
+    const firstAccepted = await interactionsSvc.acceptSuggestedTasks({
+      id: issueId,
+      companyId,
+      goalId,
+      projectId: null,
+    }, firstInteraction.id, {}, {
+      userId: "local-board",
+    });
+
+    const rootChildren = await issuesSvc.list(companyId, { parentId: issueId });
+    expect(rootChildren).toHaveLength(1);
+
+    const secondInteraction = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "suggest_tasks",
+      continuationPolicy: "wake_assignee",
+      payload,
+    }, {
+      userId: "local-board",
+    });
+
+    const secondAccepted = await interactionsSvc.acceptSuggestedTasks({
+      id: issueId,
+      companyId,
+      goalId,
+      projectId: null,
+    }, secondInteraction.id, {}, {
+      userId: "local-board",
+    });
+
+    expect(secondAccepted.interaction.result).toMatchObject({
+      version: 1,
+      createdTasks: [
+        expect.objectContaining({ clientKey: "root", issueId: firstAccepted.interaction.result.createdTasks[0]?.issueId }),
+        expect.objectContaining({ clientKey: "child", issueId: firstAccepted.interaction.result.createdTasks[1]?.issueId }),
+      ],
+    });
+
+    const rootChildrenAfterReplay = await issuesSvc.list(companyId, { parentId: issueId });
+    expect(rootChildrenAfterReplay).toHaveLength(1);
+    expect(rootChildrenAfterReplay[0]?.id).toBe(firstAccepted.interaction.result.createdTasks[0]?.issueId);
+
+    const nestedChildrenAfterReplay = await issuesSvc.list(companyId, { parentId: rootChildrenAfterReplay[0]!.id });
+    expect(nestedChildrenAfterReplay).toHaveLength(1);
+    expect(nestedChildrenAfterReplay[0]?.id).toBe(firstAccepted.interaction.result.createdTasks[1]?.issueId);
+  });
+
   it("accepts a selected subset of suggested tasks and records the skipped drafts", async () => {
     const companyId = randomUUID();
     const goalId = randomUUID();

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -288,6 +288,8 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
         expect.objectContaining({ clientKey: "child", issueId: firstAccepted.interaction.result.createdTasks[1]?.issueId }),
       ],
     });
+    expect(firstAccepted.createdIssues).toHaveLength(2);
+    expect(secondAccepted.createdIssues).toEqual([]);
 
     const rootChildrenAfterReplay = await issuesSvc.list(companyId, { parentId: issueId });
     expect(rootChildrenAfterReplay).toHaveLength(1);

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1659,6 +1659,62 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
       ]),
     );
   });
+
+  it("reuses an accepted suggested task child even after its status changes", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const parentIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Suggested task dedupe",
+      level: "task",
+      status: "active",
+    });
+
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+      requestDepth: 1,
+    });
+
+    const first = await svc.createChild(parentIssueId, {
+      title: "Dedupe target",
+      status: "todo",
+      priority: "medium",
+      description: "Implement the helper.",
+      originKind: "suggested_task",
+    });
+
+    await db
+      .update(issues)
+      .set({ status: "in_progress" })
+      .where(eq(issues.id, first.issue.id));
+
+    const second = await svc.createChild(parentIssueId, {
+      title: "Dedupe target",
+      status: "todo",
+      priority: "medium",
+      description: "Implement the helper.",
+      originKind: "suggested_task",
+    });
+
+    expect(second.isReused).toBe(true);
+    expect(second.issue.id).toBe(first.issue.id);
+    expect(second.issue.status).toBe("in_progress");
+  });
 });
 
 describeEmbeddedPostgres("issueService blockers and dependency wake readiness", () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1592,6 +1592,73 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
       }),
     ]);
   });
+
+  it("does not reuse manually created sibling issues when creating a suggested task child", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const parentIssueId = randomUUID();
+    const manualIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Suggested task dedupe",
+      level: "task",
+      status: "active",
+    });
+
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+      requestDepth: 1,
+    });
+
+    await db.insert(issues).values({
+      id: manualIssueId,
+      companyId,
+      parentId: parentIssueId,
+      goalId,
+      title: "Manually created sibling",
+      status: "todo",
+      priority: "medium",
+      description: null,
+      requestDepth: 2,
+    });
+
+    const result = await svc.createChild(parentIssueId, {
+      title: "Manually created sibling",
+      status: "todo",
+      priority: "medium",
+      description: null,
+      originKind: "suggested_task",
+    });
+
+    expect(result.isReused).toBe(false);
+    expect(result.issue.id).not.toBe(manualIssueId);
+
+    const children = await db
+      .select({ id: issues.id, originKind: issues.originKind })
+      .from(issues)
+      .where(eq(issues.parentId, parentIssueId));
+    expect(children).toHaveLength(2);
+    expect(children).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: manualIssueId, originKind: "manual" }),
+        expect.objectContaining({ id: result.issue.id, originKind: "suggested_task" }),
+      ]),
+    );
+  });
 });
 
 describeEmbeddedPostgres("issueService blockers and dependency wake readiness", () => {

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1032,7 +1032,7 @@ export function issueThreadInteractionService(db: Db) {
             throw unprocessable(`Unable to resolve parent for suggested task ${task.clientKey}`);
           }
 
-          const { issue: createdIssue } = await issueService(tx as unknown as Db).createChild(parentIssueId, {
+          const { issue: createdIssue, isReused } = await issueService(tx as unknown as Db).createChild(parentIssueId, {
             title: task.title,
             description: task.description ?? null,
             status: "todo",
@@ -1060,11 +1060,13 @@ export function issueThreadInteractionService(db: Db) {
             parentIssueId,
             parentIdentifier,
           });
-          createdWakeTargets.push({
-            id: createdIssue.id,
-            assigneeAgentId: createdIssue.assigneeAgentId ?? null,
-            status: createdIssue.status,
-          });
+          if (!isReused) {
+            createdWakeTargets.push({
+              id: createdIssue.id,
+              assigneeAgentId: createdIssue.assigneeAgentId ?? null,
+              status: createdIssue.status,
+            });
+          }
         }
 
         const [updated] = await tx

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1042,6 +1042,7 @@ export function issueThreadInteractionService(db: Db) {
             projectId: task.projectId ?? issue.projectId,
             goalId: task.goalId ?? issue.goalId,
             billingCode: task.billingCode ?? null,
+            originKind: "suggested_task",
             createdByAgentId: actor.agentId ?? null,
             createdByUserId: actor.userId ?? null,
             actorAgentId: actor.agentId ?? null,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -116,7 +116,6 @@ function normalizeSuggestedTaskFingerprintValue(value: unknown): unknown {
 function createSuggestedTaskFingerprint(input: {
   title: string;
   description: string | null;
-  status: string;
   priority: string;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
@@ -2396,7 +2395,6 @@ export function issueService(db: Db) {
           ? createSuggestedTaskFingerprint({
               title: normalizedTitle,
               description: normalizedDescription,
-              status: issueData.status ?? "todo",
               priority: issueData.priority ?? "medium",
               assigneeAgentId: resolvedAssigneeAgentId,
               assigneeUserId: resolvedAssigneeUserId,
@@ -2414,15 +2412,7 @@ export function issueService(db: Db) {
             eq(issues.companyId, parent.companyId),
             eq(issues.parentId, parent.id),
             eq(issues.originKind, "suggested_task"),
-            eq(issues.title, normalizedTitle),
-            eq(issues.status, issueData.status ?? "todo"),
-            eq(issues.priority, issueData.priority ?? "medium"),
-            normalizedDescription === null ? isNull(issues.description) : eq(issues.description, normalizedDescription),
-            resolvedAssigneeAgentId === null ? isNull(issues.assigneeAgentId) : eq(issues.assigneeAgentId, resolvedAssigneeAgentId),
-            resolvedAssigneeUserId === null ? isNull(issues.assigneeUserId) : eq(issues.assigneeUserId, resolvedAssigneeUserId),
-            resolvedProjectId === null ? isNull(issues.projectId) : eq(issues.projectId, resolvedProjectId),
-            resolvedGoalId === null ? isNull(issues.goalId) : eq(issues.goalId, resolvedGoalId),
-            resolvedBillingCode === null ? isNull(issues.billingCode) : eq(issues.billingCode, resolvedBillingCode),
+            eq(issues.originFingerprint, suggestedTaskFingerprint!),
             isNull(issues.hiddenAt),
           ))
           .orderBy(asc(issues.createdAt), asc(issues.id))

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
 import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
@@ -96,6 +97,35 @@ function applyStatusSideEffects(
     patch.cancelledAt = new Date();
   }
   return patch;
+}
+
+function normalizeSuggestedTaskFingerprintValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeSuggestedTaskFingerprintValue(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, childValue]) => [key, normalizeSuggestedTaskFingerprintValue(childValue)]),
+    );
+  }
+  return value;
+}
+
+function createSuggestedTaskFingerprint(input: {
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  assigneeAgentId: string | null;
+  assigneeUserId: string | null;
+  projectId: string | null;
+  goalId: string | null;
+  billingCode: string | null;
+}) {
+  const canonical = JSON.stringify(normalizeSuggestedTaskFingerprintValue(input));
+  return createHash("sha256").update(canonical).digest("hex");
 }
 
 export interface IssueFilters {
@@ -2347,6 +2377,77 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
       if (!parent) throw notFound("Parent issue not found");
 
+      const {
+        acceptanceCriteria,
+        blockParentUntilDone,
+        actorAgentId,
+        actorUserId,
+        ...issueData
+      } = data;
+      const normalizedTitle = issueData.title.trim();
+      const normalizedDescription = appendAcceptanceCriteriaToDescription(issueData.description, acceptanceCriteria) ?? null;
+      const resolvedProjectId = issueData.projectId ?? parent.projectId ?? null;
+      const resolvedGoalId = issueData.goalId ?? parent.goalId ?? null;
+      const resolvedAssigneeAgentId = issueData.assigneeAgentId ?? null;
+      const resolvedAssigneeUserId = issueData.assigneeUserId ?? null;
+      const resolvedBillingCode = issueData.billingCode ?? null;
+      const suggestedTaskFingerprint =
+        issueData.originKind === "suggested_task"
+          ? createSuggestedTaskFingerprint({
+              title: normalizedTitle,
+              description: normalizedDescription,
+              status: issueData.status ?? "todo",
+              priority: issueData.priority ?? "medium",
+              assigneeAgentId: resolvedAssigneeAgentId,
+              assigneeUserId: resolvedAssigneeUserId,
+              projectId: resolvedProjectId,
+              goalId: resolvedGoalId,
+              billingCode: resolvedBillingCode,
+            })
+          : null;
+
+      if (issueData.originKind === "suggested_task") {
+        const existing = await db
+          .select()
+          .from(issues)
+          .where(and(
+            eq(issues.companyId, parent.companyId),
+            eq(issues.parentId, parent.id),
+            eq(issues.title, normalizedTitle),
+            eq(issues.status, issueData.status ?? "todo"),
+            eq(issues.priority, issueData.priority ?? "medium"),
+            normalizedDescription === null ? isNull(issues.description) : eq(issues.description, normalizedDescription),
+            resolvedAssigneeAgentId === null ? isNull(issues.assigneeAgentId) : eq(issues.assigneeAgentId, resolvedAssigneeAgentId),
+            resolvedAssigneeUserId === null ? isNull(issues.assigneeUserId) : eq(issues.assigneeUserId, resolvedAssigneeUserId),
+            resolvedProjectId === null ? isNull(issues.projectId) : eq(issues.projectId, resolvedProjectId),
+            resolvedGoalId === null ? isNull(issues.goalId) : eq(issues.goalId, resolvedGoalId),
+            resolvedBillingCode === null ? isNull(issues.billingCode) : eq(issues.billingCode, resolvedBillingCode),
+            isNull(issues.hiddenAt),
+          ))
+          .orderBy(asc(issues.createdAt), asc(issues.id))
+          .then((rows) => rows[0] ?? null);
+
+        if (existing) {
+          if (blockParentUntilDone) {
+            const existingBlockers = await db
+              .select({ blockerIssueId: issueRelations.issueId })
+              .from(issueRelations)
+              .where(and(eq(issueRelations.companyId, parent.companyId), eq(issueRelations.relatedIssueId, parent.id), eq(issueRelations.type, "blocks")));
+            await syncBlockedByIssueIds(
+              parent.id,
+              parent.companyId,
+              [...new Set([...existingBlockers.map((row) => row.blockerIssueId), existing.id])],
+              { agentId: actorAgentId ?? null, userId: actorUserId ?? null },
+            );
+          }
+
+          return {
+            issue: existing,
+            parentBlockerAdded: Boolean(blockParentUntilDone),
+          };
+        }
+      }
+
       const [{ childCount }] = await db
         .select({ childCount: sql<number>`count(*)::int` })
         .from(issues)
@@ -2355,20 +2456,21 @@ export function issueService(db: Db) {
         throw unprocessable(`Parent issue already has the maximum ${MAX_CHILD_ISSUES_CREATED_BY_HELPER} child issues for this helper`);
       }
 
-      const {
-        acceptanceCriteria,
-        blockParentUntilDone,
-        actorAgentId,
-        actorUserId,
-        ...issueData
-      } = data;
       const child = await issueService(db).create(parent.companyId, {
         ...issueData,
+        ...(issueData.originKind === "suggested_task"
+          ? {
+              originKind: "suggested_task",
+              originId: parent.id,
+              originFingerprint: suggestedTaskFingerprint ?? "default",
+            }
+          : {}),
         parentId: parent.id,
-        projectId: issueData.projectId ?? parent.projectId,
-        goalId: issueData.goalId ?? parent.goalId,
+        title: normalizedTitle,
+        description: normalizedDescription,
+        projectId: resolvedProjectId ?? undefined,
+        goalId: resolvedGoalId ?? undefined,
         requestDepth: Math.max(parent.requestDepth + 1, issueData.requestDepth ?? 0),
-        description: appendAcceptanceCriteriaToDescription(issueData.description, acceptanceCriteria),
         inheritExecutionWorkspaceFromIssueId: parent.id,
       });
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2413,6 +2413,7 @@ export function issueService(db: Db) {
           .where(and(
             eq(issues.companyId, parent.companyId),
             eq(issues.parentId, parent.id),
+            eq(issues.originKind, "suggested_task"),
             eq(issues.title, normalizedTitle),
             eq(issues.status, issueData.status ?? "todo"),
             eq(issues.priority, issueData.priority ?? "medium"),
@@ -2444,6 +2445,7 @@ export function issueService(db: Db) {
           return {
             issue: existing,
             parentBlockerAdded: Boolean(blockParentUntilDone),
+            isReused: true,
           };
         }
       }
@@ -2462,7 +2464,7 @@ export function issueService(db: Db) {
           ? {
               originKind: "suggested_task",
               originId: parent.id,
-              originFingerprint: suggestedTaskFingerprint ?? "default",
+              originFingerprint: suggestedTaskFingerprint,
             }
           : {}),
         parentId: parent.id,
@@ -2490,6 +2492,7 @@ export function issueService(db: Db) {
       return {
         issue: child,
         parentBlockerAdded: Boolean(blockParentUntilDone),
+        isReused: false,
       };
     },
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2404,7 +2404,7 @@ export function issueService(db: Db) {
               goalId: resolvedGoalId,
               billingCode: resolvedBillingCode,
             })
-          : null;
+          : undefined;
 
       if (issueData.originKind === "suggested_task") {
         const existing = await db


### PR DESCRIPTION
This pull request enhances the handling of suggested tasks within the issue management system, specifically ensuring that accepting the same suggested task bundle multiple times does not create duplicate issues. Instead, it reuses existing child issues when the same suggestions are accepted again. The changes include new logic for fingerprinting suggested tasks, updating issue creation to check for and reuse existing issues, and extending the test suite to cover these scenarios.

**Suggested Task Deduplication and Fingerprinting:**

* Added a new function, `createSuggestedTaskFingerprint`, that generates a SHA-256 hash based on the normalized content of a suggested task, ensuring a consistent and unique identifier for each suggestion. This normalization sorts object keys and recursively processes arrays and objects for stable hashing. (`server/src/services/issues.ts`)
* During child issue creation, if the origin kind is `"suggested_task"`, the service now computes a fingerprint and checks for an existing issue with matching properties (title, description, status, priority, assignee, project, goal, billing code). If found, it reuses the existing issue rather than creating a duplicate. (`server/src/services/issues.ts`) [[1]](diffhunk://#diff-7a5eda40421cea322da52e74b854f1df1138544bcf1141173fb66329dd2a3906R2380-R2450) [[2]](diffhunk://#diff-7a5eda40421cea322da52e74b854f1df1138544bcf1141173fb66329dd2a3906L2358-L2371)
* When reusing an existing suggested task, the logic also ensures that blocking relationships are updated if required. (`server/src/services/issues.ts`)

**API and Data Model Updates:**

* Added `"suggested_task"` as a valid value for `originKind` in both the shared constants and the issue creation logic, ensuring that suggested tasks are properly identified and handled throughout the system. (`packages/shared/src/constants.ts`, `server/src/services/issue-thread-interactions.ts`) [[1]](diffhunk://#diff-1d536cd3a832ab8cf6a670a23882cb3d64e3defef66e7bb26847f21d26ddf748L199-R199) [[2]](diffhunk://#diff-6dcdf5f91d66d8a990c56212cedbb41d96dcebf99bbb07a6749f1fd985b5463cR1045)

**Testing Improvements:**

* Introduced a comprehensive test to verify that accepting the same suggested task bundle twice reuses the same child issues, confirming the deduplication logic works as intended. (`server/src/__tests__/issue-thread-interactions-service.test.ts`)

**Dependency Update:**

* Added import for `createHash` from `node:crypto` to support fingerprint generation. (`server/src/services/issues.ts`)