### PR TITLE
docs: Build Log — Week of 2026-06-01

### DIFF
--- a/community/build-logs/2026-06-05-build-log.md
+++ b/community/build-logs/2026-06-05-build-log.md
@@ -1,0 +1,102 @@
+---
+title: "Bizbox Build Log — Week of 2026-06-01"
+slug: bizbox-build-log-2026-06-05
+date: 2026-06-05
+tags: [bizbox, build-in-public, changelog, devlog]
+canonical_url: https://github.com/zesthq/bizbox/blob/master/community/build-logs/2026-06-05-build-log.md
+cover_image: ""
+series: "Bizbox Build Log"
+channels: [devto, github-discussion, x, discourse]
+---
+
+# Bizbox Build Log — Week of 2026-06-01
+
+Four PRs merged (2026-06-01 through 2026-06-03), four releases shipped, CI at 13/17 green. The headline: Workflows land as a first-class Bizbox primitive — company-scoped, ADK-backed, with topological pipeline graphs, live console output, and human handoffs. Alongside that: a critical fix to Google ADK instruction parsing, suggested-task deduplication to prevent ghost child issues, and a CI stabilisation for headless e2e runs.
+
+*Release tags this week: v2026.601.0 (PRs #72, #74, #76, #84), v2026.602.0 (PRs #83, #88), v2026.602.1 (PR #87), v2026.603.0 (PR #86).*
+
+---
+
+## Shipped This Week
+
+### 🔁 Workflows: a new company-scoped primitive
+**PR [#86](https://github.com/zesthq/bizbox/pull/86) · @DennisDenuto · merged 2026-06-03 · v2026.603.0**
+
+The largest change this week introduces `Workflows` as a distinct Bizbox primitive, separate from issues and routines. A workflow is a multi-phase pipeline backed by Google ADK: it has a database record, run history, deliverables, and a UI that renders phases as a topological graph with live phase state and console output.
+
+Key additions under the hood:
+- New DB schema, API routes, and JWT-protected runtime callbacks for workflow runs.
+- ADK project analysis so the pipeline structure is inferred automatically and rendered as a graph.
+- Human handoff slots within a pipeline run — agents can pause and wait for operator input without blocking the whole workflow.
+- Mixed deliverable support: a single workflow run can surface structured data, documents, and raw console output side by side.
+- UI navigation, workflow detail/run views, and pipeline graph rendering.
+
+This is the first step toward long-running, multi-agent orchestration that doesn't fit neatly into the issue/heartbeat model.
+
+### 🐛 Google ADK: strip frontmatter from AGENTS.md instructions
+**PR [#87](https://github.com/zesthq/bizbox/pull/87) · @ralphbibera · merged 2026-06-02 · v2026.602.1**
+
+YAML frontmatter in `AGENTS.md` is used by Paperclip for metadata and discovery — but the Google ADK adapter was passing the raw file (frontmatter and all) as agent instructions. ADK treated the YAML block as part of the instruction text, which produced garbled prompts for ADK-backed agents. The fix strips frontmatter before forwarding instructions to the ADK runtime. Simple change, material impact on ADK agent behaviour.
+
+### 🔂 Suggested-task deduplication
+**PR [#88](https://github.com/zesthq/bizbox/pull/88) · @adPalafox · merged 2026-06-02 · v2026.602.0**
+
+Accepting the same `suggest_tasks` interaction bundle multiple times used to create duplicate child issues — each acceptance would open fresh tasks regardless of whether identical ones already existed. This PR fixes that with SHA-256 fingerprinting of suggested tasks: if a matching child issue (same title, description, status, priority, assignee, project, goal, billing code) already exists, the service reuses it instead of creating a duplicate. Blocker relationships are also preserved on reuse.
+
+The change adds `"suggested_task"` as an explicit `originKind` constant so the dedup path is unambiguous at the data layer.
+
+### 🧪 CI: headless Chrome on runner for e2e workflows
+**PR [#84](https://github.com/zesthq/bizbox/pull/84) · @ralphbibera · merged 2026-06-01 · v2026.601.0**
+
+E2e tests for headless control-plane workflows were timing out on CI. Root cause was browser bootstrap latency on the runner, not application logic. Switching to the runner's native Chrome instance (instead of downloading on every run) eliminates the cold-start delay. Green on the same test suites that were failing before.
+
+---
+
+## Decisions
+
+**Workflows are a primitive, not a plugin.** The team chose to build `Workflows` into the Bizbox data model (new DB tables, API routes, shared contracts) rather than modelling them as a layer on top of routines or issues. The reasoning: workflows need their own run lineage, deliverable surface, and pipeline graph that the existing primitives can't cleanly host. The trade-off is more surface area to maintain.
+
+**ADK pipeline structure inferred, not declared.** Rather than requiring operators to declare the pipeline graph upfront, PR #86 adds ADK project analysis so the phase structure is inferred from the ADK project definition at run time. This reduces operator configuration but means the graph is only as accurate as ADK's own project metadata.
+
+**Fingerprint-based deduplication over timestamp guards.** The team chose SHA-256 fingerprinting of the full task spec (not a simple title check or timestamp window) for suggested-task dedup. The stronger guarantee is worth the extra hashing overhead at issue-creation time.
+
+---
+
+## Trade-offs
+
+- **Workflows ship without end-to-end integration tests.** PR #86 includes server, shared, and UI unit tests plus local verification, but there is no automated test covering the full path: workflow create → ADK run → phase graph render → human handoff → deliverable surface. The Release pipeline also failed on the first push of this commit (run [#26858452717](https://github.com/zesthq/bizbox/actions/runs/26858452717)); a follow-up is needed to confirm the release surface is clean.
+- **Fingerprint deduplication is strict.** A suggested task that differs by even one field (e.g. priority bumped from `medium` to `high`) will create a new child issue rather than reusing the existing one. This is correct but may surprise operators who expected a looser match.
+- **v2026.601.0 bundles last week's untagged PRs.** PRs #72, #74, and #76 (all merged 2026-05-28) finally shipped in a tagged release this week. If you were waiting on a stable tag for the awaiting-human bridge or Google ADK adapter, v2026.601.0 is it.
+
+---
+
+## Open Challenges
+
+- **Workflow Release CI failure.** The Release workflow failed after PR #86 merged (run [#26858452717](https://github.com/zesthq/bizbox/actions/runs/26858452717)). This is worth an immediate investigation to confirm the release artefact is sound — or to cut a patch release if it isn't.
+- **Workflows end-to-end test gap.** The pipeline graph, human handoff, and deliverable surface are all new and not yet covered by automated integration tests. Given the complexity of the ADK execution path, this is a non-trivial reliability risk for early adopters.
+- **ClickUp bridge adapter (PR #78) still open.** The awaiting-human bridge infrastructure (PRs #74 and #76, now in v2026.601.0) is merged and tagged, but the ClickUp transport itself is still in review. The full approval loop — company settings → bridge core → ClickUp → human reply → agent wake — is not yet closed.
+
+---
+
+## X Thread Teaser
+
+> 🧵 Bizbox Build Log — Week of June 1, 2026
+>
+> 4 PRs merged, 4 releases shipped. Workflows land as a new Bizbox primitive — ADK-backed pipelines with graph rendering, human handoffs, and persisted deliverables. Plus two important fixes. Thread 👇
+
+> 1/ Workflows are here. A new company-scoped primitive: ADK pipeline runs with phase graphs, live console output, human handoffs, and mixed deliverables. Not an issue, not a routine — its own thing.
+> https://github.com/zesthq/bizbox/pull/86
+
+> 2/ Fix: Google ADK agents were getting YAML frontmatter in their instruction prompt. Now stripped before it reaches ADK. If your ADK agents were behaving strangely, this is likely why.
+> https://github.com/zesthq/bizbox/pull/87
+
+> 3/ Suggested-task dedup. Accepting the same task suggestion twice used to create duplicates. SHA-256 fingerprinting now reuses the existing child issue instead. Clean.
+> https://github.com/zesthq/bizbox/pull/88
+
+> 4/ Open challenge: the Release CI pipeline failed after the Workflows PR merged. Worth watching before shipping to production.
+>
+> Full build log: https://github.com/zesthq/bizbox/blob/master/community/build-logs/2026-06-05-build-log.md
+
+---
+
+*Grounded in merged PRs and releases from [zesthq/bizbox](https://github.com/zesthq/bizbox), 2026-06-01 to 2026-06-05. No activity was invented.*


### PR DESCRIPTION
## Build Log — Week of 2026-06-01

This PR adds the weekly Build Log draft at `community/build-logs/2026-06-05-build-log.md`.

**Headline:** Workflows land as a first-class Bizbox primitive — ADK-backed pipeline graphs, human handoffs, and persisted deliverables ship in v2026.603.0.

**Coverage:** 4 PRs merged (#84, #86, #87, #88), 4 releases (v2026.601.0 – v2026.603.0), CI 13/17 green.

**Notable items flagged for Dennis review:**
- Release CI pipeline failed after the Workflows PR (#86) merged — flagged as open challenge.
- Workflows ships without automated end-to-end integration tests — flagged as trade-off.

**Review chain:** Tech Reviewer → DevRel Lead → Dennis (`dennis-approved` label required for syndication)

Paperclip issue: CITAAAA-246