### PR TITLE
social: Bizbox Dev Happenings — Tue 2026-06-02

### DIFF
--- a/social-articles/2026-06-02.md
+++ b/social-articles/2026-06-02.md
@@ -1,0 +1,61 @@
+---
+title: "Bizbox Dev Happenings — Tue 2026-06-02"
+slug: bizbox-dev-happenings-2026-06-02
+date: 2026-06-02
+tags: [bizbox, build-in-public, devlog, community]
+canonical_url: https://github.com/zesthq/bizbox/blob/master/social-articles/2026-06-02.md
+channels: [x]
+x_handle: "@BizboxAI"
+---
+
+# Bizbox Dev Happenings — Tue 2026-06-02
+
+A busy 72 hours in the Bizbox repo: a new release shipped this morning, a big community PR is drawing review attention, and the awaiting-human bridge keeps getting sharper. Here's what's moving.
+
+---
+
+## 🚀 Released: v2026.602.0
+
+Two PRs landed in this morning's release:
+
+**Smarter issue deduplication ([PR #88](https://github.com/zesthq/bizbox/pull/88) · @adPalafox)**
+When an agent accepts the same suggested-task bundle more than once, Bizbox now fingerprints each suggestion (SHA-256 over normalised content) and reuses the existing child issue instead of creating a duplicate. Small change, real quality-of-life improvement for anyone running multi-step agent workflows.
+
+**Monthly Deep Dive — June 2026 ([PR #83](https://github.com/zesthq/bizbox/pull/83) · @adPalafox)**
+The June deep dive on the awaiting-human bridge architecture is now merged and published. If you want the full technical walkthrough of how Bizbox routes human handoffs through a provider-agnostic bridge layer, [it's in the repo](https://github.com/zesthq/bizbox/blob/master/community/deep-dives/2026-06.md).
+
+---
+
+## 🔧 Also Shipped This Week
+
+**ClickUp bridge adapter as a pure plugin ([PR #78](https://github.com/zesthq/bizbox/pull/78) · @ralphbibera · merged 2026-05-31)**
+The ClickUp transport for the awaiting-human bridge is now a clean plugin — zero ClickUp-specific code in the bridge core. The registry pattern means future providers (Slack, Discord, etc.) can plug in the same way. This is the third and final PR in the awaiting-human bridge series.
+
+**CI: runner Chrome for headless workflows ([PR #84](https://github.com/zesthq/bizbox/pull/84) · @ralphbibera · merged 2026-06-01)**
+Flaky e2e timeouts traced back to browser bootstrap overhead, not app logic. Switching to the preinstalled runner Chrome binary (mirroring a fix from upstream Paperclip) cuts setup noise and keeps the same coverage. Boring fix, meaningful reliability gain.
+
+---
+
+## 👀 High-Signal PR in Review: Workflows + ADK
+
+**[PR #86](https://github.com/zesthq/bizbox/pull/86) — Add company-scoped Workflows with ADK pipeline runs · @DennisDenuto**
+
+This one is still open and it's the biggest PR in the queue right now: 40 files changed, 5,500+ lines added. It introduces **Workflows** as a new first-class primitive in Bizbox — separate from issues and routines — backed by Google ADK pipeline execution.
+
+What it adds:
+- Company-scoped workflow definitions with run records and persisted deliverables
+- ADK project analysis so pipelines render as a live topological graph in the UI
+- Human handoff support inside workflow runs
+- JWT-protected runtime callbacks for ADK phase state
+
+The Greptile bot has already summarised the scope; 7 review comments are open. If you're interested in how Bizbox is thinking about structured multi-phase AI pipelines, this PR is worth watching.
+
+---
+
+## Open Challenge
+
+The Workflows PR (#86) is a significant surface area — database schema, API routes, UI, and ADK integration all in one shot. The open review comments suggest the team is working through the details carefully. Shipping something this broad in a single PR is a deliberate trade-off: faster iteration vs. harder review. We'll see how the review resolves.
+
+---
+
+*Built from real repo activity in [zesthq/bizbox](https://github.com/zesthq/bizbox). Next update Thursday.*

--- a/social-articles/2026-06-02.md
+++ b/social-articles/2026-06-02.md
@@ -40,7 +40,7 @@ Flaky e2e timeouts traced back to browser bootstrap overhead, not app logic. Swi
 
 **[PR #86](https://github.com/zesthq/bizbox/pull/86) — Add company-scoped Workflows with ADK pipeline runs · @DennisDenuto**
 
-This one is still open and it's the biggest PR in the queue right now: 40 files changed, 5,500+ lines added. It introduces **Workflows** as a new first-class primitive in Bizbox — separate from issues and routines — backed by Google ADK pipeline execution.
+This one is still open and it's the biggest PR in the queue right now: 41 files changed, 5,644 additions, 441 deletions. It introduces **Workflows** as a new first-class primitive in Bizbox — separate from issues and routines — backed by Google ADK pipeline execution.
 
 What it adds:
 - Company-scoped workflow definitions with run records and persisted deliverables


### PR DESCRIPTION
## Bizbox Dev Happenings Social Article — Tue 2026-06-02

Twice-weekly social article grounded in real repo activity from the past 2–3 days.

### What's covered
- **v2026.602.0 release** — issue deduplication (PR #88) + June deep dive (PR #83)
- **PR #78** (ClickUp bridge adapter as pure plugin) — merged 2026-05-31
- **PR #84** (CI runner Chrome fix) — merged 2026-06-01
- **PR #86** (Workflows + ADK) — high-signal open PR, noted as in-review

### Review routing
1. Tech Reviewer — accuracy + leakage pass
2. DevRel Lead — editorial review
3. Dennis — final approval before publishing to X (@BizboxAI)

### Guardrails check
- No internal tooling, customer names, partner names, or cost numbers
- No active incidents referenced
- PR #86 noted as open/in-review (not claimed as shipped)
- X is text-only

cc: Tech Reviewer, DevRel Lead