### PR TITLE
Improve workflow ClickUp handoff lifecycle

### DIFF
--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -324,6 +324,40 @@ describe("getClickUpChatMessageReplies", () => {
     });
   });
 
+  it("orders same-time replies by IDs beyond Number precision", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: "9007199254740993",
+            parent_message: "message-42",
+            content: "second",
+            links: { reactions: "https://example.test/reactions/second" },
+          },
+          {
+            id: "9007199254740992",
+            parent_message: "message-42",
+            content: "first",
+            links: { reactions: "https://example.test/reactions/first" },
+          },
+        ],
+      }),
+    }) as typeof fetch;
+
+    const result = await getClickUpChatMessageReplies("message-42");
+
+    expect(result.status).toBe("sent");
+    expect(result.replies.map((reply) => reply.id)).toEqual([
+      "9007199254740992",
+      "9007199254740993",
+    ]);
+  });
+
   it("aborts slow ClickUp reply polling requests", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -359,6 +359,66 @@ describe("getClickUpChatMessageReplies", () => {
     ]);
   });
 
+  it("paginates replies and orders them chronologically across all pages", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{
+            id: "reply-3",
+            parent_message: "message-42",
+            content: "third",
+            date: 3000,
+            links: { reactions: "https://example.test/reactions/third" },
+          }],
+          next_cursor: "cursor-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [
+            {
+              id: "reply-1",
+              parent_message: "message-42",
+              content: "first",
+              date: 1000,
+              links: { reactions: "https://example.test/reactions/first" },
+            },
+            {
+              id: "reply-2",
+              parent_message: "message-42",
+              content: "second",
+              date: 2000,
+              links: { reactions: "https://example.test/reactions/second" },
+            },
+          ],
+          next_cursor: null,
+        }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await getClickUpChatMessageReplies("message-42");
+
+    expect(result.status).toBe("sent");
+    expect(result.replies.map((reply) => reply.id)).toEqual(["reply-1", "reply-2", "reply-3"]);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/message-42/replies",
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/message-42/replies?cursor=cursor-1",
+      expect.anything(),
+    );
+  });
+
   it("aborts slow ClickUp reply polling requests", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
@@ -855,5 +915,102 @@ describe("detectClickUpAwaitingHumanBridgeEventsAfterMessage", () => {
         },
       }],
     });
+  });
+
+  it("detects a human answer on page 2 after a marker on page 1", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{
+            id: "question-reply-1",
+            parent_message: "thread-root-1",
+            content: "**Workflow input required**",
+            date: 1000,
+            links: { reactions: "https://example.test/reactions/question" },
+          }],
+          next_cursor: "cursor-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{
+            id: "human-reply-1",
+            parent_message: "thread-root-1",
+            content: "Celsius",
+            date: 2000,
+            links: { reactions: "https://example.test/reactions/answer" },
+          }],
+          next_cursor: null,
+        }),
+      }) as typeof fetch;
+
+    const result = await detectClickUpAwaitingHumanBridgeEventsAfterMessage(
+      "thread-root-1",
+      "question-reply-1",
+    );
+
+    expect(result.status).toBe("sent");
+    expect(result.detail).toBe("replies-detected");
+    expect(result.events.map((event) => event.externalEventId)).toEqual(["human-reply-1"]);
+  });
+
+  it("detects a marker on page 2 after older replies on page 1", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{
+            id: "previous-human-reply",
+            parent_message: "thread-root-1",
+            content: "Sydney",
+            date: 1000,
+            links: { reactions: "https://example.test/reactions/previous" },
+          }],
+          next_cursor: "cursor-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [
+            {
+              id: "question-reply-2",
+              parent_message: "thread-root-1",
+              content: "**Workflow input required**",
+              date: 2000,
+              links: { reactions: "https://example.test/reactions/question" },
+            },
+            {
+              id: "human-reply-2",
+              parent_message: "thread-root-1",
+              content: "Fahrenheit",
+              date: 3000,
+              links: { reactions: "https://example.test/reactions/answer" },
+            },
+          ],
+          next_cursor: null,
+        }),
+      }) as typeof fetch;
+
+    const result = await detectClickUpAwaitingHumanBridgeEventsAfterMessage(
+      "thread-root-1",
+      "question-reply-2",
+    );
+
+    expect(result.status).toBe("sent");
+    expect(result.detail).toBe("replies-detected");
+    expect(result.events.map((event) => event.externalEventId)).toEqual(["human-reply-2"]);
   });
 });

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -3,8 +3,10 @@ import {
   addClickUpChatMessageReaction,
   deleteClickUpChatMessageReaction,
   detectClickUpAwaitingHumanBridgeEvents,
+  detectClickUpAwaitingHumanBridgeEventsAfterMessage,
   getClickUpChatMessageReplies,
   sendAwaitingHumanNotification,
+  sendAwaitingHumanNotificationReply,
   uploadClickUpReviewFile,
 } from "../services/clickup-awaiting-human-transport.js";
 import { logger } from "../middleware/logger.js";
@@ -316,6 +318,7 @@ describe("getClickUpChatMessageReplies", () => {
           parentMessageId: "message-42",
           reactionsUrl: "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/reply-row-1/reactions",
           content: "approve",
+          dateMs: null,
         },
       ],
     });
@@ -431,6 +434,108 @@ describe("sendAwaitingHumanNotification review context", () => {
   });
 });
 
+describe("sendAwaitingHumanNotificationReply", () => {
+  it("posts a ClickUp chat reply under the workflow thread root", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ id: "question-reply-1" }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotificationReply("thread-root-1", {
+      companyId: "company-1",
+      issueId: "handoff-1",
+      handoffKind: "ask_user_questions",
+      notification: {
+        title: "Workflow input required",
+        summary: "Which city?",
+        body: "Which city should I check?",
+        link: "",
+        cta: "Reply with your response.",
+        labels: ["workflow_handoff", "response"],
+      },
+    });
+
+    expect(result).toEqual({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId: "question-reply-1",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/thread-root-1/replies",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "token-123",
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      type: "message",
+      content: "**Workflow input required**\n\nWhich city should I check?\n\nReply with your response.",
+      content_format: "text/md",
+    });
+  });
+
+  it("keeps long workflow approval replies intact instead of applying the short channel-message cap", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const longApprovalBody = [
+      "# Landing Page Approval Required",
+      "",
+      "## Slug",
+      "",
+      "- `adk-bizbox-human-gate-smoke-1780911620717` (new)",
+      "",
+      "## Section Order",
+      "",
+      ...Array.from({ length: 35 }, (_, index) =>
+        `- Section ${index + 1}: This line should remain visible in the ClickUp thread reply so the human can review the complete workflow approval context before replying.`,
+      ),
+      "",
+      "## Final Decision",
+      "",
+      "Please approve or reject this landing page plan.",
+    ].join("\n");
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ id: "question-reply-1" }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotificationReply("thread-root-1", {
+      companyId: "company-1",
+      issueId: "handoff-1",
+      handoffKind: "approval",
+      notification: {
+        title: "Workflow approval required",
+        summary: "Landing page approval required",
+        body: longApprovalBody,
+        link: "",
+        cta: "Reply with: approve or reject (optionally include a note).",
+        labels: ["workflow_handoff", "approval"],
+      },
+    });
+
+    expect(result.status).toBe("sent");
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.content.length).toBeGreaterThan(1_800);
+    expect(body.content).toContain("Section 35");
+    expect(body.content).toContain("Please approve or reject this landing page plan.");
+    expect(body.content).toContain("Reply with: approve or reject");
+    expect(body.content).not.toMatch(/…$/);
+  });
+});
+
 describe("detectClickUpAwaitingHumanBridgeEvents", () => {
   it("skips replies without stable reply ids and logs a warning", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
@@ -473,6 +578,7 @@ describe("detectClickUpAwaitingHumanBridgeEvents", () => {
           parentMessageId: "message-42",
           reactionsUrl: "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/reply-unknown-1/reactions",
           content: "First reply",
+          dateMs: null,
         },
       },
       "Skipping ClickUp reply without stable reply.id",
@@ -510,6 +616,145 @@ describe("detectClickUpAwaitingHumanBridgeEvents", () => {
         externalMessageId: "message-42",
         body: "Reject",
         metadata: { clickupReplyId: "reply-1" },
+      }],
+    });
+  });
+});
+
+describe("detectClickUpAwaitingHumanBridgeEventsAfterMessage", () => {
+  it("returns only replies after the current bot question marker", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: "previous-human-reply",
+            parent_message: "thread-root-1",
+            content: "Melbourne",
+            date: 1000,
+            links: { reactions: "https://example.test/reactions/previous" },
+          },
+          {
+            id: "question-reply-2",
+            parent_message: "thread-root-1",
+            content: "Which unit?",
+            date: 2000,
+            links: { reactions: "https://example.test/reactions/question" },
+          },
+          {
+            id: "human-reply-2",
+            parent_message: "thread-root-1",
+            content: "Celsius",
+            date: 3000,
+            links: { reactions: "https://example.test/reactions/answer" },
+          },
+        ],
+      }),
+    }) as typeof fetch;
+
+    const result = await detectClickUpAwaitingHumanBridgeEventsAfterMessage(
+      "thread-root-1",
+      "question-reply-2",
+    );
+
+    expect(result).toEqual({
+      status: "sent",
+      detail: "replies-detected",
+      events: [{
+        kind: "reply",
+        externalEventId: "human-reply-2",
+        externalThreadId: "thread-root-1",
+        externalMessageId: "question-reply-2",
+        body: "Celsius",
+        metadata: {
+          clickupReplyId: "human-reply-2",
+          clickupThreadId: "thread-root-1",
+          clickupQuestionMessageId: "question-reply-2",
+        },
+      }],
+    });
+  });
+
+  it("does not accept replies when the bot question marker is missing", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{
+          id: "human-reply-1",
+          parent_message: "thread-root-1",
+          content: "Sydney",
+          date: 3000,
+          links: { reactions: "https://example.test/reactions/answer" },
+        }],
+      }),
+    }) as typeof fetch;
+
+    const result = await detectClickUpAwaitingHumanBridgeEventsAfterMessage(
+      "thread-root-1",
+      "question-reply-1",
+    );
+
+    expect(result).toEqual({
+      status: "sent",
+      detail: "question-marker-not-found",
+      events: [],
+    });
+  });
+
+  it("normalizes ClickUp newest-first replies before applying the question marker", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: "80160041502274",
+            parent_message: "80160041502221",
+            content: "Ankara Turkey",
+            date: 1780920048301,
+            links: { reactions: "https://example.test/reactions/answer" },
+          },
+          {
+            id: "80160041502222",
+            parent_message: "80160041502221",
+            content: "**Workflow input required**",
+            date: 1780920031891,
+            links: { reactions: "https://example.test/reactions/question" },
+          },
+        ],
+      }),
+    }) as typeof fetch;
+
+    const result = await detectClickUpAwaitingHumanBridgeEventsAfterMessage(
+      "80160041502221",
+      "80160041502222",
+    );
+
+    expect(result).toEqual({
+      status: "sent",
+      detail: "replies-detected",
+      events: [{
+        kind: "reply",
+        externalEventId: "80160041502274",
+        externalThreadId: "80160041502221",
+        externalMessageId: "80160041502222",
+        body: "Ankara Turkey",
+        metadata: {
+          clickupReplyId: "80160041502274",
+          clickupThreadId: "80160041502221",
+          clickupQuestionMessageId: "80160041502222",
+        },
       }],
     });
   });

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -703,7 +703,7 @@ describe("detectClickUpAwaitingHumanBridgeEventsAfterMessage", () => {
     );
 
     expect(result).toEqual({
-      status: "sent",
+      status: "failed",
       detail: "question-marker-not-found",
       events: [],
     });

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -179,6 +179,8 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     const result = await workflowHandoffBridgeService(db).pollActiveBridges();
 
     expect(result.checked).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.terminalClosed).toBe(1);
     expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
       "reply-1",
       "x",
@@ -226,6 +228,8 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     const result = await workflowHandoffBridgeService(db).pollActiveBridges();
 
     expect(result.checked).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.terminalClosed).toBe(1);
     expect(mocks.deleteClickUpChatMessageReaction).toHaveBeenCalledWith(
       "message-1",
       "brain_is_thinking",
@@ -240,6 +244,64 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
     expect(bridge?.status).toBe("closed");
     expect(bridge?.closeOutcome).toBe("expired");
+    expect(bridge?.nextPollAt).toBeNull();
+  });
+
+  it("rejects replies if the workflow becomes terminal after polling", async () => {
+    const { runId, handoffId, bridgeId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "awaiting_human",
+      runError: null,
+    });
+
+    mocks.detectClickUpAwaitingHumanBridgeEvents.mockImplementationOnce(async () => {
+      await db.update(workflowRuns).set({
+        status: "failed",
+        error: "Tool failed",
+        finishedAt: new Date(),
+        updatedAt: new Date(),
+      }).where(eq(workflowRuns.id, runId));
+      return {
+        status: "sent",
+        detail: "ok",
+        events: [{
+          kind: "reply",
+          externalEventId: "reply-1",
+          externalMessageId: "message-1",
+          body: "yes",
+          metadata: { clickupReplyId: "reply-1" },
+        }],
+      };
+    });
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.checked).toBe(1);
+    expect(result.resolved).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.terminalClosed).toBe(1);
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "reply-1",
+      "x",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "message-1",
+      "x",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "white_check_mark",
+      expect.anything(),
+    );
+
+    const [handoff] = await db.select().from(workflowHandoffs).where(eq(workflowHandoffs.id, handoffId));
+    expect(handoff?.status).toBe("cancelled");
+    expect(handoff?.responseMarkdown).toBeNull();
+
+    const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
+    expect(bridge?.status).toBe("closed");
+    expect(bridge?.closeOutcome).toBe("failed");
     expect(bridge?.nextPollAt).toBeNull();
   });
 });

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -1,0 +1,245 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  companies,
+  createDb,
+  workflowHandoffBridges,
+  workflowHandoffs,
+  workflowRunPhases,
+  workflowRuns,
+  workflows,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mocks = vi.hoisted(() => ({
+  addClickUpChatMessageReaction: vi.fn(async () => ({
+    status: "sent",
+    detail: "sent",
+  })),
+  deleteClickUpChatMessageReaction: vi.fn(async () => ({
+    status: "sent",
+    detail: "deleted",
+  })),
+  detectClickUpAwaitingHumanBridgeEvents: vi.fn(),
+  sendAwaitingHumanNotification: vi.fn(),
+  logActivity: vi.fn(async () => {}),
+}));
+
+vi.mock("../services/clickup-awaiting-human-transport.js", () => ({
+  addClickUpChatMessageReaction: mocks.addClickUpChatMessageReaction,
+  deleteClickUpChatMessageReaction: mocks.deleteClickUpChatMessageReaction,
+  detectClickUpAwaitingHumanBridgeEvents: mocks.detectClickUpAwaitingHumanBridgeEvents,
+  sendAwaitingHumanNotification: mocks.sendAwaitingHumanNotification,
+}));
+
+vi.mock("../services/awaiting-human-settings.js", () => ({
+  awaitingHumanSettingsService: () => ({
+    resolveClickUpRuntimeConfig: async () => ({
+      enabled: true,
+      provider: "clickup",
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-1",
+      attachmentTaskId: "task-sink-1",
+    }),
+  }),
+}));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mocks.logActivity,
+}));
+
+const { workflowHandoffBridgeService } = await import("../services/workflow-handoff-bridge.js");
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres workflow handoff bridge tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function insertWaitingWorkflowBridge(
+  db: ReturnType<typeof createDb>,
+  input: { runStatus: string; runError: string | null },
+) {
+  const companyId = randomUUID();
+  const workflowId = randomUUID();
+  const runId = randomUUID();
+  const phaseId = randomUUID();
+  const handoffId = randomUUID();
+  const bridgeId = randomUUID();
+
+  await db.insert(companies).values({
+    id: companyId,
+    name: "Paperclip",
+    issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+    requireBoardApprovalForNewAgents: false,
+  });
+  await db.insert(workflows).values({
+    id: workflowId,
+    companyId,
+    title: "Weather Lookup",
+    status: "active",
+    runnerType: "google_adk",
+    runnerConfig: { agentPath: "/tmp/agent.py" },
+    pipelineDefinition: { entrypoint: "agent.py", generatedAt: new Date(0).toISOString(), phases: [] },
+    pipelineSourceHash: null,
+  });
+  await db.insert(workflowRuns).values({
+    id: runId,
+    companyId,
+    workflowId,
+    status: input.runStatus,
+    inputMarkdown: "weather",
+    error: input.runError,
+  });
+  await db.insert(workflowRunPhases).values({
+    id: phaseId,
+    companyId,
+    workflowRunId: runId,
+    phaseKey: "phase-1",
+    label: "Phase 1",
+    kind: "phase",
+    ordinal: 0,
+    status: "awaiting_human",
+  });
+  await db.insert(workflowHandoffs).values({
+    id: handoffId,
+    companyId,
+    workflowRunId: runId,
+    phaseKey: "phase-1",
+    kind: "approval",
+    status: "pending",
+    promptMarkdown: "Approve Manila?",
+  });
+  await db.insert(workflowHandoffBridges).values({
+    id: bridgeId,
+    companyId,
+    workflowRunId: runId,
+    workflowHandoffId: handoffId,
+    provider: "clickup",
+    status: "waiting_for_human",
+    externalMessageId: "message-1",
+    nextPollAt: new Date(0),
+  });
+
+  return { runId, phaseId, handoffId, bridgeId };
+}
+
+describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workflow-handoff-bridge-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await db.delete(workflowHandoffBridges);
+    await db.delete(workflowHandoffs);
+    await db.delete(workflowRunPhases);
+    await db.delete(workflowRuns);
+    await db.delete(workflows);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("closes terminal run bridges without accepting late replies", async () => {
+    const { runId, phaseId, handoffId, bridgeId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "failed",
+      runError: "Tool failed",
+    });
+
+    mocks.detectClickUpAwaitingHumanBridgeEvents.mockResolvedValueOnce({
+      status: "sent",
+      detail: "ok",
+      events: [{
+        kind: "reply",
+        externalEventId: "reply-1",
+        externalMessageId: "message-1",
+        body: "yes",
+        metadata: { clickupReplyId: "reply-1" },
+      }],
+    });
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.checked).toBe(1);
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "reply-1",
+      "x",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "message-1",
+      "x",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "white_check_mark",
+      expect.anything(),
+    );
+
+    const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
+    expect(bridge?.status).toBe("closed");
+    expect(bridge?.closeOutcome).toBe("failed");
+    expect(bridge?.nextPollAt).toBeNull();
+
+    const [handoff] = await db.select().from(workflowHandoffs).where(eq(workflowHandoffs.id, handoffId));
+    expect(handoff?.status).toBe("cancelled");
+    expect(handoff?.responseMarkdown).toBeNull();
+
+    const [run] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, runId));
+    expect(run?.status).toBe("failed");
+
+    const [phase] = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.id, phaseId));
+    expect(phase?.status).toBe("awaiting_human");
+  });
+
+  it("closes timed out terminal bridges as expired and stops polling", async () => {
+    const { bridgeId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "failed",
+      runError: "Timed out after 86400s",
+    });
+
+    mocks.detectClickUpAwaitingHumanBridgeEvents.mockResolvedValueOnce({
+      status: "sent",
+      detail: "ok",
+      events: [],
+    });
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.checked).toBe(1);
+    expect(mocks.deleteClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "message-1",
+      "brain_is_thinking",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "message-1",
+      "x",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+
+    const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
+    expect(bridge?.status).toBe("closed");
+    expect(bridge?.closeOutcome).toBe("expired");
+    expect(bridge?.nextPollAt).toBeNull();
+  });
+});

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -25,7 +25,9 @@ const mocks = vi.hoisted(() => ({
     detail: "deleted",
   })),
   detectClickUpAwaitingHumanBridgeEvents: vi.fn(),
+  detectClickUpAwaitingHumanBridgeEventsAfterMessage: vi.fn(),
   sendAwaitingHumanNotification: vi.fn(),
+  sendAwaitingHumanNotificationReply: vi.fn(),
   logActivity: vi.fn(async () => {}),
 }));
 
@@ -33,7 +35,9 @@ vi.mock("../services/clickup-awaiting-human-transport.js", () => ({
   addClickUpChatMessageReaction: mocks.addClickUpChatMessageReaction,
   deleteClickUpChatMessageReaction: mocks.deleteClickUpChatMessageReaction,
   detectClickUpAwaitingHumanBridgeEvents: mocks.detectClickUpAwaitingHumanBridgeEvents,
+  detectClickUpAwaitingHumanBridgeEventsAfterMessage: mocks.detectClickUpAwaitingHumanBridgeEventsAfterMessage,
   sendAwaitingHumanNotification: mocks.sendAwaitingHumanNotification,
+  sendAwaitingHumanNotificationReply: mocks.sendAwaitingHumanNotificationReply,
 }));
 
 vi.mock("../services/awaiting-human-settings.js", () => ({
@@ -64,16 +68,15 @@ if (!embeddedPostgresSupport.supported) {
   );
 }
 
-async function insertWaitingWorkflowBridge(
+async function insertWorkflowHandoff(
   db: ReturnType<typeof createDb>,
-  input: { runStatus: string; runError: string | null },
+  input: { runStatus: string; runError: string | null; promptMarkdown?: string },
 ) {
   const companyId = randomUUID();
   const workflowId = randomUUID();
   const runId = randomUUID();
   const phaseId = randomUUID();
   const handoffId = randomUUID();
-  const bridgeId = randomUUID();
 
   await db.insert(companies).values({
     id: companyId,
@@ -116,20 +119,37 @@ async function insertWaitingWorkflowBridge(
     phaseKey: "phase-1",
     kind: "approval",
     status: "pending",
-    promptMarkdown: "Approve Manila?",
+    promptMarkdown: input.promptMarkdown ?? "Approve Manila?",
   });
+
+  return { companyId, workflowId, runId, phaseId, handoffId };
+}
+
+async function insertWaitingWorkflowBridge(
+  db: ReturnType<typeof createDb>,
+  input: {
+    runStatus: string;
+    runError: string | null;
+    externalThreadId?: string | null;
+    externalMessageId?: string;
+  },
+) {
+  const base = await insertWorkflowHandoff(db, input);
+  const bridgeId = randomUUID();
+
   await db.insert(workflowHandoffBridges).values({
     id: bridgeId,
-    companyId,
-    workflowRunId: runId,
-    workflowHandoffId: handoffId,
+    companyId: base.companyId,
+    workflowRunId: base.runId,
+    workflowHandoffId: base.handoffId,
     provider: "clickup",
     status: "waiting_for_human",
-    externalMessageId: "message-1",
+    externalMessageId: input.externalMessageId ?? "message-1",
+    externalThreadId: input.externalThreadId ?? null,
     nextPollAt: new Date(0),
   });
 
-  return { runId, phaseId, handoffId, bridgeId };
+  return { ...base, bridgeId };
 }
 
 describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
@@ -158,6 +178,155 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     await tempDb?.cleanup();
   });
 
+  it("creates a workflow thread root and posts the first handoff as a reply", async () => {
+    const { companyId, runId, handoffId } = await insertWorkflowHandoff(db, {
+      runStatus: "awaiting_human",
+      runError: null,
+      promptMarkdown: "Which city should I check?",
+    });
+    mocks.sendAwaitingHumanNotification.mockResolvedValueOnce({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId: "thread-root-1",
+    });
+    mocks.sendAwaitingHumanNotificationReply.mockResolvedValueOnce({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId: "question-reply-1",
+    });
+
+    const bridge = await workflowHandoffBridgeService(db).openForHandoff({
+      id: handoffId,
+      companyId,
+      workflowRunId: runId,
+      kind: "response",
+      promptMarkdown: "Which city should I check?",
+    });
+
+    expect(mocks.sendAwaitingHumanNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendAwaitingHumanNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notification: expect.objectContaining({
+          title: "Workflow handoff: Weather Lookup",
+          body: expect.stringContaining("Workflow: Weather Lookup"),
+        }),
+      }),
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.sendAwaitingHumanNotificationReply).toHaveBeenCalledWith(
+      "thread-root-1",
+      expect.objectContaining({
+        notification: expect.objectContaining({
+          body: "Which city should I check?",
+        }),
+      }),
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(bridge?.externalThreadId).toBe("thread-root-1");
+    expect(bridge?.externalMessageId).toBe("question-reply-1");
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "question-reply-1",
+      "brain_is_thinking",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+  });
+
+  it("reuses the existing workflow thread for later handoffs in the same run", async () => {
+    const first = await insertWorkflowHandoff(db, {
+      runStatus: "awaiting_human",
+      runError: null,
+    });
+    await db.insert(workflowHandoffBridges).values({
+      id: randomUUID(),
+      companyId: first.companyId,
+      workflowRunId: first.runId,
+      workflowHandoffId: first.handoffId,
+      provider: "clickup",
+      status: "closed",
+      closeOutcome: "responded",
+      externalThreadId: "thread-root-1",
+      externalMessageId: "question-reply-1",
+      closedAt: new Date(),
+    });
+    const secondHandoffId = randomUUID();
+    await db.insert(workflowHandoffs).values({
+      id: secondHandoffId,
+      companyId: first.companyId,
+      workflowRunId: first.runId,
+      phaseKey: "phase-1",
+      kind: "response",
+      status: "pending",
+      promptMarkdown: "Celsius or Fahrenheit?",
+    });
+    mocks.sendAwaitingHumanNotificationReply.mockResolvedValueOnce({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId: "question-reply-2",
+    });
+
+    const bridge = await workflowHandoffBridgeService(db).openForHandoff({
+      id: secondHandoffId,
+      companyId: first.companyId,
+      workflowRunId: first.runId,
+      kind: "response",
+      promptMarkdown: "Celsius or Fahrenheit?",
+    });
+
+    expect(mocks.sendAwaitingHumanNotification).not.toHaveBeenCalled();
+    expect(mocks.sendAwaitingHumanNotificationReply).toHaveBeenCalledWith(
+      "thread-root-1",
+      expect.anything(),
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(bridge?.externalThreadId).toBe("thread-root-1");
+    expect(bridge?.externalMessageId).toBe("question-reply-2");
+  });
+
+  it("polls threaded bridges from the workflow root and resolves replies after the question marker", async () => {
+    const { runId, bridgeId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "awaiting_human",
+      runError: null,
+      externalThreadId: "thread-root-1",
+      externalMessageId: "question-reply-1",
+    });
+    mocks.detectClickUpAwaitingHumanBridgeEventsAfterMessage.mockResolvedValueOnce({
+      status: "sent",
+      detail: "replies-detected",
+      events: [{
+        kind: "reply",
+        externalEventId: "human-reply-1",
+        externalThreadId: "thread-root-1",
+        externalMessageId: "question-reply-1",
+        body: "Sydney",
+        metadata: { clickupReplyId: "human-reply-1" },
+      }],
+    });
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.resolved).toBe(1);
+    expect(mocks.detectClickUpAwaitingHumanBridgeEventsAfterMessage).toHaveBeenCalledWith(
+      "thread-root-1",
+      "question-reply-1",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.detectClickUpAwaitingHumanBridgeEvents).not.toHaveBeenCalled();
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "human-reply-1",
+      "white_check_mark",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+
+    const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
+    expect(bridge?.status).toBe("closed");
+    expect(bridge?.closeOutcome).toBe("responded");
+    const [run] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, runId));
+    expect(run?.status).toBe("running");
+  });
+
   it("closes terminal run bridges without accepting late replies", async () => {
     const { runId, phaseId, handoffId, bridgeId } = await insertWaitingWorkflowBridge(db, {
       runStatus: "failed",
@@ -179,6 +348,11 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     const result = await workflowHandoffBridgeService(db).pollActiveBridges();
 
     expect(result.checked).toBe(1);
+    expect(mocks.detectClickUpAwaitingHumanBridgeEvents).toHaveBeenCalledWith(
+      "message-1",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.detectClickUpAwaitingHumanBridgeEventsAfterMessage).not.toHaveBeenCalled();
     expect(result.failed).toBe(0);
     expect(result.terminalClosed).toBe(1);
     expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -512,7 +512,7 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     expect(secondBridge?.status).toBe("closed");
   });
 
-  it("rejects replies if the workflow becomes terminal after polling", async () => {
+  it("rejects replies if the workflow becomes terminal after polling even when closure logging fails", async () => {
     const { runId, handoffId, bridgeId } = await insertWaitingWorkflowBridge(db, {
       runStatus: "awaiting_human",
       runError: null,
@@ -537,6 +537,7 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
         }],
       };
     });
+    mocks.logActivity.mockRejectedValueOnce(new Error("activity log unavailable"));
 
     const result = await workflowHandoffBridgeService(db).pollActiveBridges();
 
@@ -559,6 +560,10 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
       "white_check_mark",
       expect.anything(),
     );
+    expect(mocks.logActivity).toHaveBeenCalledTimes(1);
+    expect(mocks.logActivity).toHaveBeenCalledWith(db, expect.objectContaining({
+      action: "workflow.handoff.bridge_closed_terminal",
+    }));
 
     const [handoff] = await db.select().from(workflowHandoffs).where(eq(workflowHandoffs.id, handoffId));
     expect(handoff?.status).toBe("cancelled");

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -524,6 +524,61 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     expect(bridge?.nextPollAt).toBeNull();
   });
 
+  it("closes terminal succeeded bridges with accepted outcome when handoff is already resolved", async () => {
+    const { bridgeId, handoffId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "succeeded",
+      runError: null,
+    });
+    await db.update(workflowHandoffs).set({
+      status: "approved",
+      responseMarkdown: "Looks good",
+      decidedByUserId: "clickup_bridge",
+      decidedAt: new Date(),
+      updatedAt: new Date(),
+    }).where(eq(workflowHandoffs.id, handoffId));
+
+    mocks.detectClickUpAwaitingHumanBridgeEvents.mockResolvedValueOnce({
+      status: "sent",
+      detail: "ok",
+      events: [{
+        kind: "approval_signal",
+        externalEventId: "reply-1",
+        externalMessageId: "message-1",
+        body: "approve",
+        metadata: { clickupReplyId: "reply-1" },
+      }],
+    });
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.checked).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.terminalClosed).toBe(1);
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "reply-1",
+      "white_check_mark",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "message-1",
+      "white_check_mark",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "x",
+      expect.anything(),
+    );
+
+    const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
+    expect(bridge?.status).toBe("closed");
+    expect(bridge?.closeOutcome).toBe("approved");
+
+    const [handoff] = await db.select().from(workflowHandoffs).where(eq(workflowHandoffs.id, handoffId));
+    expect(handoff?.status).toBe("approved");
+    expect(handoff?.responseMarkdown).toBe("Looks good");
+  });
+
   it("closes terminal threaded bridges even when the question marker cannot be found", async () => {
     const { bridgeId } = await insertWaitingWorkflowBridge(db, {
       runStatus: "failed",

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -247,6 +247,35 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     expect(bridge?.nextPollAt).toBeNull();
   });
 
+  it("continues polling terminal bridges when terminal cleanup logging fails", async () => {
+    const first = await insertWaitingWorkflowBridge(db, {
+      runStatus: "failed",
+      runError: "Tool failed",
+    });
+    const second = await insertWaitingWorkflowBridge(db, {
+      runStatus: "failed",
+      runError: "Tool failed",
+    });
+
+    mocks.detectClickUpAwaitingHumanBridgeEvents.mockResolvedValue({
+      status: "sent",
+      detail: "ok",
+      events: [],
+    });
+    mocks.logActivity.mockRejectedValueOnce(new Error("activity log unavailable"));
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.checked).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.terminalClosed).toBe(2);
+
+    const [firstBridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, first.bridgeId));
+    const [secondBridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, second.bridgeId));
+    expect(firstBridge?.status).toBe("closed");
+    expect(secondBridge?.status).toBe("closed");
+  });
+
   it("rejects replies if the workflow becomes terminal after polling", async () => {
     const { runId, handoffId, bridgeId } = await insertWaitingWorkflowBridge(db, {
       runStatus: "awaiting_human",

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -247,6 +247,30 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     expect(bridge?.nextPollAt).toBeNull();
   });
 
+  it("closes active bridges after direct handoff resolution", async () => {
+    const { bridgeId, handoffId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "running",
+      runError: null,
+    });
+
+    const bridge = await workflowHandoffBridgeService(db).closeResolvedHandoff(handoffId, "approved");
+
+    expect(bridge?.id).toBe(bridgeId);
+    expect(bridge?.status).toBe("closed");
+    expect(bridge?.closeOutcome).toBe("approved");
+    expect(bridge?.nextPollAt).toBeNull();
+    expect(mocks.deleteClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "message-1",
+      "brain_is_thinking",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "message-1",
+      "white_check_mark",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+  });
+
   it("continues polling terminal bridges when terminal cleanup logging fails", async () => {
     const first = await insertWaitingWorkflowBridge(db, {
       runStatus: "failed",

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -233,6 +233,47 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     );
   });
 
+  it("keeps an opened bridge when open activity logging fails", async () => {
+    const { companyId, runId, handoffId } = await insertWorkflowHandoff(db, {
+      runStatus: "awaiting_human",
+      runError: null,
+      promptMarkdown: "Which city should I check?",
+    });
+    mocks.sendAwaitingHumanNotification.mockResolvedValueOnce({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId: "thread-root-1",
+    });
+    mocks.sendAwaitingHumanNotificationReply.mockResolvedValueOnce({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId: "question-reply-1",
+    });
+    mocks.logActivity.mockRejectedValueOnce(new Error("activity log unavailable"));
+
+    const bridge = await workflowHandoffBridgeService(db).openForHandoff({
+      id: handoffId,
+      companyId,
+      workflowRunId: runId,
+      kind: "response",
+      promptMarkdown: "Which city should I check?",
+    });
+
+    expect(bridge).not.toBeNull();
+    expect(bridge?.status).toBe("waiting_for_human");
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "question-reply-1",
+      "brain_is_thinking",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.logActivity).toHaveBeenCalledTimes(1);
+
+    const [persistedBridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridge!.id));
+    expect(persistedBridge?.status).toBe("waiting_for_human");
+  });
+
   it("reuses the existing workflow thread for later handoffs in the same run", async () => {
     const first = await insertWorkflowHandoff(db, {
       runStatus: "awaiting_human",

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -524,6 +524,44 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     expect(bridge?.nextPollAt).toBeNull();
   });
 
+  it("closes terminal threaded bridges even when the question marker cannot be found", async () => {
+    const { bridgeId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "failed",
+      runError: "Tool failed",
+      externalThreadId: "thread-root-1",
+      externalMessageId: "question-reply-1",
+    });
+
+    mocks.detectClickUpAwaitingHumanBridgeEventsAfterMessage.mockResolvedValueOnce({
+      status: "failed",
+      detail: "question-marker-not-found",
+      events: [],
+    });
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.checked).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.terminalClosed).toBe(1);
+    expect(mocks.detectClickUpAwaitingHumanBridgeEventsAfterMessage).toHaveBeenCalledWith(
+      "thread-root-1",
+      "question-reply-1",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledTimes(1);
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "question-reply-1",
+      "x",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+
+    const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
+    expect(bridge?.status).toBe("closed");
+    expect(bridge?.closeOutcome).toBe("failed");
+    expect(bridge?.lastError).toBe("question-marker-not-found");
+    expect(bridge?.nextPollAt).toBeNull();
+  });
+
   it("closes active bridges after direct handoff resolution", async () => {
     const { bridgeId, handoffId } = await insertWaitingWorkflowBridge(db, {
       runStatus: "running",

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -327,6 +327,30 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     expect(run?.status).toBe("running");
   });
 
+  it("records missing threaded question markers as poll failures", async () => {
+    const { bridgeId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "awaiting_human",
+      runError: null,
+      externalThreadId: "thread-root-1",
+      externalMessageId: "question-reply-1",
+    });
+    mocks.detectClickUpAwaitingHumanBridgeEventsAfterMessage.mockResolvedValueOnce({
+      status: "failed",
+      detail: "question-marker-not-found",
+      events: [],
+    });
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.failed).toBe(1);
+    expect(result.noSignal).toBe(0);
+
+    const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
+    expect(bridge?.status).toBe("waiting_for_human");
+    expect(bridge?.lastError).toBe("question-marker-not-found");
+    expect(bridge?.nextPollAt?.getTime()).toBeGreaterThan(Date.now());
+  });
+
   it("still resolves accepted replies when resolution activity logging fails", async () => {
     const { runId, bridgeId } = await insertWaitingWorkflowBridge(db, {
       runStatus: "awaiting_human",
@@ -510,6 +534,37 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     const [secondBridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, second.bridgeId));
     expect(firstBridge?.status).toBe("closed");
     expect(secondBridge?.status).toBe("closed");
+  });
+
+  it("continues polling active bridges when poll-failure logging fails", async () => {
+    const first = await insertWaitingWorkflowBridge(db, {
+      runStatus: "awaiting_human",
+      runError: null,
+    });
+    const second = await insertWaitingWorkflowBridge(db, {
+      runStatus: "awaiting_human",
+      runError: null,
+    });
+
+    mocks.detectClickUpAwaitingHumanBridgeEvents
+      .mockRejectedValueOnce(new Error("ClickUp timeout"))
+      .mockResolvedValueOnce({
+        status: "sent",
+        detail: "no-replies",
+        events: [],
+      });
+    mocks.logActivity.mockRejectedValueOnce(new Error("activity log unavailable"));
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.checked).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.noSignal).toBe(1);
+
+    const [firstBridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, first.bridgeId));
+    const [secondBridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, second.bridgeId));
+    expect(firstBridge?.lastError).toBe("ClickUp timeout");
+    expect(secondBridge?.lastError).toBeNull();
   });
 
   it("rejects replies if the workflow becomes terminal after polling even when closure logging fails", async () => {

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -327,6 +327,44 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     expect(run?.status).toBe("running");
   });
 
+  it("still resolves accepted replies when resolution activity logging fails", async () => {
+    const { runId, bridgeId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "awaiting_human",
+      runError: null,
+      externalThreadId: "thread-root-1",
+      externalMessageId: "question-reply-1",
+    });
+    mocks.detectClickUpAwaitingHumanBridgeEventsAfterMessage.mockResolvedValueOnce({
+      status: "sent",
+      detail: "replies-detected",
+      events: [{
+        kind: "reply",
+        externalEventId: "human-reply-1",
+        externalThreadId: "thread-root-1",
+        externalMessageId: "question-reply-1",
+        body: "Sydney",
+        metadata: { clickupReplyId: "human-reply-1" },
+      }],
+    });
+    mocks.logActivity.mockRejectedValueOnce(new Error("activity log unavailable"));
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.resolved).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "human-reply-1",
+      "white_check_mark",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+
+    const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
+    expect(bridge?.status).toBe("closed");
+    expect(bridge?.closeOutcome).toBe("responded");
+    const [run] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, runId));
+    expect(run?.status).toBe("running");
+  });
+
   it("closes terminal run bridges without accepting late replies", async () => {
     const { runId, phaseId, handoffId, bridgeId } = await insertWaitingWorkflowBridge(db, {
       runStatus: "failed",

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -507,6 +507,60 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     );
   });
 
+  it("closes stale accepted bridges with accepted reactions", async () => {
+    const { bridgeId, handoffId } = await insertWaitingWorkflowBridge(db, {
+      runStatus: "running",
+      runError: null,
+    });
+    await db.update(workflowHandoffs).set({
+      status: "approved",
+      responseMarkdown: "Looks good",
+      decidedByUserId: "clickup_bridge",
+      decidedAt: new Date(),
+      updatedAt: new Date(),
+    }).where(eq(workflowHandoffs.id, handoffId));
+
+    mocks.detectClickUpAwaitingHumanBridgeEvents.mockResolvedValueOnce({
+      status: "sent",
+      detail: "ok",
+      events: [{
+        kind: "approval_signal",
+        externalEventId: "reply-1",
+        externalMessageId: "message-1",
+        body: "approve",
+        metadata: { clickupReplyId: "reply-1" },
+      }],
+    });
+
+    const result = await workflowHandoffBridgeService(db).pollActiveBridges();
+
+    expect(result.resolved).toBe(1);
+    expect(result.terminalClosed).toBe(0);
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "reply-1",
+      "white_check_mark",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).toHaveBeenCalledWith(
+      "message-1",
+      "white_check_mark",
+      expect.objectContaining({ personalToken: "token-123" }),
+    );
+    expect(mocks.addClickUpChatMessageReaction).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "x",
+      expect.anything(),
+    );
+
+    const [bridge] = await db.select().from(workflowHandoffBridges).where(eq(workflowHandoffBridges.id, bridgeId));
+    expect(bridge?.status).toBe("closed");
+    expect(bridge?.closeOutcome).toBe("approved");
+
+    const [handoff] = await db.select().from(workflowHandoffs).where(eq(workflowHandoffs.id, handoffId));
+    expect(handoff?.status).toBe("approved");
+    expect(handoff?.responseMarkdown).toBe("Looks good");
+  });
+
   it("continues polling terminal bridges when terminal cleanup logging fails", async () => {
     const first = await insertWaitingWorkflowBridge(db, {
       runStatus: "failed",

--- a/server/src/__tests__/workflow-service-run-manual.test.ts
+++ b/server/src/__tests__/workflow-service-run-manual.test.ts
@@ -201,7 +201,9 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
   it("marks active workflow runs interrupted on startup recovery", async () => {
     const companyId = randomUUID();
     const workflowId = randomUUID();
+    const durableWorkflowId = randomUUID();
     const activeRunId = randomUUID();
+    const durableRunId = randomUUID();
     const doneRunId = randomUUID();
 
     await db.insert(companies).values({
@@ -220,6 +222,16 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
       pipelineDefinition: { entrypoint: "agent.py", generatedAt: new Date(0).toISOString(), phases: [] },
       pipelineSourceHash: null,
     });
+    await db.insert(workflows).values({
+      id: durableWorkflowId,
+      companyId,
+      title: "Durable workflow",
+      status: "active",
+      runnerType: "durable_queue",
+      runnerConfig: {},
+      pipelineDefinition: { entrypoint: "queue", generatedAt: new Date(0).toISOString(), phases: [] },
+      pipelineSourceHash: null,
+    });
     await db.insert(workflowRuns).values([
       {
         id: activeRunId,
@@ -227,6 +239,13 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
         workflowId,
         status: "awaiting_human",
         inputMarkdown: "generate",
+      },
+      {
+        id: durableRunId,
+        companyId,
+        workflowId: durableWorkflowId,
+        status: "awaiting_human",
+        inputMarkdown: "durable",
       },
       {
         id: doneRunId,
@@ -240,6 +259,15 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
       {
         companyId,
         workflowRunId: activeRunId,
+        phaseKey: "phase-1",
+        label: "Phase 1",
+        kind: "phase",
+        ordinal: 0,
+        status: "awaiting_human",
+      },
+      {
+        companyId,
+        workflowRunId: durableRunId,
         phaseKey: "phase-1",
         label: "Phase 1",
         kind: "phase",
@@ -265,6 +293,12 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
     expect(activeRun?.error).toBe("Workflow process was interrupted before completion.");
     const [activePhase] = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, activeRunId));
     expect(activePhase?.status).toBe("failed");
+
+    const [durableRun] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, durableRunId));
+    expect(durableRun?.status).toBe("awaiting_human");
+    expect(durableRun?.error).toBeNull();
+    const [durablePhase] = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, durableRunId));
+    expect(durablePhase?.status).toBe("awaiting_human");
 
     const [doneRun] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, doneRunId));
     expect(doneRun?.status).toBe("succeeded");

--- a/server/src/__tests__/workflow-service-run-manual.test.ts
+++ b/server/src/__tests__/workflow-service-run-manual.test.ts
@@ -322,7 +322,7 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
         label: "Phase 1",
         kind: "phase",
         ordinal: 0,
-        status: "awaiting_human",
+        status: "idle",
       },
       {
         companyId,
@@ -352,6 +352,8 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
     expect(activeRun?.error).toBe("Workflow process was interrupted before completion.");
     const [activePhase] = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, activeRunId));
     expect(activePhase?.status).toBe("failed");
+    expect(activePhase?.startedAt).toBeInstanceOf(Date);
+    expect(activePhase?.finishedAt).toBeInstanceOf(Date);
 
     const [durableRun] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, durableRunId));
     expect(durableRun?.status).toBe("awaiting_human");

--- a/server/src/__tests__/workflow-service-run-manual.test.ts
+++ b/server/src/__tests__/workflow-service-run-manual.test.ts
@@ -147,6 +147,12 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
     expect(mockPrepareInstrumentedWorkflowRuntime.mock.calls[0]?.[0]).toMatchObject({
       analysis: expect.objectContaining({ sourceHash: "hash-1" }),
     });
+    expect(mockPrepareInstrumentedWorkflowRuntime.mock.calls[0]?.[0]).toMatchObject({
+      runnerConfig: expect.objectContaining({ timeoutSec: 86400 }),
+    });
+    expect(mockInvokeGoogleAdk).toHaveBeenCalledWith(expect.objectContaining({
+      config: expect.objectContaining({ timeoutSec: 86400 }),
+    }));
 
     const phases = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, run.id));
     expect(phases).toHaveLength(1);
@@ -190,5 +196,79 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
     expect(updated?.status).toBe("succeeded");
     const phases = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, run.id));
     expect(phases[0]?.status).toBe("succeeded");
+  });
+
+  it("marks active workflow runs interrupted on startup recovery", async () => {
+    const companyId = randomUUID();
+    const workflowId = randomUUID();
+    const activeRunId = randomUUID();
+    const doneRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(workflows).values({
+      id: workflowId,
+      companyId,
+      title: "Brief generator",
+      status: "active",
+      runnerType: "google_adk",
+      runnerConfig: { agentPath: "/tmp/agent.py" },
+      pipelineDefinition: { entrypoint: "agent.py", generatedAt: new Date(0).toISOString(), phases: [] },
+      pipelineSourceHash: null,
+    });
+    await db.insert(workflowRuns).values([
+      {
+        id: activeRunId,
+        companyId,
+        workflowId,
+        status: "awaiting_human",
+        inputMarkdown: "generate",
+      },
+      {
+        id: doneRunId,
+        companyId,
+        workflowId,
+        status: "succeeded",
+        inputMarkdown: "done",
+      },
+    ]);
+    await db.insert(workflowRunPhases).values([
+      {
+        companyId,
+        workflowRunId: activeRunId,
+        phaseKey: "phase-1",
+        label: "Phase 1",
+        kind: "phase",
+        ordinal: 0,
+        status: "awaiting_human",
+      },
+      {
+        companyId,
+        workflowRunId: doneRunId,
+        phaseKey: "phase-1",
+        label: "Phase 1",
+        kind: "phase",
+        ordinal: 0,
+        status: "succeeded",
+      },
+    ]);
+
+    const result = await workflowService(db).failInterruptedActiveRuns();
+
+    expect(result).toMatchObject({ failed: 1, runIds: [activeRunId] });
+    const [activeRun] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, activeRunId));
+    expect(activeRun?.status).toBe("failed");
+    expect(activeRun?.error).toBe("Workflow process was interrupted before completion.");
+    const [activePhase] = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, activeRunId));
+    expect(activePhase?.status).toBe("failed");
+
+    const [doneRun] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, doneRunId));
+    expect(doneRun?.status).toBe("succeeded");
+    const [donePhase] = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, doneRunId));
+    expect(donePhase?.status).toBe("succeeded");
   });
 });

--- a/server/src/__tests__/workflow-service-run-manual.test.ts
+++ b/server/src/__tests__/workflow-service-run-manual.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { companies, createDb, workflowRunPhases, workflowRuns, workflows } from "@paperclipai/db";
+import { companies, createDb, workflowHandoffs, workflowRunPhases, workflowRuns, workflows } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -57,6 +57,10 @@ const mockPrepareInstrumentedWorkflowRuntime = vi.hoisted(() => vi.fn(async (inp
   analysis: input.analysis,
 })));
 const mockCollectWorkflowRuntimeArtifacts = vi.hoisted(() => vi.fn(async () => []));
+const mockCloseResolvedHandoff = vi.hoisted(() => vi.fn(async () => null));
+const mockWorkflowHandoffBridgeService = vi.hoisted(() => vi.fn(() => ({
+  closeResolvedHandoff: mockCloseResolvedHandoff,
+})));
 
 vi.mock("../storage/index.js", () => ({
   getStorageService: mockGetStorageService,
@@ -70,6 +74,10 @@ vi.mock("../services/workflows-runtime.js", () => ({
   analyzeWorkflowProject: mockAnalyzeWorkflowProject,
   prepareInstrumentedWorkflowRuntime: mockPrepareInstrumentedWorkflowRuntime,
   collectWorkflowRuntimeArtifacts: mockCollectWorkflowRuntimeArtifacts,
+}));
+
+vi.mock("../services/workflow-handoff-bridge.js", () => ({
+  workflowHandoffBridgeService: mockWorkflowHandoffBridgeService,
 }));
 
 vi.mock("../workflow-run-jwt.js", () => ({
@@ -102,6 +110,7 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
   });
 
   afterEach(async () => {
+    await db.delete(workflowHandoffs);
     await db.delete(workflowRunPhases);
     await db.delete(workflowRuns);
     await db.delete(workflows);
@@ -157,6 +166,56 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
     const phases = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, run.id));
     expect(phases).toHaveLength(1);
     expect(phases[0]?.phaseKey).toBe("phase-1");
+  });
+
+  it("closes active phases when the ADK invocation exits", async () => {
+    const companyId = randomUUID();
+    const workflowId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(workflows).values({
+      id: workflowId,
+      companyId,
+      title: "Brief generator",
+      status: "active",
+      runnerType: "google_adk",
+      runnerConfig: { agentPath: "/tmp/agent.py" },
+      pipelineDefinition: { entrypoint: "agent.py", generatedAt: new Date(0).toISOString(), phases: [] },
+      pipelineSourceHash: null,
+    });
+
+    mockInvokeGoogleAdk.mockImplementationOnce(async (input: { runId: string }) => {
+      await db.update(workflowRunPhases).set({
+        status: "running",
+        updatedAt: new Date(),
+      }).where(eq(workflowRunPhases.workflowRunId, input.runId));
+      return {
+        summary: "done",
+        resultJson: { ok: true },
+        errorMessage: null,
+        provider: "google",
+        model: "gemini",
+        usage: null,
+      };
+    });
+
+    const svc = workflowService(db);
+    const run = await svc.runManual(workflowId, { inputMarkdown: "generate" });
+
+    await vi.waitFor(async () => {
+      const updated = await db.select().from(workflowRuns).where(eq(workflowRuns.id, run.id)).then((rows) => rows[0] ?? null);
+      expect(updated?.status).toBe("succeeded");
+    }, 10_000);
+
+    const [phase] = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, run.id));
+    expect(phase?.status).toBe("succeeded");
+    expect(phase?.finishedAt).toBeInstanceOf(Date);
   });
 
   it("does not let late phase events overwrite a terminal run status", async () => {
@@ -304,5 +363,69 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
     expect(doneRun?.status).toBe("succeeded");
     const [donePhase] = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, doneRunId));
     expect(donePhase?.status).toBe("succeeded");
+  });
+
+  it("closes an active ClickUp bridge when a handoff is resolved directly", async () => {
+    const companyId = randomUUID();
+    const workflowId = randomUUID();
+    const runId = randomUUID();
+    const handoffId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(workflows).values({
+      id: workflowId,
+      companyId,
+      title: "Brief generator",
+      status: "active",
+      runnerType: "google_adk",
+      runnerConfig: { agentPath: "/tmp/agent.py" },
+      pipelineDefinition: { entrypoint: "agent.py", generatedAt: new Date(0).toISOString(), phases: [] },
+      pipelineSourceHash: null,
+    });
+    await db.insert(workflowRuns).values({
+      id: runId,
+      companyId,
+      workflowId,
+      status: "awaiting_human",
+      inputMarkdown: "generate",
+    });
+    await db.insert(workflowRunPhases).values({
+      companyId,
+      workflowRunId: runId,
+      phaseKey: "phase-1",
+      label: "Phase 1",
+      kind: "phase",
+      ordinal: 0,
+      status: "awaiting_human",
+    });
+    await db.insert(workflowHandoffs).values({
+      id: handoffId,
+      companyId,
+      workflowRunId: runId,
+      phaseKey: "phase-1",
+      kind: "approval",
+      status: "pending",
+      promptMarkdown: "Approve?",
+    });
+
+    const resolved = await workflowService(db).resolveHandoff(
+      handoffId,
+      "approved",
+      { userId: "board" },
+      { responseMarkdown: "Approve" },
+    );
+
+    expect(resolved?.status).toBe("approved");
+    expect(mockCloseResolvedHandoff).toHaveBeenCalledWith(handoffId, "approved");
+
+    const [run] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, runId));
+    expect(run?.status).toBe("running");
+    const [phase] = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, runId));
+    expect(phase?.status).toBe("running");
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,6 +36,7 @@ import {
   clickupBridgeService,
   reconcilePersistedRuntimeServicesOnStartup,
   routineService,
+  workflowService,
 } from "./services/index.js";
 import { registerAwaitingHumanBridgeAdapter } from "./services/awaiting-human-bridge-registry.js";
 import { clickupAwaitingHumanBridgeAdapter } from "./services/clickup-awaiting-human-bridge-adapter.js";
@@ -672,6 +673,7 @@ export async function startServer(): Promise<StartedServer> {
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any);
     const routines = routineService(db as any);
+    const workflows = workflowService(db as any);
   
     // Reap orphaned running runs at startup while in-memory execution state is empty,
     // then resume any persisted queued runs that were waiting on the previous process.
@@ -681,12 +683,14 @@ export async function startServer(): Promise<StartedServer> {
       .then(async (promotion) => {
         await heartbeat.resumeQueuedRuns();
         const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
+        const interruptedWorkflows = await workflows.failInterruptedActiveRuns();
         const approvals = await heartbeat.reconcileAwaitingHumanApprovals();
         if (
           promotion.promoted > 0 ||
           reconciled.dispatchRequeued > 0 ||
           reconciled.continuationRequeued > 0 ||
           reconciled.escalated > 0 ||
+          interruptedWorkflows.failed > 0 ||
           approvals.approved > 0 ||
           approvals.failed > 0
         ) {
@@ -695,6 +699,7 @@ export async function startServer(): Promise<StartedServer> {
               promotedScheduledRetries: promotion.promoted,
               promotedScheduledRetryRunIds: promotion.runIds,
               ...reconciled,
+              interruptedWorkflowRuns: interruptedWorkflows,
               clickupAwaitingHumanApprovals: approvals,
             },
             "startup heartbeat recovery changed assigned issue state",

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -271,10 +271,15 @@ function compareClickUpRepliesChronologically(
     return aDate - bDate;
   }
 
-  const aId = readNumericValue(a.id);
-  const bId = readNumericValue(b.id);
-  if (aId !== null && bId !== null && aId !== bId) {
-    return aId - bId;
+  const aIdStr = typeof a.id === "string" && a.id.trim().length > 0 ? a.id.trim() : null;
+  const bIdStr = typeof b.id === "string" && b.id.trim().length > 0 ? b.id.trim() : null;
+  if (aIdStr !== null && bIdStr !== null && aIdStr !== bIdStr) {
+    try {
+      const cmp = BigInt(aIdStr) - BigInt(bIdStr);
+      if (cmp !== 0n) return cmp > 0n ? 1 : -1;
+    } catch {
+      return aIdStr < bIdStr ? -1 : 1;
+    }
   }
 
   return 0;

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -1144,7 +1144,7 @@ export async function detectClickUpAwaitingHumanBridgeEventsAfterMessage(
   }
 
   if (!markerFound) {
-    return { status: "sent", detail: "question-marker-not-found", events: [] };
+    return { status: "failed", detail: "question-marker-not-found", events: [] };
   }
   if (events.length > 0) {
     return { status: "sent", detail: "replies-detected", events };

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -19,6 +19,7 @@ const MAX_SUMMARY_LENGTH = 280;
 const MAX_DETAIL_BULLETS = 5;
 const MAX_BULLET_LENGTH = 220;
 const DEFAULT_CLICKUP_TIMEOUT_SEC = 30;
+const MAX_CLICKUP_REPLY_PAGES = 20;
 const CLICKUP_ATTACHMENT_FILE_FIELD = "attachment[0]";
 
 export interface ClickUpTransportTestNotification {
@@ -248,8 +249,8 @@ type ClickUpReplyMessageResponse = {
 };
 
 type ClickUpGetChatMessageRepliesResponse = {
-  data: ClickUpReplyMessageResponse[];
-  next_cursor: string;
+  data?: ClickUpReplyMessageResponse[];
+  next_cursor?: string | null;
 };
 
 function readNumericValue(value: unknown) {
@@ -289,14 +290,18 @@ function compareClickUpRepliesChronologically(
   return 0;
 }
 
-function extractReplyRows(payload: ClickUpGetChatMessageRepliesResponse): ClickUpChatMessageReply[] {
-  return [...payload.data].sort(compareClickUpRepliesChronologically).map((row) => ({
+function extractReplyRowsFromRows(rows: ClickUpReplyMessageResponse[]): ClickUpChatMessageReply[] {
+  return [...rows].sort(compareClickUpRepliesChronologically).map((row) => ({
     id: row.id,
     parentMessageId: row.parent_message,
     reactionsUrl: row.links.reactions,
     content: row.content,
     dateMs: readClickUpReplyDate(row),
   }));
+}
+
+function extractReplyRows(payload: ClickUpGetChatMessageRepliesResponse): ClickUpChatMessageReply[] {
+  return extractReplyRowsFromRows(Array.isArray(payload.data) ? payload.data : []);
 }
 function formatClickUpUserMention(userId: string | null | undefined) {
   const trimmed = readString(userId);
@@ -880,18 +885,30 @@ export async function getClickUpChatMessageReplies(
     };
   }
 
-  const response = await fetchClickUpJson(
-    config,
-    `/chat/messages/${encodeURIComponent(messageId)}/replies`,
-  );
-  if (response.status === "failed") {
-    return { status: "failed", detail: response.detail, replies: [] };
+  const rawReplies: ClickUpReplyMessageResponse[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; page < MAX_CLICKUP_REPLY_PAGES; page += 1) {
+    const cursorQuery = cursor
+      ? `?${new URLSearchParams({ cursor }).toString()}`
+      : "";
+    const response = await fetchClickUpJson(
+      config,
+      `/chat/messages/${encodeURIComponent(messageId)}/replies${cursorQuery}`,
+    );
+    if (response.status === "failed") {
+      return { status: "failed", detail: response.detail, replies: [] };
+    }
+
+    const payload = response.payload as ClickUpGetChatMessageRepliesResponse;
+    if (Array.isArray(payload.data)) rawReplies.push(...payload.data);
+    cursor = readString(payload.next_cursor);
+    if (!cursor) break;
   }
 
   return {
     status: "sent",
     detail: "ok",
-    replies: extractReplyRows(response.payload as ClickUpGetChatMessageRepliesResponse),
+    replies: extractReplyRowsFromRows(rawReplies),
   };
 }
 

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -12,6 +12,8 @@ import type { AwaitingHumanBridgePollEvent } from "./awaiting-human-bridge-regis
 import { normalizeClickUpAttachmentTaskId } from "./clickup-awaiting-human-settings-adapter.js";
 
 const CLICKUP_CHAT_MESSAGE_MAX_CHARS = 1_800;
+const CLICKUP_CHAT_REPLY_MESSAGE_MAX_CHARS = 39_000;
+const CLICKUP_CHAT_REPLY_BODY_MAX_CHARS = 38_000;
 const MAX_TITLE_LENGTH = 120;
 const MAX_SUMMARY_LENGTH = 280;
 const MAX_DETAIL_BULLETS = 5;
@@ -57,6 +59,7 @@ export interface ClickUpChatMessageReply {
   parentMessageId: string | null;
   reactionsUrl: string | null;
   content: string | null;
+  dateMs: number | null;
 }
 
 function compactWhitespace(value: string) {
@@ -88,6 +91,19 @@ function formatBodySection(body: string | null | undefined) {
     .slice(0, MAX_DETAIL_BULLETS * 6)
     .map((line) => truncateText(line, MAX_BULLET_LENGTH));
   return trimTotal(limited.join("\n"), 1_000);
+}
+
+function formatFullBodySection(body: string | null | undefined) {
+  if (!body) return null;
+  const lines = body
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(
+      (line, index, all) =>
+        line.length > 0 || (index > 0 && all[index - 1]?.length > 0),
+    );
+  if (lines.length === 0) return null;
+  return trimTotal(lines.join("\n"), CLICKUP_CHAT_REPLY_BODY_MAX_CHARS);
 }
 
 function readString(value: unknown) {
@@ -222,6 +238,8 @@ type ClickUpReplyMessageResponse = {
   id: string;
   parent_message: string;
   content: string;
+  date?: number | string | null;
+  date_assigned?: number | string | null;
   links: ClickUpReplyMessageLinksResponse;
 };
 
@@ -230,12 +248,45 @@ type ClickUpGetChatMessageRepliesResponse = {
   next_cursor: string;
 };
 
+function readNumericValue(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function readClickUpReplyDate(row: ClickUpReplyMessageResponse) {
+  return readNumericValue(row.date) ?? readNumericValue(row.date_assigned);
+}
+
+function compareClickUpRepliesChronologically(
+  a: ClickUpReplyMessageResponse,
+  b: ClickUpReplyMessageResponse,
+) {
+  const aDate = readClickUpReplyDate(a);
+  const bDate = readClickUpReplyDate(b);
+  if (aDate !== null && bDate !== null && aDate !== bDate) {
+    return aDate - bDate;
+  }
+
+  const aId = readNumericValue(a.id);
+  const bId = readNumericValue(b.id);
+  if (aId !== null && bId !== null && aId !== bId) {
+    return aId - bId;
+  }
+
+  return 0;
+}
+
 function extractReplyRows(payload: ClickUpGetChatMessageRepliesResponse): ClickUpChatMessageReply[] {
-  return payload.data.map((row) => ({
+  return [...payload.data].sort(compareClickUpRepliesChronologically).map((row) => ({
     id: row.id,
     parentMessageId: row.parent_message,
     reactionsUrl: row.links.reactions,
     content: row.content,
+    dateMs: readClickUpReplyDate(row),
   }));
 }
 function formatClickUpUserMention(userId: string | null | undefined) {
@@ -289,9 +340,20 @@ function renderApprovalContextSection(
   return lines.join("\n");
 }
 
-function renderClickUpMessage(notification: AwaitingHumanNotificationPayload, config: ClickUpChatConfig) {
+function renderClickUpMessage(
+  notification: AwaitingHumanNotificationPayload,
+  config: ClickUpChatConfig,
+  options?: {
+    maxChars?: number;
+    preserveBody?: boolean;
+    includeCtaWithBody?: boolean;
+  },
+) {
+  const maxChars = options?.maxChars ?? CLICKUP_CHAT_MESSAGE_MAX_CHARS;
   const title = truncateText(notification.title, MAX_TITLE_LENGTH);
-  const bodySection = formatBodySection(notification.body);
+  const bodySection = options?.preserveBody
+    ? formatFullBodySection(notification.body)
+    : formatBodySection(notification.body);
   const approvalSection = renderApprovalContextSection(notification, config);
   const lines = [`**${title}**`];
 
@@ -333,12 +395,12 @@ function renderClickUpMessage(notification: AwaitingHumanNotificationPayload, co
     }
   }
 
-  if (!bodySection && notification.cta.trim().length > 0) {
+  if ((options?.includeCtaWithBody || !bodySection) && notification.cta.trim().length > 0) {
     lines.push("");
     lines.push(truncateText(notification.cta, 180));
   }
 
-  return trimTotal(lines.join("\n"), CLICKUP_CHAT_MESSAGE_MAX_CHARS);
+  return trimTotal(lines.join("\n"), maxChars);
 }
 
 function renderClickUpTransportTestMessage(
@@ -438,6 +500,80 @@ async function postClickUpChatMessage(
   }
 }
 
+async function postClickUpChatMessageReply(
+  parentMessageId: string,
+  content: string,
+  overrides?: ClickUpAwaitingHumanConfigOverrides,
+): Promise<AwaitingHumanNotificationResult> {
+  const config = readClickUpChatConfig(overrides);
+  if (!config.personalToken) {
+    return {
+      status: "skipped",
+      channel: "clickup-chat",
+      detail: "missing-credential: CLICKUP_PERSONAL_TOKEN",
+    };
+  }
+  if (!config.workspaceId) {
+    return {
+      status: "skipped",
+      channel: "clickup-chat",
+      detail: "missing-target: CLICKUP_WORKSPACE_ID",
+    };
+  }
+
+  const messageId = parentMessageId.trim();
+  if (!messageId) {
+    return {
+      status: "skipped",
+      channel: "clickup-chat",
+      detail: "missing-target: parent-message-id",
+    };
+  }
+
+  try {
+    const response = await fetchText(
+      `https://api.clickup.com/api/v3/workspaces/${encodeURIComponent(config.workspaceId)}/chat/messages/${encodeURIComponent(messageId)}/replies`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: config.personalToken,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          type: "message",
+          content,
+          content_format: "text/md",
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      return {
+        status: "failed",
+        channel: "clickup-chat",
+        detail: `http-error:${response.status}:${truncateText(response.text, 240)}`,
+      };
+    }
+
+    const externalId = response.text.trim().length > 0
+      ? parseClickUpCreateChatMessageResponse(response.text).messageId
+      : null;
+
+    return {
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId,
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      channel: "clickup-chat",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export async function sendAwaitingHumanNotification(
   input: SendAwaitingHumanNotificationInput,
   overrides?: ClickUpAwaitingHumanConfigOverrides,
@@ -445,6 +581,27 @@ export async function sendAwaitingHumanNotification(
   const config = readClickUpChatConfig(overrides);
   return postClickUpChatMessage(
     renderClickUpMessage(input.notification, config),
+    overrides,
+  );
+}
+
+export async function sendAwaitingHumanNotificationReply(
+  parentMessageId: string,
+  input: SendAwaitingHumanNotificationInput,
+  overrides?: ClickUpAwaitingHumanConfigOverrides,
+): Promise<AwaitingHumanNotificationResult> {
+  const config = readClickUpChatConfig(overrides);
+  return postClickUpChatMessageReply(
+    parentMessageId,
+    renderClickUpMessage(
+      input.notification,
+      config,
+      {
+        maxChars: CLICKUP_CHAT_REPLY_MESSAGE_MAX_CHARS,
+        preserveBody: true,
+        includeCtaWithBody: true,
+      },
+    ),
     overrides,
   );
 }
@@ -919,6 +1076,76 @@ export async function detectClickUpAwaitingHumanBridgeEvents(
     });
   }
 
+  if (events.length > 0) {
+    return { status: "sent", detail: "replies-detected", events };
+  }
+
+  return { status: "sent", detail: "no-replies", events: [] };
+}
+
+export async function detectClickUpAwaitingHumanBridgeEventsAfterMessage(
+  threadMessageId: string,
+  markerMessageId: string,
+  overrides?: ClickUpAwaitingHumanConfigOverrides,
+): Promise<{
+  status: ClickUpApiStatus;
+  detail: string;
+  events: AwaitingHumanBridgePollEvent[];
+}> {
+  const threadId = threadMessageId.trim();
+  const markerId = markerMessageId.trim();
+  if (!threadId) {
+    return { status: "skipped", detail: "missing-thread-message-id", events: [] };
+  }
+  if (!markerId) {
+    return { status: "skipped", detail: "missing-marker-message-id", events: [] };
+  }
+
+  const repliesResult = await getClickUpChatMessageReplies(threadId, overrides);
+  if (repliesResult.status === "failed" || repliesResult.status === "skipped") {
+    return {
+      status: repliesResult.status,
+      detail: repliesResult.detail,
+      events: [],
+    };
+  }
+
+  const events: AwaitingHumanBridgePollEvent[] = [];
+  let markerFound = false;
+  for (const reply of repliesResult.replies) {
+    const replyId = readString(reply.id);
+    if (!replyId) {
+      logger.warn(
+        { messageId: threadId, markerMessageId: markerId, reply },
+        "Skipping ClickUp thread reply without stable reply.id",
+      );
+      continue;
+    }
+    if (replyId === markerId) {
+      markerFound = true;
+      continue;
+    }
+    if (!markerFound) continue;
+
+    const replyBody = readString(reply.content);
+    if (!replyBody) continue;
+    events.push({
+      kind: "reply",
+      externalEventId: replyId,
+      externalThreadId: threadId,
+      externalMessageId: markerId,
+      body: replyBody,
+      metadata: {
+        clickupReplyId: replyId,
+        clickupThreadId: threadId,
+        clickupQuestionMessageId: markerId,
+      },
+    });
+  }
+
+  if (!markerFound) {
+    return { status: "sent", detail: "question-marker-not-found", events: [] };
+  }
   if (events.length > 0) {
     return { status: "sent", detail: "replies-detected", events };
   }

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -585,14 +585,12 @@ export function workflowHandoffBridgeService(db: Db) {
             runError: run?.error ?? null,
           }, "workflow handoff bridge: terminal run reply poll failed while closing bridge");
           await tryRecordBridgePollFailure(db, bridge, now, detail);
-          summary.failed += 1;
-          continue;
+          detectedTerminal = { status: "sent", detail: "terminal-reply-detection-failed", events: [] };
         }
 
         if (detectedTerminal.status === "failed") {
           await tryRecordBridgePollFailure(db, bridge, now, detectedTerminal.detail);
-          summary.failed += 1;
-          continue;
+          detectedTerminal = { status: "sent", detail: detectedTerminal.detail, events: [] };
         }
 
         try {

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -787,24 +787,33 @@ export function workflowHandoffBridgeService(db: Db) {
               ? "failed"
               : "cancelled";
           await closeBridgeRow(db, bridge, closeOutcome, overrides);
-          await logActivity(db, {
-            companyId: bridge.companyId,
-            actorType: "system",
-            actorId: "workflow_handoff_bridge",
-            action: "workflow.handoff.bridge_closed_terminal",
-            entityType: "workflow_run",
-            entityId: bridge.workflowRunId,
-            details: {
+          try {
+            await logActivity(db, {
+              companyId: bridge.companyId,
+              actorType: "system",
+              actorId: "workflow_handoff_bridge",
+              action: "workflow.handoff.bridge_closed_terminal",
+              entityType: "workflow_run",
+              entityId: bridge.workflowRunId,
+              details: {
+                bridgeId: bridge.id,
+                workflowHandoffId: bridge.workflowHandoffId,
+                provider: bridge.provider,
+                externalMessageId: bridge.externalMessageId ?? null,
+                externalThreadId: bridge.externalThreadId ?? null,
+                runStatus: staleRun?.status ?? null,
+                runError: staleRun?.error ?? null,
+                closeOutcome,
+              },
+            });
+          } catch (error) {
+            logger.warn({
+              err: error,
               bridgeId: bridge.id,
+              companyId: bridge.companyId,
               workflowHandoffId: bridge.workflowHandoffId,
-              provider: bridge.provider,
-              externalMessageId: bridge.externalMessageId ?? null,
-              externalThreadId: bridge.externalThreadId ?? null,
-              runStatus: staleRun?.status ?? null,
-              runError: staleRun?.error ?? null,
-              closeOutcome,
-            },
-          });
+            }, "workflow handoff bridge: failed to log stale-run bridge closure");
+          }
           summary.terminalClosed += 1;
           continue;
         }

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -19,6 +19,7 @@ import type { AwaitingHumanNotificationPayload } from "./awaiting-human-notifica
 
 const POLL_INTERVAL_MS = 60_000;
 const POLL_FAILURE_BACKOFF_MS = 5 * 60 * 1000;
+const TERMINAL_WORKFLOW_RUN_STATUSES = ["succeeded", "failed", "cancelled"];
 
 function truncateText(value: string, maxLength: number) {
   const compact = value.trim().replace(/\s+/g, " ");
@@ -129,7 +130,7 @@ async function closeBridgeRow(
       target: "main",
       overrides,
     });
-  } else if (outcome === "failed" || outcome === "expired") {
+  } else if (outcome === "failed" || outcome === "expired" || outcome === "cancelled") {
     await applyReaction({
       db,
       bridgeId: bridge.id,
@@ -162,7 +163,16 @@ async function resolveHandoffFromBridge(
 
   if (!handoff) return;
 
+  let resolved = false;
   await db.transaction(async (tx) => {
+    const [run] = await tx
+      .select({ status: workflowRuns.status })
+      .from(workflowRuns)
+      .where(eq(workflowRuns.id, bridge.workflowRunId))
+      .limit(1);
+
+    if (run?.status !== "awaiting_human") return;
+
     await tx.update(workflowHandoffs).set({
       status: resolution,
       responseMarkdown: responseMarkdown ?? null,
@@ -191,7 +201,10 @@ async function resolveHandoffFromBridge(
       eq(workflowRuns.id, bridge.workflowRunId),
       eq(workflowRuns.status, "awaiting_human"),
     ));
+    resolved = true;
   });
+
+  if (!resolved) return;
 
   await logActivity(db, {
     companyId: bridge.companyId,
@@ -361,6 +374,86 @@ export function workflowHandoffBridgeService(db: Db) {
           nextPollAt: new Date(now.getTime() + POLL_FAILURE_BACKOFF_MS),
           updatedAt: now,
         }).where(eq(workflowHandoffBridges.id, bridge.id));
+        summary.failed += 1;
+        continue;
+      }
+
+      const [run] = await db
+        .select({ status: workflowRuns.status, error: workflowRuns.error })
+        .from(workflowRuns)
+        .where(eq(workflowRuns.id, bridge.workflowRunId))
+        .limit(1);
+      if (!run || TERMINAL_WORKFLOW_RUN_STATUSES.includes(run.status)) {
+        let detectedTerminal: Awaited<ReturnType<typeof detectClickUpAwaitingHumanBridgeEvents>> | null = null;
+        try {
+          detectedTerminal = await detectClickUpAwaitingHumanBridgeEvents(messageId, overrides);
+        } catch (error) {
+          logger.warn({
+            err: error,
+            bridgeId: bridge.id,
+            companyId: bridge.companyId,
+            workflowHandoffId: bridge.workflowHandoffId,
+            messageId,
+            runStatus: run?.status ?? null,
+            runError: run?.error ?? null,
+          }, "workflow handoff bridge: terminal run reply poll failed while closing bridge");
+        }
+
+        if (detectedTerminal?.status === "sent") {
+          const replyMessageIds = new Set<string>();
+          for (const event of detectedTerminal.events) {
+            const replyId = typeof event.metadata?.clickupReplyId === "string" && event.metadata.clickupReplyId.trim().length > 0
+              ? event.metadata.clickupReplyId.trim()
+              : null;
+            if (replyId) replyMessageIds.add(replyId);
+          }
+          for (const replyId of replyMessageIds) {
+            await applyReaction({
+              db,
+              bridgeId: bridge.id,
+              companyId: bridge.companyId,
+              workflowHandoffId: bridge.workflowHandoffId,
+              messageId: replyId,
+              reaction: "x",
+              target: "reply",
+              overrides,
+            });
+          }
+        }
+
+        await db.update(workflowHandoffs).set({
+          status: "cancelled",
+          responseMarkdown: null,
+          decidedByUserId: "workflow_handoff_bridge",
+          decidedAt: now,
+          updatedAt: now,
+        }).where(and(
+          eq(workflowHandoffs.id, bridge.workflowHandoffId),
+          eq(workflowHandoffs.status, "pending"),
+        ));
+        const closeOutcome = run?.status === "failed" && run.error?.startsWith("Timed out after ")
+          ? "expired"
+          : run?.status === "failed"
+            ? "failed"
+            : "cancelled";
+        await closeBridgeRow(db, bridge, closeOutcome, overrides);
+        await logActivity(db, {
+          companyId: bridge.companyId,
+          actorType: "system",
+          actorId: "workflow_handoff_bridge",
+          action: "workflow.handoff.bridge_closed_terminal",
+          entityType: "workflow_run",
+          entityId: bridge.workflowRunId,
+          details: {
+            bridgeId: bridge.id,
+            workflowHandoffId: bridge.workflowHandoffId,
+            provider: bridge.provider,
+            externalMessageId: bridge.externalMessageId ?? null,
+            runStatus: run?.status ?? null,
+            runError: run?.error ?? null,
+            closeOutcome,
+          },
+        });
         summary.failed += 1;
         continue;
       }

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -601,6 +601,14 @@ export function workflowHandoffBridgeService(db: Db) {
               : null;
             if (replyId) replyMessageIds.add(replyId);
           }
+          const [currentHandoff] = await db
+            .select({ status: workflowHandoffs.status })
+            .from(workflowHandoffs)
+            .where(eq(workflowHandoffs.id, bridge.workflowHandoffId))
+            .limit(1);
+          const acceptedOutcome = isResolvedHandoffStatus(currentHandoff?.status)
+            ? currentHandoff.status
+            : null;
           for (const replyId of replyMessageIds) {
             await applyReaction({
               db,
@@ -608,23 +616,25 @@ export function workflowHandoffBridgeService(db: Db) {
               companyId: bridge.companyId,
               workflowHandoffId: bridge.workflowHandoffId,
               messageId: replyId,
-              reaction: "x",
+              reaction: acceptedOutcome ? "white_check_mark" : "x",
               target: "reply",
               overrides,
             });
           }
 
-          await db.update(workflowHandoffs).set({
-            status: "cancelled",
-            responseMarkdown: null,
-            decidedByUserId: "workflow_handoff_bridge",
-            decidedAt: now,
-            updatedAt: now,
-          }).where(and(
-            eq(workflowHandoffs.id, bridge.workflowHandoffId),
-            eq(workflowHandoffs.status, "pending"),
-          ));
-          const closeOutcome = toCloseOutcome(run);
+          if (!acceptedOutcome) {
+            await db.update(workflowHandoffs).set({
+              status: "cancelled",
+              responseMarkdown: null,
+              decidedByUserId: "workflow_handoff_bridge",
+              decidedAt: now,
+              updatedAt: now,
+            }).where(and(
+              eq(workflowHandoffs.id, bridge.workflowHandoffId),
+              eq(workflowHandoffs.status, "pending"),
+            ));
+          }
+          const closeOutcome = acceptedOutcome ?? toCloseOutcome(run);
           await closeBridgeRow(db, bridge, closeOutcome, overrides);
           try {
             await logActivity(db, {
@@ -642,6 +652,7 @@ export function workflowHandoffBridgeService(db: Db) {
                 externalThreadId: bridge.externalThreadId ?? null,
                 runStatus: run?.status ?? null,
                 runError: run?.error ?? null,
+                handoffStatus: currentHandoff?.status ?? null,
                 closeOutcome,
               },
             });

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -685,21 +685,25 @@ export function workflowHandoffBridgeService(db: Db) {
           workflowHandoffId: bridge.workflowHandoffId,
           messageId,
         }, "workflow handoff bridge: ClickUp poll failed");
-        await db.update(workflowHandoffBridges).set({
-          lastError: detail,
-          lastPolledAt: now,
-          nextPollAt: new Date(now.getTime() + POLL_FAILURE_BACKOFF_MS),
-          updatedAt: now,
-        }).where(eq(workflowHandoffBridges.id, bridge.id));
-        await logActivity(db, {
-          companyId: bridge.companyId,
-          actorType: "system",
-          actorId: "workflow_handoff_bridge",
-          action: "workflow.handoff.bridge_poll_failed",
-          entityType: "workflow_run",
-          entityId: bridge.workflowRunId,
-          details: { bridgeId: bridge.id, workflowHandoffId: bridge.workflowHandoffId, detail },
-        });
+        await tryRecordBridgePollFailure(db, bridge, now, detail);
+        try {
+          await logActivity(db, {
+            companyId: bridge.companyId,
+            actorType: "system",
+            actorId: "workflow_handoff_bridge",
+            action: "workflow.handoff.bridge_poll_failed",
+            entityType: "workflow_run",
+            entityId: bridge.workflowRunId,
+            details: { bridgeId: bridge.id, workflowHandoffId: bridge.workflowHandoffId, detail },
+          });
+        } catch (activityError) {
+          logger.warn({
+            err: activityError,
+            bridgeId: bridge.id,
+            companyId: bridge.companyId,
+            workflowHandoffId: bridge.workflowHandoffId,
+          }, "workflow handoff bridge: failed to log active bridge poll failure");
+        }
         summary.failed += 1;
         continue;
       }

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -144,6 +144,38 @@ async function closeBridgeRow(
   }
 }
 
+async function recordBridgePollFailure(
+  db: Db,
+  bridge: typeof workflowHandoffBridges.$inferSelect,
+  now: Date,
+  detail: string,
+) {
+  await db.update(workflowHandoffBridges).set({
+    lastError: detail,
+    lastPolledAt: now,
+    nextPollAt: new Date(now.getTime() + POLL_FAILURE_BACKOFF_MS),
+    updatedAt: now,
+  }).where(eq(workflowHandoffBridges.id, bridge.id));
+}
+
+async function tryRecordBridgePollFailure(
+  db: Db,
+  bridge: typeof workflowHandoffBridges.$inferSelect,
+  now: Date,
+  detail: string,
+) {
+  try {
+    await recordBridgePollFailure(db, bridge, now, detail);
+  } catch (error) {
+    logger.error({
+      err: error,
+      bridgeId: bridge.id,
+      companyId: bridge.companyId,
+      workflowHandoffId: bridge.workflowHandoffId,
+    }, "workflow handoff bridge: failed to record poll failure");
+  }
+}
+
 async function resolveHandoffFromBridge(
   db: Db,
   bridge: typeof workflowHandoffBridges.$inferSelect,
@@ -385,10 +417,11 @@ export function workflowHandoffBridgeService(db: Db) {
         .where(eq(workflowRuns.id, bridge.workflowRunId))
         .limit(1);
       if (!run || TERMINAL_WORKFLOW_RUN_STATUSES.includes(run.status)) {
-        let detectedTerminal: Awaited<ReturnType<typeof detectClickUpAwaitingHumanBridgeEvents>> | null = null;
+        let detectedTerminal: Awaited<ReturnType<typeof detectClickUpAwaitingHumanBridgeEvents>>;
         try {
           detectedTerminal = await detectClickUpAwaitingHumanBridgeEvents(messageId, overrides);
         } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
           logger.warn({
             err: error,
             bridgeId: bridge.id,
@@ -398,9 +431,18 @@ export function workflowHandoffBridgeService(db: Db) {
             runStatus: run?.status ?? null,
             runError: run?.error ?? null,
           }, "workflow handoff bridge: terminal run reply poll failed while closing bridge");
+          await tryRecordBridgePollFailure(db, bridge, now, detail);
+          summary.failed += 1;
+          continue;
         }
 
-        if (detectedTerminal?.status === "sent") {
+        if (detectedTerminal.status === "failed") {
+          await tryRecordBridgePollFailure(db, bridge, now, detectedTerminal.detail);
+          summary.failed += 1;
+          continue;
+        }
+
+        try {
           const replyMessageIds = new Set<string>();
           for (const event of detectedTerminal.events) {
             const replyId = typeof event.metadata?.clickupReplyId === "string" && event.metadata.clickupReplyId.trim().length > 0
@@ -420,42 +462,82 @@ export function workflowHandoffBridgeService(db: Db) {
               overrides,
             });
           }
-        }
 
-        await db.update(workflowHandoffs).set({
-          status: "cancelled",
-          responseMarkdown: null,
-          decidedByUserId: "workflow_handoff_bridge",
-          decidedAt: now,
-          updatedAt: now,
-        }).where(and(
-          eq(workflowHandoffs.id, bridge.workflowHandoffId),
-          eq(workflowHandoffs.status, "pending"),
-        ));
-        const closeOutcome = run?.status === "failed" && run.error?.startsWith("Timed out after ")
-          ? "expired"
-          : run?.status === "failed"
-            ? "failed"
-            : "cancelled";
-        await closeBridgeRow(db, bridge, closeOutcome, overrides);
-        await logActivity(db, {
-          companyId: bridge.companyId,
-          actorType: "system",
-          actorId: "workflow_handoff_bridge",
-          action: "workflow.handoff.bridge_closed_terminal",
-          entityType: "workflow_run",
-          entityId: bridge.workflowRunId,
-          details: {
+          await db.update(workflowHandoffs).set({
+            status: "cancelled",
+            responseMarkdown: null,
+            decidedByUserId: "workflow_handoff_bridge",
+            decidedAt: now,
+            updatedAt: now,
+          }).where(and(
+            eq(workflowHandoffs.id, bridge.workflowHandoffId),
+            eq(workflowHandoffs.status, "pending"),
+          ));
+          const closeOutcome = run?.status === "failed" && run.error?.startsWith("Timed out after ")
+            ? "expired"
+            : run?.status === "failed"
+              ? "failed"
+              : "cancelled";
+          await closeBridgeRow(db, bridge, closeOutcome, overrides);
+          try {
+            await logActivity(db, {
+              companyId: bridge.companyId,
+              actorType: "system",
+              actorId: "workflow_handoff_bridge",
+              action: "workflow.handoff.bridge_closed_terminal",
+              entityType: "workflow_run",
+              entityId: bridge.workflowRunId,
+              details: {
+                bridgeId: bridge.id,
+                workflowHandoffId: bridge.workflowHandoffId,
+                provider: bridge.provider,
+                externalMessageId: bridge.externalMessageId ?? null,
+                runStatus: run?.status ?? null,
+                runError: run?.error ?? null,
+                closeOutcome,
+              },
+            });
+          } catch (error) {
+            logger.warn({
+              err: error,
+              bridgeId: bridge.id,
+              companyId: bridge.companyId,
+              workflowHandoffId: bridge.workflowHandoffId,
+            }, "workflow handoff bridge: failed to log terminal bridge closure");
+          }
+          summary.terminalClosed += 1;
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          logger.error({
+            err: error,
             bridgeId: bridge.id,
+            companyId: bridge.companyId,
             workflowHandoffId: bridge.workflowHandoffId,
-            provider: bridge.provider,
-            externalMessageId: bridge.externalMessageId ?? null,
+            messageId,
             runStatus: run?.status ?? null,
             runError: run?.error ?? null,
-            closeOutcome,
-          },
-        });
-        summary.terminalClosed += 1;
+          }, "workflow handoff bridge: failed to close terminal bridge");
+          await tryRecordBridgePollFailure(db, bridge, now, detail);
+          try {
+            await logActivity(db, {
+              companyId: bridge.companyId,
+              actorType: "system",
+              actorId: "workflow_handoff_bridge",
+              action: "workflow.handoff.bridge_poll_failed",
+              entityType: "workflow_run",
+              entityId: bridge.workflowRunId,
+              details: { bridgeId: bridge.id, workflowHandoffId: bridge.workflowHandoffId, detail },
+            });
+          } catch (activityError) {
+            logger.warn({
+              err: activityError,
+              bridgeId: bridge.id,
+              companyId: bridge.companyId,
+              workflowHandoffId: bridge.workflowHandoffId,
+            }, "workflow handoff bridge: failed to log terminal bridge close failure");
+          }
+          summary.failed += 1;
+        }
         continue;
       }
 

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -149,7 +149,7 @@ async function resolveHandoffFromBridge(
   bridge: typeof workflowHandoffBridges.$inferSelect,
   resolution: "responded" | "approved" | "rejected",
   responseMarkdown: string | null,
-) {
+): Promise<boolean> {
   const now = new Date();
 
   const [handoff] = await db
@@ -161,7 +161,7 @@ async function resolveHandoffFromBridge(
     ))
     .limit(1);
 
-  if (!handoff) return;
+  if (!handoff) return false;
 
   let resolved = false;
   await db.transaction(async (tx) => {
@@ -204,7 +204,7 @@ async function resolveHandoffFromBridge(
     resolved = true;
   });
 
-  if (!resolved) return;
+  if (!resolved) return false;
 
   await logActivity(db, {
     companyId: bridge.companyId,
@@ -221,6 +221,7 @@ async function resolveHandoffFromBridge(
       externalMessageId: bridge.externalMessageId ?? null,
     },
   });
+  return true;
 }
 
 export function workflowHandoffBridgeService(db: Db) {
@@ -342,7 +343,7 @@ export function workflowHandoffBridgeService(db: Db) {
       )
       .limit(50);
 
-    const summary = { checked: 0, resolved: 0, noSignal: 0, failed: 0 };
+    const summary = { checked: 0, resolved: 0, noSignal: 0, failed: 0, terminalClosed: 0 };
 
     for (const bridge of bridges) {
       summary.checked += 1;
@@ -454,7 +455,7 @@ export function workflowHandoffBridgeService(db: Db) {
             closeOutcome,
           },
         });
-        summary.failed += 1;
+        summary.terminalClosed += 1;
         continue;
       }
 
@@ -511,7 +512,7 @@ export function workflowHandoffBridgeService(db: Db) {
         continue;
       }
 
-      // Process first meaningful event -- acknowledge all reply messages
+      // Process first meaningful event -- acknowledge reply messages only after the workflow accepts them.
       const replyMessageIds = new Set<string>();
       for (const event of detected.events) {
         const replyId = typeof event.metadata?.clickupReplyId === "string" && event.metadata.clickupReplyId.trim().length > 0
@@ -519,19 +520,6 @@ export function workflowHandoffBridgeService(db: Db) {
           : null;
         if (replyId) replyMessageIds.add(replyId);
       }
-      for (const replyId of replyMessageIds) {
-        await applyReaction({
-          db,
-          bridgeId: bridge.id,
-          companyId: bridge.companyId,
-          workflowHandoffId: bridge.workflowHandoffId,
-          messageId: replyId,
-          reaction: "white_check_mark",
-          target: "reply",
-          overrides,
-        });
-      }
-
       // Resolve using the first event
       const event = detected.events[0]!;
       let resolution: "responded" | "approved" | "rejected";
@@ -550,7 +538,73 @@ export function workflowHandoffBridgeService(db: Db) {
       }
 
       try {
-        await resolveHandoffFromBridge(db, bridge, resolution, responseMarkdown);
+        const applied = await resolveHandoffFromBridge(db, bridge, resolution, responseMarkdown);
+        if (!applied) {
+          for (const replyId of replyMessageIds) {
+            await applyReaction({
+              db,
+              bridgeId: bridge.id,
+              companyId: bridge.companyId,
+              workflowHandoffId: bridge.workflowHandoffId,
+              messageId: replyId,
+              reaction: "x",
+              target: "reply",
+              overrides,
+            });
+          }
+          const [staleRun] = await db
+            .select({ status: workflowRuns.status, error: workflowRuns.error })
+            .from(workflowRuns)
+            .where(eq(workflowRuns.id, bridge.workflowRunId))
+            .limit(1);
+          await db.update(workflowHandoffs).set({
+            status: "cancelled",
+            responseMarkdown: null,
+            decidedByUserId: "workflow_handoff_bridge",
+            decidedAt: now,
+            updatedAt: now,
+          }).where(and(
+            eq(workflowHandoffs.id, bridge.workflowHandoffId),
+            eq(workflowHandoffs.status, "pending"),
+          ));
+          const closeOutcome = staleRun?.status === "failed" && staleRun.error?.startsWith("Timed out after ")
+            ? "expired"
+            : staleRun?.status === "failed"
+              ? "failed"
+              : "cancelled";
+          await closeBridgeRow(db, bridge, closeOutcome, overrides);
+          await logActivity(db, {
+            companyId: bridge.companyId,
+            actorType: "system",
+            actorId: "workflow_handoff_bridge",
+            action: "workflow.handoff.bridge_closed_terminal",
+            entityType: "workflow_run",
+            entityId: bridge.workflowRunId,
+            details: {
+              bridgeId: bridge.id,
+              workflowHandoffId: bridge.workflowHandoffId,
+              provider: bridge.provider,
+              externalMessageId: bridge.externalMessageId ?? null,
+              runStatus: staleRun?.status ?? null,
+              runError: staleRun?.error ?? null,
+              closeOutcome,
+            },
+          });
+          summary.terminalClosed += 1;
+          continue;
+        }
+        for (const replyId of replyMessageIds) {
+          await applyReaction({
+            db,
+            bridgeId: bridge.id,
+            companyId: bridge.companyId,
+            workflowHandoffId: bridge.workflowHandoffId,
+            messageId: replyId,
+            reaction: "white_check_mark",
+            target: "reply",
+            overrides,
+          });
+        }
         await closeBridgeRow(db, bridge, resolution, overrides);
         summary.resolved += 1;
       } catch (error) {

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -292,12 +292,6 @@ async function resolveHandoffFromBridge(
 
   if (!resolved) return false;
 
-  await logActivity(db, {
-    companyId: bridge.companyId,
-    actorType: "system",
-    actorId: "workflow_handoff_bridge",
-    action: "workflow.handoff.bridge_resolved",
-    entityType: "workflow_run",
   try {
     await logActivity(db, {
       companyId: bridge.companyId,

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -298,16 +298,31 @@ async function resolveHandoffFromBridge(
     actorId: "workflow_handoff_bridge",
     action: "workflow.handoff.bridge_resolved",
     entityType: "workflow_run",
-    entityId: bridge.workflowRunId,
-    details: {
+  try {
+    await logActivity(db, {
+      companyId: bridge.companyId,
+      actorType: "system",
+      actorId: "workflow_handoff_bridge",
+      action: "workflow.handoff.bridge_resolved",
+      entityType: "workflow_run",
+      entityId: bridge.workflowRunId,
+      details: {
+        bridgeId: bridge.id,
+        workflowHandoffId: bridge.workflowHandoffId,
+        resolution,
+        provider: bridge.provider,
+        externalMessageId: bridge.externalMessageId ?? null,
+        externalThreadId: bridge.externalThreadId ?? null,
+      },
+    });
+  } catch (error) {
+    logger.warn({
+      err: error,
       bridgeId: bridge.id,
+      companyId: bridge.companyId,
       workflowHandoffId: bridge.workflowHandoffId,
-      resolution,
-      provider: bridge.provider,
-      externalMessageId: bridge.externalMessageId ?? null,
-      externalThreadId: bridge.externalThreadId ?? null,
-    },
-  });
+    }, "workflow handoff bridge: failed to log handoff resolution");
+  }
   return true;
 }
 

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -24,6 +24,9 @@ import type { AwaitingHumanNotificationPayload } from "./awaiting-human-notifica
 const POLL_INTERVAL_MS = 60_000;
 const POLL_FAILURE_BACKOFF_MS = 5 * 60 * 1000;
 const TERMINAL_WORKFLOW_RUN_STATUSES = ["succeeded", "failed", "cancelled"];
+type BridgeCloseOutcome = "responded" | "approved" | "rejected" | "expired" | "cancelled" | "failed";
+type ResolvedHandoffStatus = Extract<BridgeCloseOutcome, "responded" | "approved" | "rejected">;
+type TerminalBridgeCloseOutcome = Extract<BridgeCloseOutcome, "expired" | "cancelled" | "failed">;
 
 function truncateText(value: string, maxLength: number) {
   const compact = value.trim().replace(/\s+/g, " ");
@@ -148,7 +151,7 @@ async function removeReaction(input: {
 async function closeBridgeRow(
   db: Db,
   bridge: typeof workflowHandoffBridges.$inferSelect,
-  outcome: "responded" | "approved" | "rejected" | "expired" | "cancelled" | "failed",
+  outcome: BridgeCloseOutcome,
   overrides: { personalToken: string | null; workspaceId: string | null; channelId: string | null },
 ) {
   const now = new Date();
@@ -196,6 +199,16 @@ async function closeBridgeRow(
       overrides,
     });
   }
+}
+
+function isResolvedHandoffStatus(status: string | null | undefined): status is ResolvedHandoffStatus {
+  return status === "responded" || status === "approved" || status === "rejected";
+}
+
+function toCloseOutcome(run: { status: string | null; error: string | null } | null | undefined): TerminalBridgeCloseOutcome {
+  if (run?.status === "failed" && run.error?.startsWith("Timed out after ")) return "expired";
+  if (run?.status === "failed") return "failed";
+  return "cancelled";
 }
 
 async function recordBridgePollFailure(
@@ -604,11 +617,7 @@ export function workflowHandoffBridgeService(db: Db) {
             eq(workflowHandoffs.id, bridge.workflowHandoffId),
             eq(workflowHandoffs.status, "pending"),
           ));
-          const closeOutcome = run?.status === "failed" && run.error?.startsWith("Timed out after ")
-            ? "expired"
-            : run?.status === "failed"
-              ? "failed"
-              : "cancelled";
+          const closeOutcome = toCloseOutcome(run);
           await closeBridgeRow(db, bridge, closeOutcome, overrides);
           try {
             await logActivity(db, {
@@ -758,6 +767,14 @@ export function workflowHandoffBridgeService(db: Db) {
       try {
         const applied = await resolveHandoffFromBridge(db, bridge, resolution, responseMarkdown);
         if (!applied) {
+          const [currentHandoff] = await db
+            .select({ status: workflowHandoffs.status })
+            .from(workflowHandoffs)
+            .where(eq(workflowHandoffs.id, bridge.workflowHandoffId))
+            .limit(1);
+          const acceptedOutcome = isResolvedHandoffStatus(currentHandoff?.status)
+            ? currentHandoff.status
+            : null;
           for (const replyId of replyMessageIds) {
             await applyReaction({
               db,
@@ -765,7 +782,7 @@ export function workflowHandoffBridgeService(db: Db) {
               companyId: bridge.companyId,
               workflowHandoffId: bridge.workflowHandoffId,
               messageId: replyId,
-              reaction: "x",
+              reaction: acceptedOutcome ? "white_check_mark" : "x",
               target: "reply",
               overrides,
             });
@@ -775,21 +792,19 @@ export function workflowHandoffBridgeService(db: Db) {
             .from(workflowRuns)
             .where(eq(workflowRuns.id, bridge.workflowRunId))
             .limit(1);
-          await db.update(workflowHandoffs).set({
-            status: "cancelled",
-            responseMarkdown: null,
-            decidedByUserId: "workflow_handoff_bridge",
-            decidedAt: now,
-            updatedAt: now,
-          }).where(and(
-            eq(workflowHandoffs.id, bridge.workflowHandoffId),
-            eq(workflowHandoffs.status, "pending"),
-          ));
-          const closeOutcome = staleRun?.status === "failed" && staleRun.error?.startsWith("Timed out after ")
-            ? "expired"
-            : staleRun?.status === "failed"
-              ? "failed"
-              : "cancelled";
+          if (!acceptedOutcome) {
+            await db.update(workflowHandoffs).set({
+              status: "cancelled",
+              responseMarkdown: null,
+              decidedByUserId: "workflow_handoff_bridge",
+              decidedAt: now,
+              updatedAt: now,
+            }).where(and(
+              eq(workflowHandoffs.id, bridge.workflowHandoffId),
+              eq(workflowHandoffs.status, "pending"),
+            ));
+          }
+          const closeOutcome = acceptedOutcome ?? toCloseOutcome(staleRun);
           await closeBridgeRow(db, bridge, closeOutcome, overrides);
           try {
             await logActivity(db, {
@@ -807,6 +822,7 @@ export function workflowHandoffBridgeService(db: Db) {
                 externalThreadId: bridge.externalThreadId ?? null,
                 runStatus: staleRun?.status ?? null,
                 runError: staleRun?.error ?? null,
+                handoffStatus: currentHandoff?.status ?? null,
                 closeOutcome,
               },
             });
@@ -818,7 +834,11 @@ export function workflowHandoffBridgeService(db: Db) {
               workflowHandoffId: bridge.workflowHandoffId,
             }, "workflow handoff bridge: failed to log stale-run bridge closure");
           }
-          summary.terminalClosed += 1;
+          if (acceptedOutcome) {
+            summary.resolved += 1;
+          } else {
+            summary.terminalClosed += 1;
+          }
           continue;
         }
         for (const replyId of replyMessageIds) {

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -732,9 +732,28 @@ export function workflowHandoffBridgeService(db: Db) {
     return bridge ?? null;
   }
 
+  async function closeResolvedHandoff(
+    workflowHandoffId: string,
+    outcome: "responded" | "approved" | "rejected",
+  ) {
+    const bridge = await getActiveBridge(workflowHandoffId);
+    if (!bridge) return null;
+
+    const config = await settings.resolveClickUpRuntimeConfig(bridge.companyId);
+    const overrides = {
+      personalToken: config.personalToken,
+      workspaceId: config.workspaceId,
+      channelId: config.channelId,
+      attachmentTaskId: config.attachmentTaskId,
+    };
+    await closeBridgeRow(db, bridge, outcome, overrides);
+    return getBridgeForHandoff(workflowHandoffId);
+  }
+
   return {
     openForHandoff,
     pollActiveBridges,
+    closeResolvedHandoff,
     getActiveBridge,
     getBridgeForHandoff,
   };

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -1,10 +1,11 @@
-import { and, asc, desc, eq, inArray, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, lte, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   workflowHandoffBridges,
   workflowHandoffs,
   workflowRunPhases,
   workflowRuns,
+  workflows,
 } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
 import { logActivity } from "./activity-log.js";
@@ -13,8 +14,11 @@ import {
   addClickUpChatMessageReaction,
   deleteClickUpChatMessageReaction,
   detectClickUpAwaitingHumanBridgeEvents,
+  detectClickUpAwaitingHumanBridgeEventsAfterMessage,
   sendAwaitingHumanNotification,
+  sendAwaitingHumanNotificationReply,
 } from "./clickup-awaiting-human-transport.js";
+import type { AwaitingHumanNotificationResult } from "./awaiting-human-notifications.js";
 import type { AwaitingHumanNotificationPayload } from "./awaiting-human-notifications.js";
 
 const POLL_INTERVAL_MS = 60_000;
@@ -42,6 +46,56 @@ function buildHandoffNotification(handoff: {
       : "Reply with your response.",
     labels: ["workflow_handoff", handoff.kind],
   };
+}
+
+function buildWorkflowThreadNotification(input: {
+  workflowTitle: string | null;
+  workflowRunId: string;
+  inputMarkdown: string | null;
+  createdAt: Date | null;
+}): AwaitingHumanNotificationPayload {
+  const title = input.workflowTitle?.trim() || "Workflow";
+  const lines = [
+    `Workflow: ${title}`,
+    `Run ID: ${input.workflowRunId}`,
+  ];
+  if (input.createdAt) {
+    lines.push(`Created: ${input.createdAt.toISOString()}`);
+  }
+  const runInput = input.inputMarkdown?.trim();
+  if (runInput) {
+    lines.push("");
+    lines.push("Input:");
+    lines.push(truncateText(runInput, 800));
+  }
+  return {
+    title: `Workflow handoff: ${title}`,
+    summary: `Human input thread for workflow run ${input.workflowRunId}`,
+    body: lines.join("\n"),
+    link: "",
+    cta: "",
+    labels: ["workflow_handoff", "workflow_thread"],
+  };
+}
+
+function requireClickUpExternalId(
+  result: AwaitingHumanNotificationResult,
+  failurePrefix: string,
+) {
+  if (result.status !== "sent") {
+    throw Object.assign(
+      new Error(`${failurePrefix}: ${result.detail}`),
+      { code: "clickup_send_failed", status: 503 },
+    );
+  }
+  const externalId = result.externalId?.trim();
+  if (!externalId) {
+    throw Object.assign(
+      new Error(`${failurePrefix}: missing-external-id`),
+      { code: "clickup_send_failed", status: 503 },
+    );
+  }
+  return externalId;
 }
 
 async function applyReaction(input: {
@@ -251,6 +305,7 @@ async function resolveHandoffFromBridge(
       resolution,
       provider: bridge.provider,
       externalMessageId: bridge.externalMessageId ?? null,
+      externalThreadId: bridge.externalThreadId ?? null,
     },
   });
   return true;
@@ -295,8 +350,10 @@ export function workflowHandoffBridgeService(db: Db) {
     }
 
     const notification = buildHandoffNotification(handoff);
+    const externalThreadId = await getOrCreateWorkflowThreadId(handoff, overrides);
 
-    const result = await sendAwaitingHumanNotification(
+    const result = await sendAwaitingHumanNotificationReply(
+      externalThreadId,
       {
         companyId: handoff.companyId,
         issueId: handoff.id, // not an issue -- reusing field for context
@@ -306,14 +363,7 @@ export function workflowHandoffBridgeService(db: Db) {
       overrides,
     );
 
-    if (result.status !== "sent") {
-      throw Object.assign(
-        new Error(`Failed to post workflow handoff to ClickUp: ${result.detail}`),
-        { code: "clickup_send_failed", status: 503 },
-      );
-    }
-
-    const externalMessageId = result.externalId ?? null;
+    const externalMessageId = requireClickUpExternalId(result, "Failed to post workflow handoff question to ClickUp");
     const now = new Date();
 
     const [bridge] = await db.insert(workflowHandoffBridges).values({
@@ -323,6 +373,7 @@ export function workflowHandoffBridgeService(db: Db) {
       provider: "clickup",
       status: "waiting_for_human",
       externalMessageId,
+      externalThreadId,
       nextPollAt: new Date(now.getTime() + POLL_INTERVAL_MS),
     }).onConflictDoNothing({
       target: workflowHandoffBridges.workflowHandoffId,
@@ -354,10 +405,81 @@ export function workflowHandoffBridgeService(db: Db) {
         workflowHandoffId: handoff.id,
         provider: "clickup",
         externalMessageId,
+        externalThreadId,
       },
     });
 
     return bridge ?? null;
+  }
+
+  async function getExistingWorkflowThreadId(workflowRunId: string) {
+    const [bridge] = await db
+      .select({ externalThreadId: workflowHandoffBridges.externalThreadId })
+      .from(workflowHandoffBridges)
+      .where(and(
+        eq(workflowHandoffBridges.workflowRunId, workflowRunId),
+        eq(workflowHandoffBridges.provider, "clickup"),
+        isNotNull(workflowHandoffBridges.externalThreadId),
+      ))
+      .orderBy(asc(workflowHandoffBridges.createdAt))
+      .limit(1);
+    return bridge?.externalThreadId?.trim() || null;
+  }
+
+  async function loadWorkflowThreadContext(workflowRunId: string) {
+    const [row] = await db
+      .select({
+        workflowTitle: workflows.title,
+        workflowRunId: workflowRuns.id,
+        inputMarkdown: workflowRuns.inputMarkdown,
+        createdAt: workflowRuns.createdAt,
+      })
+      .from(workflowRuns)
+      .innerJoin(workflows, eq(workflows.id, workflowRuns.workflowId))
+      .where(eq(workflowRuns.id, workflowRunId))
+      .limit(1);
+    return row ?? {
+      workflowTitle: null,
+      workflowRunId,
+      inputMarkdown: null,
+      createdAt: null,
+    };
+  }
+
+  async function getOrCreateWorkflowThreadId(
+    handoff: {
+      id: string;
+      companyId: string;
+      workflowRunId: string;
+    },
+    overrides: { personalToken: string | null; workspaceId: string | null; channelId: string | null; attachmentTaskId: string | null },
+  ) {
+    const existingThreadId = await getExistingWorkflowThreadId(handoff.workflowRunId);
+    if (existingThreadId) return existingThreadId;
+
+    const context = await loadWorkflowThreadContext(handoff.workflowRunId);
+    const result = await sendAwaitingHumanNotification(
+      {
+        companyId: handoff.companyId,
+        issueId: handoff.id, // not an issue -- reusing field for context
+        handoffKind: "ask_user_questions",
+        notification: buildWorkflowThreadNotification(context),
+      },
+      overrides,
+    );
+    return requireClickUpExternalId(result, "Failed to post workflow thread to ClickUp");
+  }
+
+  async function detectBridgeEvents(
+    bridge: typeof workflowHandoffBridges.$inferSelect,
+    messageId: string,
+    overrides: { personalToken: string | null; workspaceId: string | null; channelId: string | null; attachmentTaskId: string | null },
+  ) {
+    const threadId = bridge.externalThreadId?.trim();
+    if (threadId && threadId !== messageId) {
+      return detectClickUpAwaitingHumanBridgeEventsAfterMessage(threadId, messageId, overrides);
+    }
+    return detectClickUpAwaitingHumanBridgeEvents(messageId, overrides);
   }
 
   async function pollActiveBridges() {
@@ -419,7 +541,7 @@ export function workflowHandoffBridgeService(db: Db) {
       if (!run || TERMINAL_WORKFLOW_RUN_STATUSES.includes(run.status)) {
         let detectedTerminal: Awaited<ReturnType<typeof detectClickUpAwaitingHumanBridgeEvents>>;
         try {
-          detectedTerminal = await detectClickUpAwaitingHumanBridgeEvents(messageId, overrides);
+          detectedTerminal = await detectBridgeEvents(bridge, messageId, overrides);
         } catch (error) {
           const detail = error instanceof Error ? error.message : String(error);
           logger.warn({
@@ -492,6 +614,7 @@ export function workflowHandoffBridgeService(db: Db) {
                 workflowHandoffId: bridge.workflowHandoffId,
                 provider: bridge.provider,
                 externalMessageId: bridge.externalMessageId ?? null,
+                externalThreadId: bridge.externalThreadId ?? null,
                 runStatus: run?.status ?? null,
                 runError: run?.error ?? null,
                 closeOutcome,
@@ -543,7 +666,7 @@ export function workflowHandoffBridgeService(db: Db) {
 
       let detected: Awaited<ReturnType<typeof detectClickUpAwaitingHumanBridgeEvents>>;
       try {
-        detected = await detectClickUpAwaitingHumanBridgeEvents(messageId, overrides);
+        detected = await detectBridgeEvents(bridge, messageId, overrides);
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         logger.error({
@@ -667,6 +790,7 @@ export function workflowHandoffBridgeService(db: Db) {
               workflowHandoffId: bridge.workflowHandoffId,
               provider: bridge.provider,
               externalMessageId: bridge.externalMessageId ?? null,
+              externalThreadId: bridge.externalThreadId ?? null,
               runStatus: staleRun?.status ?? null,
               runError: staleRun?.error ?? null,
               closeOutcome,

--- a/server/src/services/workflow-handoff-bridge.ts
+++ b/server/src/services/workflow-handoff-bridge.ts
@@ -415,21 +415,30 @@ export function workflowHandoffBridgeService(db: Db) {
       });
     }
 
-    await logActivity(db, {
-      companyId: handoff.companyId,
-      actorType: "system",
-      actorId: "workflow_handoff_bridge",
-      action: "workflow.handoff.bridge_opened",
-      entityType: "workflow_run",
-      entityId: handoff.workflowRunId,
-      details: {
+    try {
+      await logActivity(db, {
+        companyId: handoff.companyId,
+        actorType: "system",
+        actorId: "workflow_handoff_bridge",
+        action: "workflow.handoff.bridge_opened",
+        entityType: "workflow_run",
+        entityId: handoff.workflowRunId,
+        details: {
+          bridgeId: bridge?.id ?? null,
+          workflowHandoffId: handoff.id,
+          provider: "clickup",
+          externalMessageId,
+          externalThreadId,
+        },
+      });
+    } catch (error) {
+      logger.warn({
+        err: error,
         bridgeId: bridge?.id ?? null,
+        companyId: handoff.companyId,
         workflowHandoffId: handoff.id,
-        provider: "clickup",
-        externalMessageId,
-        externalThreadId,
-      },
-    });
+      }, "workflow handoff bridge: failed to log handoff open");
+    }
 
     return bridge ?? null;
   }

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -552,17 +552,16 @@ export function workflowService(db: Db) {
         finishedAt: now,
         updatedAt: now,
       }).where(inArray(workflowRuns.id, runIds)).returning({ id: workflowRuns.id });
-      if (runIds.length > 0) {
-        await db.update(workflowRunPhases).set({
-          status: "failed",
-          finishedAt: now,
-          updatedAt: now,
-        }).where(and(
-          inArray(workflowRunPhases.workflowRunId, runIds),
-          notInArray(workflowRunPhases.status, ["succeeded", "failed", "cancelled"]),
-        ));
-      }
-      return { failed: rows.length, runIds };
+      const failedRunIds = rows.map((row) => row.id);
+      await db.update(workflowRunPhases).set({
+        status: "failed",
+        finishedAt: now,
+        updatedAt: now,
+      }).where(and(
+        inArray(workflowRunPhases.workflowRunId, failedRunIds),
+        notInArray(workflowRunPhases.status, ["succeeded", "failed", "cancelled"]),
+      ));
+      return { failed: rows.length, runIds: failedRunIds };
     },
 
     list: async (companyId: string): Promise<WorkflowListItem[]> => {

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -38,6 +38,7 @@ import {
   collectWorkflowRuntimeArtifacts,
   prepareInstrumentedWorkflowRuntime,
 } from "./workflows-runtime.js";
+import { workflowHandoffBridgeService } from "./workflow-handoff-bridge.js";
 
 function toWorkflow(row: typeof workflows.$inferSelect): Workflow {
   return {
@@ -413,15 +414,48 @@ export function workflowService(db: Db) {
       await persistContextSnapshot();
     };
 
-    try {
-    await db.update(workflowRuns).set({
-      status: "running",
-      startedAt: new Date(),
-      updatedAt: new Date(),
-      contextSnapshot,
-    }).where(eq(workflowRuns.id, runId));
+    const finishOpenPhases = async (status: "succeeded" | "failed") => {
+      const phases = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, runId)).orderBy(asc(workflowRunPhases.ordinal));
+      if (phases.length === 0) {
+        const now = new Date();
+        await db.insert(workflowRunPhases).values({
+          companyId: workflow.companyId,
+          workflowRunId: runId,
+          phaseKey: "entrypoint",
+          label: "Entrypoint",
+          kind: "phase",
+          ordinal: 0,
+          status,
+          startedAt: now,
+          finishedAt: now,
+        }).catch(() => {});
+        return;
+      }
 
-    const result = await invokeGoogleAdk({
+      for (const phase of phases) {
+        if (["succeeded", "failed", "cancelled"].includes(phase.status)) continue;
+        const now = new Date();
+        await db.update(workflowRunPhases).set({
+          status,
+          startedAt: phase.startedAt ?? now,
+          finishedAt: now,
+          updatedAt: now,
+        }).where(and(
+          eq(workflowRunPhases.id, phase.id),
+          notInArray(workflowRunPhases.status, ["succeeded", "failed", "cancelled"]),
+        ));
+      }
+    };
+
+    try {
+      await db.update(workflowRuns).set({
+        status: "running",
+        startedAt: new Date(),
+        updatedAt: new Date(),
+        contextSnapshot,
+      }).where(eq(workflowRuns.id, runId));
+
+      const result = await invokeGoogleAdk({
         runId,
         agent: {
           id: workflow.id,
@@ -475,18 +509,7 @@ export function workflowService(db: Db) {
         }
       }
 
-      const phases = await db.select().from(workflowRunPhases).where(eq(workflowRunPhases.workflowRunId, runId)).orderBy(asc(workflowRunPhases.ordinal));
-      if (phases.every((phase) => phase.status === "idle")) {
-        const first = phases[0];
-        if (first) {
-          await db.update(workflowRunPhases).set({
-            status: result.errorMessage ? "failed" : "succeeded",
-            startedAt: new Date(),
-            finishedAt: new Date(),
-            updatedAt: new Date(),
-          }).where(and(eq(workflowRunPhases.id, first.id), eq(workflowRunPhases.status, "idle")));
-        }
-      }
+      await finishOpenPhases(result.errorMessage ? "failed" : "succeeded");
 
       await db.update(workflowRuns).set({
         status: result.errorMessage ? "failed" : "succeeded",
@@ -510,6 +533,7 @@ export function workflowService(db: Db) {
       } else {
         await persistContextSnapshot();
       }
+      await finishOpenPhases("failed");
       await db.update(workflowRuns).set({
         status: "failed",
         error: err instanceof Error ? err.message : String(err),
@@ -888,6 +912,16 @@ export function workflowService(db: Db) {
         eq(workflowRuns.id, existing.workflowRunId),
         notInArray(workflowRuns.status, ["succeeded", "failed", "cancelled"]),
       ));
+      try {
+        await workflowHandoffBridgeService(db).closeResolvedHandoff(updated.id, resolution);
+      } catch (error) {
+        logger.warn({
+          err: error,
+          workflowHandoffId: updated.id,
+          workflowRunId: existing.workflowRunId,
+          resolution,
+        }, "workflow handoff bridge: failed to close bridge after direct handoff resolution");
+      }
       return updated ? toWorkflowHandoff(updated) : null;
     },
   };

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -234,6 +234,8 @@ async function selectLatestDeliverableMap(db: Db, workflowIds: string[]) {
 const WORKFLOW_DETAIL_RUN_LIMIT = 20;
 const WORKFLOW_RUN_CONSOLE_ENTRY_LIMIT = 600;
 const WORKFLOW_RUN_EXCERPT_CHAR_LIMIT = 16_000;
+const WORKFLOW_ADK_TIMEOUT_SEC = 24 * 60 * 60;
+const WORKFLOW_INTERRUPTED_ERROR = "Workflow process was interrupted before completion.";
 
 function appendWorkflowRunExcerpt(existing: string, chunk: string) {
   const next = `${existing}${chunk}`;
@@ -364,7 +366,10 @@ export function workflowService(db: Db) {
       workflowId: workflow.id,
       runId,
       companyId: workflow.companyId,
-      runnerConfig: workflow.runnerConfig,
+      runnerConfig: {
+        ...workflow.runnerConfig,
+        timeoutSec: WORKFLOW_ADK_TIMEOUT_SEC,
+      },
       analysis,
       runToken,
     });
@@ -528,6 +533,28 @@ export function workflowService(db: Db) {
   }
 
   return {
+    failInterruptedActiveRuns: async () => {
+      const now = new Date();
+      const rows = await db.update(workflowRuns).set({
+        status: "failed",
+        error: WORKFLOW_INTERRUPTED_ERROR,
+        finishedAt: now,
+        updatedAt: now,
+      }).where(inArray(workflowRuns.status, ["queued", "running", "awaiting_human"])).returning({ id: workflowRuns.id });
+      const runIds = rows.map((row) => row.id);
+      if (runIds.length > 0) {
+        await db.update(workflowRunPhases).set({
+          status: "failed",
+          finishedAt: now,
+          updatedAt: now,
+        }).where(and(
+          inArray(workflowRunPhases.workflowRunId, runIds),
+          notInArray(workflowRunPhases.status, ["succeeded", "failed", "cancelled"]),
+        ));
+      }
+      return { failed: rows.length, runIds };
+    },
+
     list: async (companyId: string): Promise<WorkflowListItem[]> => {
       const rows = await db.select().from(workflows).where(eq(workflows.companyId, companyId)).orderBy(desc(workflows.updatedAt));
       const items = rows.map(toWorkflow);

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { and, asc, desc, eq, inArray, notInArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   workflowDeliverables,
@@ -579,6 +579,7 @@ export function workflowService(db: Db) {
       const failedRunIds = rows.map((row) => row.id);
       await db.update(workflowRunPhases).set({
         status: "failed",
+        startedAt: sql`COALESCE(${workflowRunPhases.startedAt}, ${now.toISOString()}::timestamptz)`,
         finishedAt: now,
         updatedAt: now,
       }).where(and(

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -535,13 +535,23 @@ export function workflowService(db: Db) {
   return {
     failInterruptedActiveRuns: async () => {
       const now = new Date();
+      const candidates = await db
+        .select({ id: workflowRuns.id })
+        .from(workflowRuns)
+        .innerJoin(workflows, eq(workflowRuns.workflowId, workflows.id))
+        .where(and(
+          eq(workflows.runnerType, "google_adk"),
+          inArray(workflowRuns.status, ["queued", "running", "awaiting_human"]),
+        ));
+      const runIds = candidates.map((row) => row.id);
+      if (runIds.length === 0) return { failed: 0, runIds };
+
       const rows = await db.update(workflowRuns).set({
         status: "failed",
         error: WORKFLOW_INTERRUPTED_ERROR,
         finishedAt: now,
         updatedAt: now,
-      }).where(inArray(workflowRuns.status, ["queued", "running", "awaiting_human"])).returning({ id: workflowRuns.id });
-      const runIds = rows.map((row) => row.id);
+      }).where(inArray(workflowRuns.id, runIds)).returning({ id: workflowRuns.id });
       if (runIds.length > 0) {
         await db.update(workflowRunPhases).set({
           status: "failed",

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -575,7 +575,10 @@ export function workflowService(db: Db) {
         error: WORKFLOW_INTERRUPTED_ERROR,
         finishedAt: now,
         updatedAt: now,
-      }).where(inArray(workflowRuns.id, runIds)).returning({ id: workflowRuns.id });
+      }).where(and(
+        inArray(workflowRuns.id, runIds),
+        inArray(workflowRuns.status, ["queued", "running", "awaiting_human"]),
+      )).returning({ id: workflowRuns.id });
       const failedRunIds = rows.map((row) => row.id);
       await db.update(workflowRunPhases).set({
         status: "failed",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Workflow runs are the subsystem involved here, specifically Google ADK workflow execution and ClickUp human handoff bridges.
> - Longer workflows can ask for human input more than once, and separate ClickUp messages made those waits hard to follow because context was split across multiple prompts.
> - Workflow waits can also time out, fail, or be interrupted while an external ClickUp prompt still looks active.
> - This pull request makes workflow ClickUp handoffs more coherent by keeping follow-up waits from the same workflow run in one ClickUp thread.
> - It also keeps terminal workflow states honest by closing stale ClickUp bridges visibly instead of accepting late replies as success.
> - The benefit is a clearer human-in-the-loop lifecycle: one workflow conversation in ClickUp, full prompt text, and explicit closure when the run can no longer continue.

## What Changed

- Added workflow-only ClickUp threaded handoffs: the first human wait creates a workflow root message, posts the active question as a reply, and later waits in the same workflow run reuse that root thread.
- Uses existing bridge fields without a migration: `externalThreadId` stores the ClickUp workflow root message and `externalMessageId` stores the current bot question reply marker.
- Preserves backward compatibility for existing bridge rows with no `externalThreadId` by polling `externalMessageId` with the previous one-message-per-handoff behavior.
- Added marker-aware ClickUp reply polling so older thread replies are ignored and only human replies after the current bot question can resolve the active handoff.
- Normalizes ClickUp replies chronologically before marker detection, which handles ClickUp returning replies newest-first.
- Fixed workflow handoff text truncation by keeping the root/context message compact while allowing the actual question or approval reply to use a larger ClickUp-safe body budget.
- Kept workflow safety behavior: terminal or late replies close/reject the bridge rather than waking failed or timed-out workflow runs.
- Retains the earlier lifecycle cleanup in this PR: 24-hour workflow timeout, startup failure for interrupted active Google ADK runs, and visible ClickUp bridge closure for terminal runs.
- Added targeted ClickUp transport and workflow handoff bridge coverage for threaded posting, marker-aware polling, fallback polling, truncation behavior, and terminal cleanup.

## Verification

- `rtk pnpm exec vitest run server/src/__tests__/clickup-awaiting-human-transport.test.ts server/src/__tests__/workflow-handoff-bridge.test.ts` passed: 25 tests.
- `rtk pnpm -r typecheck` passed.
- Earlier verification for the original timeout/restart scope passed with `pnpm --filter @paperclipai/server exec vitest run src/__tests__/workflow-service-run-manual.test.ts src/__tests__/workflow-handoff-bridge.test.ts` and server typecheck.
- Earlier full `pnpm test` hit existing/local-suite failures unrelated to this PR, including UI `localStorage.clear is not a function` failures and long-test timeouts; the targeted workflow tests passed.
- Manual ClickUp smoke testing confirmed follow-up workflow waits can stay under the same root thread and long approval text is no longer cut off in the question reply.

## Risks

- ClickUp thread behavior depends on the root message id being saved in `externalThreadId`; if root creation succeeds but question reply creation fails, the handoff fails like other ClickUp send failures and a retry may create a fresh root.
- Reply ordering from ClickUp is normalized before detection, but future API response shape changes could require parser updates.
- Longer ClickUp reply bodies reduce truncation but still respect a conservative limit below ClickUp's documented 40,000 character message cap.
- Workflow timeout behavior changes from the previous 5-minute workflow timeout path to a fixed 24-hour wall-clock timeout.
- Startup recovery intentionally fails active workflow runs after restart because the ADK process is gone and this PR does not implement replay/resume.
- ClickUp cleanup failures should not move terminal workflow runs back to active, but external reactions still depend on ClickUp API availability.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 coding agent with tool use and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge