### PR TITLE
feat(workflow): add support for workflow handoff to ClickUp

### DIFF
--- a/packages/db/src/migrations/0078_workflow_handoff_bridges.sql
+++ b/packages/db/src/migrations/0078_workflow_handoff_bridges.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "workflow_handoff_bridges" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL REFERENCES "companies"("id") ON DELETE cascade,
+  "workflow_run_id" uuid NOT NULL REFERENCES "workflow_runs"("id") ON DELETE cascade,
+  "workflow_handoff_id" uuid NOT NULL REFERENCES "workflow_handoffs"("id") ON DELETE cascade,
+  "provider" text NOT NULL,
+  "status" text DEFAULT 'pending_delivery' NOT NULL,
+  "close_outcome" text,
+  "external_message_id" text,
+  "external_thread_id" text,
+  "next_poll_at" timestamptz,
+  "last_polled_at" timestamptz,
+  "closed_at" timestamptz,
+  "last_error" text,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX "workflow_handoff_bridges_handoff_active_uq" ON "workflow_handoff_bridges" ("workflow_handoff_id") WHERE status in ('pending_delivery', 'waiting_for_human');
+CREATE INDEX "workflow_handoff_bridges_company_poll_idx" ON "workflow_handoff_bridges" ("company_id","status","next_poll_at");

--- a/packages/db/src/migrations/0079_workflow_handoff_bridges_fix.sql
+++ b/packages/db/src/migrations/0079_workflow_handoff_bridges_fix.sql
@@ -1,0 +1,27 @@
+-- Fix schema drift: migration 0078 was applied from an earlier draft that was missing
+-- several columns and had incorrect indexes. This migration brings the table up to date.
+
+ALTER TABLE "workflow_handoff_bridges"
+  ADD COLUMN IF NOT EXISTS "provider" text NOT NULL DEFAULT 'clickup',
+  ADD COLUMN IF NOT EXISTS "close_outcome" text,
+  ADD COLUMN IF NOT EXISTS "external_thread_id" text,
+  ADD COLUMN IF NOT EXISTS "last_polled_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "closed_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "last_error" text;
+
+-- Remove the DEFAULT now that existing rows have a value
+ALTER TABLE "workflow_handoff_bridges" ALTER COLUMN "provider" DROP DEFAULT;
+
+-- Drop old incorrect indexes / constraints
+ALTER TABLE "workflow_handoff_bridges" DROP CONSTRAINT IF EXISTS "workflow_handoff_bridges_workflow_handoff_id_unique";
+DROP INDEX IF EXISTS "workflow_handoff_bridges_handoff_idx";
+DROP INDEX IF EXISTS "workflow_handoff_bridges_status_poll_idx";
+
+-- Add correct partial unique index (only one active bridge per handoff)
+CREATE UNIQUE INDEX IF NOT EXISTS "workflow_handoff_bridges_handoff_active_uq"
+  ON "workflow_handoff_bridges" ("workflow_handoff_id")
+  WHERE status IN ('pending_delivery', 'waiting_for_human');
+
+-- Add correct composite poll index
+CREATE INDEX IF NOT EXISTS "workflow_handoff_bridges_company_poll_idx"
+  ON "workflow_handoff_bridges" ("company_id", "status", "next_poll_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -547,6 +547,13 @@
       "when": 1780272000000,
       "tag": "0077_workflows",
       "breakpoints": true
+    },
+    {
+      "idx": 78,
+      "version": "7",
+      "when": 1780472465181,
+      "tag": "0078_workflow_handoff_bridges",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -554,6 +554,13 @@
       "when": 1780472465181,
       "tag": "0078_workflow_handoff_bridges",
       "breakpoints": true
+    },
+    {
+      "idx": 79,
+      "version": "7",
+      "when": 1780560000000,
+      "tag": "0079_workflow_handoff_bridges_fix",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -37,6 +37,7 @@ export { issueReferenceMentions } from "./issue_reference_mentions.js";
 export { issueRelations } from "./issue_relations.js";
 export { routines, routineTriggers, routineRuns } from "./routines.js";
 export { workflows, workflowRuns, workflowRunPhases, workflowHandoffs, workflowDeliverables } from "./workflows.js";
+export { workflowHandoffBridges } from "./workflow_handoff_bridges.js";
 export { issueWorkProducts } from "./issue_work_products.js";
 export { labels } from "./labels.js";
 export { issueLabels } from "./issue_labels.js";

--- a/packages/db/src/schema/workflow_handoff_bridges.ts
+++ b/packages/db/src/schema/workflow_handoff_bridges.ts
@@ -1,0 +1,39 @@
+import { sql } from "drizzle-orm";
+import { index, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { workflowRuns, workflowHandoffs } from "./workflows.js";
+
+export const workflowHandoffBridges = pgTable(
+  "workflow_handoff_bridges",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    workflowRunId: uuid("workflow_run_id").notNull().references(() => workflowRuns.id, { onDelete: "cascade" }),
+    workflowHandoffId: uuid("workflow_handoff_id").notNull().references(() => workflowHandoffs.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    status: text("status")
+      .notNull()
+      .$type<"pending_delivery" | "waiting_for_human" | "closed" | "failed">()
+      .default("pending_delivery"),
+    closeOutcome: text("close_outcome")
+      .$type<"responded" | "approved" | "rejected" | "expired" | "cancelled" | "failed" | null>(),
+    externalMessageId: text("external_message_id"),
+    externalThreadId: text("external_thread_id"),
+    nextPollAt: timestamp("next_poll_at", { withTimezone: true }),
+    lastPolledAt: timestamp("last_polled_at", { withTimezone: true }),
+    closedAt: timestamp("closed_at", { withTimezone: true }),
+    lastError: text("last_error"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    handoffActiveUq: uniqueIndex("workflow_handoff_bridges_handoff_active_uq")
+      .on(table.workflowHandoffId)
+      .where(sql`${table.status} in ('pending_delivery', 'waiting_for_human')`),
+    companyPollIdx: index("workflow_handoff_bridges_company_poll_idx").on(
+      table.companyId,
+      table.status,
+      table.nextPollAt,
+    ),
+  }),
+);

--- a/packages/shared/src/types/workflow.ts
+++ b/packages/shared/src/types/workflow.ts
@@ -96,6 +96,8 @@ export interface WorkflowHandoff {
   decidedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
+  /** Present when a ClickUp bridge exists for this handoff. */
+  bridgeStatus: "waiting_for_human" | "closed" | null;
 }
 
 export interface WorkflowDeliverableSummary {

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -12,7 +12,7 @@ import {
 } from "@paperclipai/shared";
 import { z } from "zod";
 import { validate } from "../middleware/validate.js";
-import { logActivity, workflowService } from "../services/index.js";
+import { logActivity, workflowHandoffBridgeService, workflowService } from "../services/index.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 
 function readRuntimeToken(req: { body?: unknown; query?: unknown }) {
@@ -193,7 +193,28 @@ export function workflowRoutes(db: Db) {
       return;
     }
     const { token: _token, ...input } = req.body as CreateWorkflowHandoff & { token: string };
-    res.status(201).json(await svc.createRuntimeHandoff(runId, input));
+    const handoff = await svc.createRuntimeHandoff(runId, input);
+
+    // Attempt to open a ClickUp bridge for the handoff.
+    // If ClickUp is not configured, return 503 immediately so the caller knows.
+    try {
+      const bridgeSvc = workflowHandoffBridgeService(db);
+      await bridgeSvc.openForHandoff({
+        id: handoff.id,
+        companyId: handoff.companyId,
+        workflowRunId: handoff.workflowRunId,
+        kind: handoff.kind,
+        promptMarkdown: handoff.promptMarkdown,
+      });
+    } catch (error) {
+      const code = (error as { code?: string }).code;
+      const status = (error as { status?: number }).status ?? 500;
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(status).json({ error: message, code });
+      return;
+    }
+
+    res.status(201).json(handoff);
   });
 
   const getRuntimeHandoff = async (req: Request, res: Response) => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -98,6 +98,7 @@ import { clickupBridgeService } from "./clickup-bridge.js";
 import { documentService } from "./documents.js";
 import { workProductService } from "./work-products.js";
 import { awaitingHumanBridgeService } from "./awaiting-human-bridge.js";
+import { workflowHandoffBridgeService } from "./workflow-handoff-bridge.js";
 import { awaitingHumanSettingsService } from "./awaiting-human-settings.js";
 import {
   hasAnyAwaitingHumanBridgeAdapter,
@@ -2118,6 +2119,7 @@ export function heartbeatService(db: Db) {
       });
     },
   });
+  const workflowHandoffBridge = workflowHandoffBridgeService(db);
   const executionWorkspacesSvc = executionWorkspaceService(db);
   const environmentsSvc = environmentService(db);
   const workspaceOperationsSvc = workspaceOperationService(db);
@@ -5425,13 +5427,14 @@ export function heartbeatService(db: Db) {
     }
 
     const pendingResult = await awaitingHumanBridge.reconcilePendingConfirmations();
+    const handoffBridgeResult = await workflowHandoffBridge.pollActiveBridges();
     return {
-      checked: legacyResult.checked + pendingResult.checked,
+      checked: legacyResult.checked + pendingResult.checked + handoffBridgeResult.checked,
       approved: legacyResult.approved + pendingResult.approved,
       rejected: legacyResult.rejected + pendingResult.rejected,
-      failed: legacyResult.failed + pendingResult.failed,
+      failed: legacyResult.failed + pendingResult.failed + handoffBridgeResult.failed,
       skipped: legacyResult.skipped + pendingResult.skipped,
-      noApproval: legacyResult.noSignal + pendingResult.noApproval,
+      noApproval: legacyResult.noSignal + pendingResult.noApproval + handoffBridgeResult.noSignal,
       replies: legacyResult.replies + pendingResult.replies,
       issueIds: [...legacyResult.approvedIssueIds, ...pendingResult.issueIds],
       interactionIds: [...legacyResult.approvedInteractionIds, ...pendingResult.interactionIds],

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -31,6 +31,7 @@ export { budgetService } from "./budgets.js";
 export { secretService } from "./secrets.js";
 export { routineService } from "./routines.js";
 export { workflowService } from "./workflows.js";
+export { workflowHandoffBridgeService } from "./workflow-handoff-bridge.js";
 export { costService } from "./costs.js";
 export { financeService } from "./finance.js";
 export { heartbeatService } from "./heartbeat.js";

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -241,6 +241,11 @@ export function workflowHandoffBridgeService(db: Db) {
       attachmentTaskId: config.attachmentTaskId,
     };
 
+    const existingBridge = await getActiveBridge(handoff.id);
+    if (existingBridge) {
+      return existingBridge;
+    }
+
     const notification = buildHandoffNotification(handoff);
 
     const result = await sendAwaitingHumanNotification(
@@ -474,7 +479,7 @@ export function workflowHandoffBridgeService(db: Db) {
     return summary;
   }
 
-  async function getActivebridge(workflowHandoffId: string) {
+  async function getActiveBridge(workflowHandoffId: string) {
     const [bridge] = await db
       .select()
       .from(workflowHandoffBridges)
@@ -499,7 +504,7 @@ export function workflowHandoffBridgeService(db: Db) {
   return {
     openForHandoff,
     pollActiveBridges,
-    getActivebridge,
+    getActiveBridge,
     getBridgeForHandoff,
   };
 }

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -1,0 +1,505 @@
+import { and, asc, eq, inArray, lte, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import {
+  workflowHandoffBridges,
+  workflowHandoffs,
+  workflowRunPhases,
+  workflowRuns,
+} from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+import { logActivity } from "./activity-log.js";
+import { awaitingHumanSettingsService } from "./awaiting-human-settings.js";
+import {
+  addClickUpChatMessageReaction,
+  deleteClickUpChatMessageReaction,
+  detectClickUpAwaitingHumanBridgeEvents,
+  sendAwaitingHumanNotification,
+} from "./clickup-awaiting-human-transport.js";
+import type { AwaitingHumanNotificationPayload } from "./awaiting-human-notifications.js";
+
+const POLL_INTERVAL_MS = 60_000;
+const POLL_FAILURE_BACKOFF_MS = 5 * 60 * 1000;
+
+function truncateText(value: string, maxLength: number) {
+  const compact = value.trim().replace(/\s+/g, " ");
+  if (compact.length <= maxLength) return compact;
+  return `${compact.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+function buildHandoffNotification(handoff: {
+  kind: string;
+  promptMarkdown: string;
+}): AwaitingHumanNotificationPayload {
+  const isApproval = handoff.kind === "approval";
+  return {
+    title: isApproval ? "Workflow approval required" : "Workflow input required",
+    summary: truncateText(handoff.promptMarkdown, 280),
+    body: handoff.promptMarkdown,
+    link: "",
+    cta: isApproval
+      ? "Reply with: approve or reject (optionally include a note)."
+      : "Reply with your response.",
+    labels: ["workflow_handoff", handoff.kind],
+  };
+}
+
+async function applyReaction(input: {
+  db: Db;
+  bridgeId: string;
+  companyId: string;
+  workflowHandoffId: string;
+  messageId: string;
+  reaction: string;
+  target: "main" | "reply";
+  overrides: { personalToken: string | null; workspaceId: string | null; channelId: string | null };
+}) {
+  try {
+    await addClickUpChatMessageReaction(input.messageId, input.reaction, input.overrides);
+  } catch (error) {
+    logger.warn({
+      err: error,
+      bridgeId: input.bridgeId,
+      companyId: input.companyId,
+      workflowHandoffId: input.workflowHandoffId,
+      messageId: input.messageId,
+      reaction: input.reaction,
+    }, "workflow handoff bridge: failed to apply ClickUp reaction");
+  }
+}
+
+async function removeReaction(input: {
+  db: Db;
+  bridgeId: string;
+  companyId: string;
+  workflowHandoffId: string;
+  messageId: string;
+  reaction: string;
+  overrides: { personalToken: string | null; workspaceId: string | null; channelId: string | null };
+}) {
+  try {
+    await deleteClickUpChatMessageReaction(input.messageId, input.reaction, input.overrides);
+  } catch (error) {
+    logger.warn({
+      err: error,
+      bridgeId: input.bridgeId,
+      companyId: input.companyId,
+      workflowHandoffId: input.workflowHandoffId,
+      messageId: input.messageId,
+      reaction: input.reaction,
+    }, "workflow handoff bridge: failed to remove ClickUp reaction");
+  }
+}
+
+async function closeBridgeRow(
+  db: Db,
+  bridge: typeof workflowHandoffBridges.$inferSelect,
+  outcome: "responded" | "approved" | "rejected" | "expired" | "cancelled" | "failed",
+  overrides: { personalToken: string | null; workspaceId: string | null; channelId: string | null },
+) {
+  const now = new Date();
+  await db.update(workflowHandoffBridges).set({
+    status: "closed",
+    closeOutcome: outcome,
+    closedAt: now,
+    nextPollAt: null,
+    updatedAt: now,
+  }).where(eq(workflowHandoffBridges.id, bridge.id));
+
+  const messageId = bridge.externalMessageId?.trim();
+  if (!messageId) return;
+
+  await removeReaction({
+    db,
+    bridgeId: bridge.id,
+    companyId: bridge.companyId,
+    workflowHandoffId: bridge.workflowHandoffId,
+    messageId,
+    reaction: "brain_is_thinking",
+    overrides,
+  });
+
+  if (outcome === "responded" || outcome === "approved" || outcome === "rejected") {
+    await applyReaction({
+      db,
+      bridgeId: bridge.id,
+      companyId: bridge.companyId,
+      workflowHandoffId: bridge.workflowHandoffId,
+      messageId,
+      reaction: "white_check_mark",
+      target: "main",
+      overrides,
+    });
+  } else if (outcome === "failed" || outcome === "expired") {
+    await applyReaction({
+      db,
+      bridgeId: bridge.id,
+      companyId: bridge.companyId,
+      workflowHandoffId: bridge.workflowHandoffId,
+      messageId,
+      reaction: "x",
+      target: "main",
+      overrides,
+    });
+  }
+}
+
+async function resolveHandoffFromBridge(
+  db: Db,
+  bridge: typeof workflowHandoffBridges.$inferSelect,
+  resolution: "responded" | "approved" | "rejected",
+  responseMarkdown: string | null,
+) {
+  const now = new Date();
+
+  const [handoff] = await db
+    .select()
+    .from(workflowHandoffs)
+    .where(and(
+      eq(workflowHandoffs.id, bridge.workflowHandoffId),
+      eq(workflowHandoffs.status, "pending"),
+    ))
+    .limit(1);
+
+  if (!handoff) return;
+
+  await db.update(workflowHandoffs).set({
+    status: resolution,
+    responseMarkdown: responseMarkdown ?? null,
+    decidedByUserId: "clickup_bridge",
+    decidedAt: now,
+    updatedAt: now,
+  }).where(and(
+    eq(workflowHandoffs.id, bridge.workflowHandoffId),
+    eq(workflowHandoffs.status, "pending"),
+  ));
+
+  // Wake the run back to running state
+  await db.update(workflowRunPhases).set({
+    status: "running",
+    updatedAt: now,
+  }).where(and(
+    eq(workflowRunPhases.workflowRunId, bridge.workflowRunId),
+    eq(workflowRunPhases.phaseKey, handoff.phaseKey),
+    inArray(workflowRunPhases.status, ["awaiting_human"]),
+  ));
+
+  await db.update(workflowRuns).set({
+    status: "running",
+    updatedAt: now,
+  }).where(and(
+    eq(workflowRuns.id, bridge.workflowRunId),
+    eq(workflowRuns.status, "awaiting_human"),
+  ));
+
+  await logActivity(db, {
+    companyId: bridge.companyId,
+    actorType: "system",
+    actorId: "workflow_handoff_bridge",
+    action: "workflow.handoff.bridge_resolved",
+    entityType: "workflow_run",
+    entityId: bridge.workflowRunId,
+    details: {
+      bridgeId: bridge.id,
+      workflowHandoffId: bridge.workflowHandoffId,
+      resolution,
+      provider: bridge.provider,
+      externalMessageId: bridge.externalMessageId ?? null,
+    },
+  });
+}
+
+export function workflowHandoffBridgeService(db: Db) {
+  const settings = awaitingHumanSettingsService(db);
+
+  async function openForHandoff(handoff: {
+    id: string;
+    companyId: string;
+    workflowRunId: string;
+    kind: string;
+    promptMarkdown: string;
+  }) {
+    let config: Awaited<ReturnType<typeof settings.resolveClickUpRuntimeConfig>>;
+    try {
+      config = await settings.resolveClickUpRuntimeConfig(handoff.companyId);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      const isBridgeDisabled = detail === "awaiting-human-bridge-disabled";
+      throw Object.assign(
+        new Error(
+          isBridgeDisabled
+            ? "ClickUp integration is not configured for this company. Workflow input() handoffs require ClickUp to be set up in company settings."
+            : `Failed to load ClickUp configuration: ${detail}`,
+        ),
+        { code: "clickup_not_configured", status: 503 },
+      );
+    }
+
+    const overrides = {
+      personalToken: config.personalToken,
+      workspaceId: config.workspaceId,
+      channelId: config.channelId,
+      attachmentTaskId: config.attachmentTaskId,
+    };
+
+    const notification = buildHandoffNotification(handoff);
+
+    const result = await sendAwaitingHumanNotification(
+      {
+        companyId: handoff.companyId,
+        issueId: handoff.id, // not an issue -- reusing field for context
+        handoffKind: handoff.kind === "approval" ? "request_confirmation" : "ask_user_questions",
+        notification,
+      },
+      overrides,
+    );
+
+    if (result.status !== "sent") {
+      throw Object.assign(
+        new Error(`Failed to post workflow handoff to ClickUp: ${result.detail}`),
+        { code: "clickup_send_failed", status: 503 },
+      );
+    }
+
+    const externalMessageId = result.externalId ?? null;
+    const now = new Date();
+
+    const [bridge] = await db.insert(workflowHandoffBridges).values({
+      companyId: handoff.companyId,
+      workflowRunId: handoff.workflowRunId,
+      workflowHandoffId: handoff.id,
+      provider: "clickup",
+      status: "waiting_for_human",
+      externalMessageId,
+      nextPollAt: new Date(now.getTime() + POLL_INTERVAL_MS),
+    }).onConflictDoNothing({
+      target: workflowHandoffBridges.workflowHandoffId,
+      where: inArray(workflowHandoffBridges.status, ["pending_delivery", "waiting_for_human"]),
+    }).returning();
+
+    if (externalMessageId && bridge) {
+      await applyReaction({
+        db,
+        bridgeId: bridge.id,
+        companyId: handoff.companyId,
+        workflowHandoffId: handoff.id,
+        messageId: externalMessageId,
+        reaction: "brain_is_thinking",
+        target: "main",
+        overrides,
+      });
+    }
+
+    await logActivity(db, {
+      companyId: handoff.companyId,
+      actorType: "system",
+      actorId: "workflow_handoff_bridge",
+      action: "workflow.handoff.bridge_opened",
+      entityType: "workflow_run",
+      entityId: handoff.workflowRunId,
+      details: {
+        bridgeId: bridge?.id ?? null,
+        workflowHandoffId: handoff.id,
+        provider: "clickup",
+        externalMessageId,
+      },
+    });
+
+    return bridge ?? null;
+  }
+
+  async function pollActiveBridges() {
+    const now = new Date();
+    const bridges = await db
+      .select()
+      .from(workflowHandoffBridges)
+      .where(and(
+        eq(workflowHandoffBridges.status, "waiting_for_human"),
+        lte(workflowHandoffBridges.nextPollAt, now),
+      ))
+      .orderBy(
+        asc(workflowHandoffBridges.nextPollAt),
+        asc(workflowHandoffBridges.createdAt),
+      )
+      .limit(50);
+
+    const summary = { checked: 0, resolved: 0, noSignal: 0, failed: 0 };
+
+    for (const bridge of bridges) {
+      summary.checked += 1;
+      const messageId = bridge.externalMessageId?.trim();
+      if (!messageId) {
+        await db.update(workflowHandoffBridges).set({
+          lastPolledAt: now,
+          nextPollAt: new Date(now.getTime() + POLL_INTERVAL_MS),
+          updatedAt: now,
+        }).where(eq(workflowHandoffBridges.id, bridge.id));
+        summary.noSignal += 1;
+        continue;
+      }
+
+      let overrides: { personalToken: string | null; workspaceId: string | null; channelId: string | null; attachmentTaskId: string | null };
+      try {
+        const config = await settings.resolveClickUpRuntimeConfig(bridge.companyId);
+        overrides = {
+          personalToken: config.personalToken,
+          workspaceId: config.workspaceId,
+          channelId: config.channelId,
+          attachmentTaskId: config.attachmentTaskId,
+        };
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        await db.update(workflowHandoffBridges).set({
+          lastError: detail,
+          lastPolledAt: now,
+          nextPollAt: new Date(now.getTime() + POLL_FAILURE_BACKOFF_MS),
+          updatedAt: now,
+        }).where(eq(workflowHandoffBridges.id, bridge.id));
+        summary.failed += 1;
+        continue;
+      }
+
+      let detected: Awaited<ReturnType<typeof detectClickUpAwaitingHumanBridgeEvents>>;
+      try {
+        detected = await detectClickUpAwaitingHumanBridgeEvents(messageId, overrides);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        logger.error({
+          err: error,
+          bridgeId: bridge.id,
+          companyId: bridge.companyId,
+          workflowHandoffId: bridge.workflowHandoffId,
+          messageId,
+        }, "workflow handoff bridge: ClickUp poll failed");
+        await db.update(workflowHandoffBridges).set({
+          lastError: detail,
+          lastPolledAt: now,
+          nextPollAt: new Date(now.getTime() + POLL_FAILURE_BACKOFF_MS),
+          updatedAt: now,
+        }).where(eq(workflowHandoffBridges.id, bridge.id));
+        await logActivity(db, {
+          companyId: bridge.companyId,
+          actorType: "system",
+          actorId: "workflow_handoff_bridge",
+          action: "workflow.handoff.bridge_poll_failed",
+          entityType: "workflow_run",
+          entityId: bridge.workflowRunId,
+          details: { bridgeId: bridge.id, workflowHandoffId: bridge.workflowHandoffId, detail },
+        });
+        summary.failed += 1;
+        continue;
+      }
+
+      if (detected.status === "failed") {
+        await db.update(workflowHandoffBridges).set({
+          lastError: detected.detail,
+          lastPolledAt: now,
+          nextPollAt: new Date(now.getTime() + POLL_FAILURE_BACKOFF_MS),
+          updatedAt: now,
+        }).where(eq(workflowHandoffBridges.id, bridge.id));
+        summary.failed += 1;
+        continue;
+      }
+
+      if (detected.events.length === 0) {
+        await db.update(workflowHandoffBridges).set({
+          lastPolledAt: now,
+          lastError: null,
+          nextPollAt: new Date(now.getTime() + POLL_INTERVAL_MS),
+          updatedAt: now,
+        }).where(eq(workflowHandoffBridges.id, bridge.id));
+        summary.noSignal += 1;
+        continue;
+      }
+
+      // Process first meaningful event -- acknowledge all reply messages
+      const replyMessageIds = new Set<string>();
+      for (const event of detected.events) {
+        const replyId = typeof event.metadata?.clickupReplyId === "string" && event.metadata.clickupReplyId.trim().length > 0
+          ? event.metadata.clickupReplyId.trim()
+          : null;
+        if (replyId) replyMessageIds.add(replyId);
+      }
+      for (const replyId of replyMessageIds) {
+        await applyReaction({
+          db,
+          bridgeId: bridge.id,
+          companyId: bridge.companyId,
+          workflowHandoffId: bridge.workflowHandoffId,
+          messageId: replyId,
+          reaction: "white_check_mark",
+          target: "reply",
+          overrides,
+        });
+      }
+
+      // Resolve using the first event
+      const event = detected.events[0]!;
+      let resolution: "responded" | "approved" | "rejected";
+      let responseMarkdown: string | null;
+
+      if (event.kind === "approval_signal") {
+        resolution = "approved";
+        responseMarkdown = event.body?.trim() || null;
+      } else if (event.kind === "reject_signal") {
+        resolution = "rejected";
+        responseMarkdown = event.body?.trim() || null;
+      } else {
+        // "reply" -- raw text response
+        resolution = "responded";
+        responseMarkdown = event.body?.trim() || null;
+      }
+
+      try {
+        await resolveHandoffFromBridge(db, bridge, resolution, responseMarkdown);
+        await closeBridgeRow(db, bridge, resolution, overrides);
+        summary.resolved += 1;
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        logger.error({
+          err: error,
+          bridgeId: bridge.id,
+          companyId: bridge.companyId,
+          workflowHandoffId: bridge.workflowHandoffId,
+        }, "workflow handoff bridge: failed to resolve handoff after reply");
+        await db.update(workflowHandoffBridges).set({
+          lastError: detail,
+          lastPolledAt: now,
+          nextPollAt: new Date(now.getTime() + POLL_FAILURE_BACKOFF_MS),
+          updatedAt: now,
+        }).where(eq(workflowHandoffBridges.id, bridge.id));
+        summary.failed += 1;
+      }
+    }
+
+    return summary;
+  }
+
+  async function getActivebridge(workflowHandoffId: string) {
+    const [bridge] = await db
+      .select()
+      .from(workflowHandoffBridges)
+      .where(and(
+        eq(workflowHandoffBridges.workflowHandoffId, workflowHandoffId),
+        inArray(workflowHandoffBridges.status, ["pending_delivery", "waiting_for_human"]),
+      ))
+      .limit(1);
+    return bridge ?? null;
+  }
+
+  async function getBridgeForHandoff(workflowHandoffId: string) {
+    const [bridge] = await db
+      .select()
+      .from(workflowHandoffBridges)
+      .where(eq(workflowHandoffBridges.workflowHandoffId, workflowHandoffId))
+      .orderBy(asc(workflowHandoffBridges.createdAt))
+      .limit(1);
+    return bridge ?? null;
+  }
+
+  return {
+    openForHandoff,
+    pollActiveBridges,
+    getActivebridge,
+    getBridgeForHandoff,
+  };
+}

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lte, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   workflowHandoffBridges,
@@ -162,34 +162,36 @@ async function resolveHandoffFromBridge(
 
   if (!handoff) return;
 
-  await db.update(workflowHandoffs).set({
-    status: resolution,
-    responseMarkdown: responseMarkdown ?? null,
-    decidedByUserId: "clickup_bridge",
-    decidedAt: now,
-    updatedAt: now,
-  }).where(and(
-    eq(workflowHandoffs.id, bridge.workflowHandoffId),
-    eq(workflowHandoffs.status, "pending"),
-  ));
+  await db.transaction(async (tx) => {
+    await tx.update(workflowHandoffs).set({
+      status: resolution,
+      responseMarkdown: responseMarkdown ?? null,
+      decidedByUserId: "clickup_bridge",
+      decidedAt: now,
+      updatedAt: now,
+    }).where(and(
+      eq(workflowHandoffs.id, bridge.workflowHandoffId),
+      eq(workflowHandoffs.status, "pending"),
+    ));
 
-  // Wake the run back to running state
-  await db.update(workflowRunPhases).set({
-    status: "running",
-    updatedAt: now,
-  }).where(and(
-    eq(workflowRunPhases.workflowRunId, bridge.workflowRunId),
-    eq(workflowRunPhases.phaseKey, handoff.phaseKey),
-    inArray(workflowRunPhases.status, ["awaiting_human"]),
-  ));
+    // Wake the run back to running state
+    await tx.update(workflowRunPhases).set({
+      status: "running",
+      updatedAt: now,
+    }).where(and(
+      eq(workflowRunPhases.workflowRunId, bridge.workflowRunId),
+      eq(workflowRunPhases.phaseKey, handoff.phaseKey),
+      inArray(workflowRunPhases.status, ["awaiting_human"]),
+    ));
 
-  await db.update(workflowRuns).set({
-    status: "running",
-    updatedAt: now,
-  }).where(and(
-    eq(workflowRuns.id, bridge.workflowRunId),
-    eq(workflowRuns.status, "awaiting_human"),
-  ));
+    await tx.update(workflowRuns).set({
+      status: "running",
+      updatedAt: now,
+    }).where(and(
+      eq(workflowRuns.id, bridge.workflowRunId),
+      eq(workflowRuns.status, "awaiting_human"),
+    ));
+  });
 
   await logActivity(db, {
     companyId: bridge.companyId,
@@ -496,7 +498,7 @@ export function workflowHandoffBridgeService(db: Db) {
       .select()
       .from(workflowHandoffBridges)
       .where(eq(workflowHandoffBridges.workflowHandoffId, workflowHandoffId))
-      .orderBy(asc(workflowHandoffBridges.createdAt))
+      .orderBy(desc(workflowHandoffBridges.createdAt))
       .limit(1);
     return bridge ?? null;
   }

--- a/server/src/services/workflows-runtime.ts
+++ b/server/src/services/workflows-runtime.ts
@@ -818,10 +818,14 @@ export async function prepareInstrumentedWorkflowRuntime(input: {
   }
 
   await fs.writeFile(path.join(tempRoot, "bizbox_workflow_runtime.py"), buildRuntimeHelperModule(), "utf8");
-  // Use a .pth file instead of sitecustomize.py so we don't shadow any existing sitecustomize
-  // in the agent project or Python distribution. site.py executes lines beginning with "import"
-  // in every .pth file it finds on sys.path.
-  await fs.writeFile(path.join(tempRoot, "bizbox_workflow_runtime.pth"), "import bizbox_workflow_runtime\n", "utf8");
+  // Use sitecustomize.py so the monkey-patch fires unconditionally before any user code runs.
+  // .pth files are only processed from site-packages directories — not from arbitrary PYTHONPATH
+  // entries — so the .pth approach silently does nothing in venv environments. sitecustomize.py,
+  // by contrast, is searched across all of sys.path (including PYTHONPATH dirs) by the Python
+  // interpreter itself, making it reliable in venvs. If the agent project already ships its own
+  // sitecustomize.py it will be shadowed, but that is an acceptable trade-off given that the
+  // alternative (input() hitting EOF in a non-interactive subprocess) is a hard crash.
+  await fs.writeFile(path.join(tempRoot, "sitecustomize.py"), "import bizbox_workflow_runtime\n", "utf8");
 
   const copiedAgentPath = (() => {
     const mapped = maybeMapIntoCopiedTree(input.analysis.rootDir, copiedRoot, input.analysis.executionTargetPath);

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -440,25 +440,29 @@ export function workflowService(db: Db) {
       // must not corrupt the run's terminal status. The agent invocation already
       // succeeded, so we log and continue rather than letting the outer catch
       // stamp the run as "failed".
-      try {
-        await createWorkflowSummaryDeliverable(db, {
-          companyId: workflow.companyId,
-          workflowId: workflow.id,
-          runId,
-          title: `${workflow.title} output`,
-          summary: result.summary ?? null,
-        });
-        await createWorkflowArtifactDeliverables(db, storage, {
-          companyId: workflow.companyId,
-          workflowId: workflow.id,
-          runId,
-          artifacts,
-        });
-      } catch (deliverableErr) {
-        console.error(
-          `[workflows] deliverable persistence failed for run ${runId} (run will still be marked succeeded):`,
-          deliverableErr,
-        );
+      // Deliverables are only created on success — a failed run must not produce
+      // any deliverable output.
+      if (!result.errorMessage) {
+        try {
+          await createWorkflowSummaryDeliverable(db, {
+            companyId: workflow.companyId,
+            workflowId: workflow.id,
+            runId,
+            title: `${workflow.title} output`,
+            summary: result.summary ?? null,
+          });
+          await createWorkflowArtifactDeliverables(db, storage, {
+            companyId: workflow.companyId,
+            workflowId: workflow.id,
+            runId,
+            artifacts,
+          });
+        } catch (deliverableErr) {
+          console.error(
+            `[workflows] deliverable persistence failed for run ${runId} (run will still be marked succeeded):`,
+            deliverableErr,
+          );
+        }
       }
 
       const phases = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, runId)).orderBy(asc(workflowRunPhases.ordinal));

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -691,9 +691,19 @@ export function workflowService(db: Db) {
             workflowHandoffId: workflowHandoffBridges.workflowHandoffId,
             status: workflowHandoffBridges.status,
           }).from(workflowHandoffBridges)
-            .where(inArray(workflowHandoffBridges.workflowHandoffId, handoffIds))
+            .where(and(
+              inArray(workflowHandoffBridges.workflowHandoffId, handoffIds),
+              inArray(workflowHandoffBridges.status, ["pending_delivery", "waiting_for_human"]),
+            ))
+            .orderBy(desc(workflowHandoffBridges.createdAt))
         : [];
-      const bridgeStatusByHandoffId = new Map(bridges.map((b) => [b.workflowHandoffId, b.status as "waiting_for_human" | "closed"]));
+      const bridgeStatusByHandoffId = new Map(
+        bridges
+          .filter((b): b is typeof b & { status: "waiting_for_human" | "closed" } =>
+            b.status === "waiting_for_human" || b.status === "closed",
+          )
+          .map((b) => [b.workflowHandoffId, b.status]),
+      );
       const deliverables = await db.select().from(workflowDeliverables).where(eq(workflowDeliverables.workflowRunId, runId)).orderBy(desc(workflowDeliverables.createdAt));
       return {
         ...toWorkflowRun(runRow),
@@ -793,11 +803,17 @@ export function workflowService(db: Db) {
       if (!row) return null;
       const bridge = await db.select({ status: workflowHandoffBridges.status })
         .from(workflowHandoffBridges)
-        .where(eq(workflowHandoffBridges.workflowHandoffId, handoffId))
-        .orderBy(asc(workflowHandoffBridges.createdAt))
+        .where(and(
+          eq(workflowHandoffBridges.workflowHandoffId, handoffId),
+          inArray(workflowHandoffBridges.status, ["pending_delivery", "waiting_for_human"]),
+        ))
+        .orderBy(desc(workflowHandoffBridges.createdAt))
         .limit(1)
         .then((rows) => rows[0] ?? null);
-      return toWorkflowHandoff(row, (bridge?.status as "waiting_for_human" | "closed") ?? null);
+      const bridgeStatus = bridge?.status === "waiting_for_human" || bridge?.status === "pending_delivery"
+        ? "waiting_for_human" as const
+        : null;
+      return toWorkflowHandoff(row, bridgeStatus);
     },
 
     resolveHandoff: async (

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -3,6 +3,7 @@ import { and, asc, desc, eq, inArray, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   workflowDeliverables,
+  workflowHandoffBridges,
   workflowHandoffs,
   workflowRunPhases,
   workflowRuns,
@@ -144,7 +145,10 @@ function toWorkflowPhase(row: typeof workflowRunPhases.$inferSelect): WorkflowPh
   };
 }
 
-function toWorkflowHandoff(row: typeof workflowHandoffs.$inferSelect): WorkflowHandoff {
+function toWorkflowHandoff(
+  row: typeof workflowHandoffs.$inferSelect,
+  bridgeStatus: "waiting_for_human" | "closed" | null = null,
+): WorkflowHandoff {
   return {
     id: row.id,
     companyId: row.companyId,
@@ -158,6 +162,7 @@ function toWorkflowHandoff(row: typeof workflowHandoffs.$inferSelect): WorkflowH
     decidedAt: row.decidedAt ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    bridgeStatus,
   };
 }
 
@@ -680,6 +685,15 @@ export function workflowService(db: Db) {
       if (!workflowRow) return null;
       const phases = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, runId)).orderBy(asc(workflowRunPhases.ordinal));
       const handoffs = await db.select().from(workflowHandoffs).where(eq(workflowHandoffs.workflowRunId, runId)).orderBy(asc(workflowHandoffs.createdAt));
+      const handoffIds = handoffs.map((h) => h.id);
+      const bridges = handoffIds.length > 0
+        ? await db.select({
+            workflowHandoffId: workflowHandoffBridges.workflowHandoffId,
+            status: workflowHandoffBridges.status,
+          }).from(workflowHandoffBridges)
+            .where(inArray(workflowHandoffBridges.workflowHandoffId, handoffIds))
+        : [];
+      const bridgeStatusByHandoffId = new Map(bridges.map((b) => [b.workflowHandoffId, b.status as "waiting_for_human" | "closed"]));
       const deliverables = await db.select().from(workflowDeliverables).where(eq(workflowDeliverables.workflowRunId, runId)).orderBy(desc(workflowDeliverables.createdAt));
       return {
         ...toWorkflowRun(runRow),
@@ -690,7 +704,7 @@ export function workflowService(db: Db) {
           runnerType: workflowRow.runnerType as "google_adk",
         },
         phases: phases.map(toWorkflowPhase),
-        handoffs: handoffs.map(toWorkflowHandoff),
+        handoffs: handoffs.map((h) => toWorkflowHandoff(h, bridgeStatusByHandoffId.get(h.id) ?? null)),
         deliverables: deliverables.map(toWorkflowDeliverableSummary),
       };
     },
@@ -776,7 +790,14 @@ export function workflowService(db: Db) {
 
     getHandoff: async (handoffId: string) => {
       const row = await db.select().from(workflowHandoffs).where(eq(workflowHandoffs.id, handoffId)).then((rows) => rows[0] ?? null);
-      return row ? toWorkflowHandoff(row) : null;
+      if (!row) return null;
+      const bridge = await db.select({ status: workflowHandoffBridges.status })
+        .from(workflowHandoffBridges)
+        .where(eq(workflowHandoffBridges.workflowHandoffId, handoffId))
+        .orderBy(asc(workflowHandoffBridges.createdAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      return toWorkflowHandoff(row, (bridge?.status as "waiting_for_human" | "closed") ?? null);
     },
 
     resolveHandoff: async (

--- a/ui/src/pages/WorkflowDetail.tsx
+++ b/ui/src/pages/WorkflowDetail.tsx
@@ -598,7 +598,15 @@ function GraphHumanNode({
           <div className="text-sm font-semibold text-foreground">
             {handoff.kind === "approval" ? "Human approval" : "Human response"}
           </div>
-          <div className="text-xs text-muted-foreground">{handoff.status.replaceAll("_", " ")}</div>
+          <div className="flex items-center gap-2">
+            <div className="text-xs text-muted-foreground">{handoff.status.replaceAll("_", " ")}</div>
+            {handoff.bridgeStatus === "waiting_for_human" && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-sky-500/15 px-2 py-0.5 text-xs font-medium text-sky-600 dark:text-sky-400">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" />
+                Waiting on ClickUp reply
+              </span>
+            )}
+          </div>
         </div>
       </div>
 

--- a/ui/src/pages/Workflows.tsx
+++ b/ui/src/pages/Workflows.tsx
@@ -1,9 +1,10 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@/lib/router";
-import { GitBranch, Play, Plus, Sparkles, Workflow as WorkflowIcon } from "lucide-react";
+import { AlertTriangle, GitBranch, Play, Plus, Sparkles, Workflow as WorkflowIcon, X } from "lucide-react";
 import type { WorkflowListItem } from "@paperclipai/shared";
 import { workflowsApi } from "../api/workflows";
+import { companyAwaitingHumanSettingsApi } from "../api/companyAwaitingHumanSettings";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useCompany } from "../context/CompanyContext";
 import { useToastActions } from "../context/ToastContext";
@@ -42,10 +43,30 @@ export function Workflows() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [draft, setDraft] = useState<WorkflowCreateDraft>(defaultDraft);
+  const [clickUpWarnDismissed, setClickUpWarnDismissed] = useState(false);
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Workflows" }]);
   }, [setBreadcrumbs]);
+
+  const awaitingHumanQuery = useQuery({
+    queryKey: queryKeys.companies.awaitingHumanSettings(selectedCompanyId ?? ""),
+    queryFn: () => companyAwaitingHumanSettingsApi.get(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+    staleTime: 60_000,
+  });
+
+  const clickUpNotConfigured = (() => {
+    const s = awaitingHumanQuery.data;
+    if (!s) return false;
+    return !(
+      s.enabled &&
+      s.provider === "clickup" &&
+      s.hasStoredAuthToken &&
+      s.providerConfig?.workspaceId &&
+      s.providerConfig?.channelId
+    );
+  })();
 
   const workflowsQuery = useQuery({
     queryKey: queryKeys.workflows.list(selectedCompanyId ?? ""),
@@ -101,6 +122,28 @@ export function Workflows() {
 
   return (
     <div className="space-y-6">
+      {clickUpNotConfigured && !clickUpWarnDismissed && (
+        <div className="flex items-start gap-3 rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+          <p className="flex-1">
+            ClickUp integration is not fully configured. Workflows that use{" "}
+            <code className="rounded bg-amber-500/20 px-1 py-0.5 text-xs font-mono">input()</code>{" "}
+            handoffs will fail with a 503 until ClickUp is enabled.{" "}
+            <Link to="/company/settings/awaiting-human" className="font-medium underline underline-offset-2 hover:text-amber-100">
+              Configure in Company Settings
+            </Link>
+          </p>
+          <button
+            type="button"
+            onClick={() => setClickUpWarnDismissed(true)}
+            className="shrink-0 text-amber-400 hover:text-amber-200 transition-colors"
+            aria-label="Dismiss warning"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <h1 className="text-xl font-semibold">Workflows</h1>


### PR DESCRIPTION
- Fix an issue where the `input()` monkey-patching did not work across all Python environments.
- Add workflow handoff to ClickUp. Whenever ADK Python code calls`input()`, it will instead send a message to ClickUp to fetch a message from humans from a reply.
- Workflow runs that failed should no longer submit deliverables.