### PR TITLE
Add connection test mode for reviewer mentions

### DIFF
--- a/packages/shared/src/types/awaiting-human-settings.ts
+++ b/packages/shared/src/types/awaiting-human-settings.ts
@@ -25,6 +25,7 @@ export interface UpdateCompanyAwaitingHumanSettingsRequest {
   provider?: AwaitingHumanProvider | null;
   providerConfig?: AwaitingHumanProviderConfig | null;
   clickupPersonalToken?: string | null;
+  connectionTestMode?: "channel" | "reviewers";
 }
 
 export interface ClickUpAwaitingHumanConnectionTestResult {

--- a/packages/shared/src/validators/awaiting-human-settings.ts
+++ b/packages/shared/src/validators/awaiting-human-settings.ts
@@ -25,6 +25,7 @@ export const patchCompanyAwaitingHumanSettingsSchema = z.object({
   provider: awaitingHumanProviderSchema.nullable().optional(),
   providerConfig: clickupAwaitingHumanProviderConfigSchema.nullable().optional(),
   clickupPersonalToken: z.string().min(1).optional().nullable(),
+  connectionTestMode: z.enum(["channel", "reviewers"]).optional(),
 }).superRefine((value, ctx) => {
   if (value.provider === null && value.providerConfig != null) {
     ctx.addIssue({

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -463,6 +463,36 @@ describe("sendClickUpTransportTestMessage reviewer mentions", () => {
     expect(body.content).toContain("Primary reviewer: clickup://user/primary-user-id");
     expect(body.content).toContain("Secondary reviewer: clickup://user/secondary-user-id");
   });
+
+  it("omits the reviewer section when no reviewer mentions are configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ id: "message-reviewers" }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendClickUpTransportTestMessage({
+      title: "Bizbox ClickUp reviewer mention test",
+      summary: "Bizbox completed a reviewer mention test for ClickUp.",
+      body: "The configured bridge successfully delivered a reviewer mention test payload to the target ClickUp channel.",
+      link: "https://bizbox.example/company/settings/awaiting-human",
+      cta: "No action is required.",
+      reviewerMentions: [
+        { label: "Primary reviewer", userId: null },
+        { label: "Secondary reviewer", userId: undefined },
+      ],
+    }, {
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-9",
+    });
+
+    expect(result.status).toBe("sent");
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.content).not.toContain("Reviewer mention test:");
+    expect(body.content).not.toContain("not configured");
+  });
 });
 
 describe("detectClickUpAwaitingHumanBridgeEvents", () => {

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -4,6 +4,7 @@ import {
   deleteClickUpChatMessageReaction,
   detectClickUpAwaitingHumanBridgeEvents,
   getClickUpChatMessageReplies,
+  sendClickUpTransportTestMessage,
   sendAwaitingHumanNotification,
   uploadClickUpReviewFile,
 } from "../services/clickup-awaiting-human-transport.js";
@@ -428,6 +429,39 @@ describe("sendAwaitingHumanNotification review context", () => {
     expect(body.content).toContain("Reviewer: clickup://user/primary-user-id");
     expect(body.content).toContain("Next reviewer: clickup://user/secondary-user-id");
     expect(body.content).toContain("Next step:");
+  });
+});
+
+describe("sendClickUpTransportTestMessage reviewer mentions", () => {
+  it("renders reviewer mention links when reviewer testing is requested", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ id: "message-reviewers" }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendClickUpTransportTestMessage({
+      title: "Bizbox ClickUp reviewer mention test",
+      summary: "Bizbox completed a reviewer mention test for ClickUp.",
+      body: "The configured bridge successfully delivered a reviewer mention test payload to the target ClickUp channel.",
+      link: "https://bizbox.example/company/settings/awaiting-human",
+      cta: "No action is required.",
+      reviewerMentions: [
+        { label: "Primary reviewer", userId: "primary-user-id" },
+        { label: "Secondary reviewer", userId: "secondary-user-id" },
+      ],
+    }, {
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-9",
+    });
+
+    expect(result.status).toBe("sent");
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.content).toContain("Reviewer mention test:");
+    expect(body.content).toContain("Primary reviewer: clickup://user/primary-user-id");
+    expect(body.content).toContain("Secondary reviewer: clickup://user/secondary-user-id");
   });
 });
 

--- a/server/src/__tests__/company-awaiting-human-settings-route.test.ts
+++ b/server/src/__tests__/company-awaiting-human-settings-route.test.ts
@@ -169,4 +169,61 @@ describe("PATCH /api/companies/:companyId/awaiting-human-settings", () => {
       action: "company.awaiting_human_settings.connection_tested",
     }));
   });
+
+  it("sends reviewer mention test message when requested", async () => {
+    mockCompanyService.getById.mockResolvedValueOnce({
+      id: "company-1",
+      name: "Bizbox",
+    });
+    mockAwaitingHumanSettingsService.resolveClickUpRuntimeConfig.mockRejectedValueOnce(new Error("awaiting-human-bridge-disabled"));
+    mockSendClickUpTransportTestMessage.mockResolvedValueOnce({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId: "message-2",
+    });
+
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/companies/company-1/awaiting-human-settings/connection-test")
+      .send({
+        provider: "clickup",
+        connectionTestMode: "reviewers",
+        providerConfig: {
+          workspaceId: "workspace-1",
+          channelId: "channel-1",
+          primaryReviewerUserId: "primary-user-id",
+          secondaryReviewerUserId: "secondary-user-id",
+        },
+        clickupPersonalToken: "token-123",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "ClickUp reviewer mention test succeeded. Message delivered to configured channel (message message-2).",
+      externalId: "message-2",
+    });
+    expect(mockSendClickUpTransportTestMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Bizbox ClickUp reviewer mention test",
+        summary: "Bizbox completed a reviewer mention test for ClickUp.",
+        body: "The configured bridge successfully delivered a reviewer mention test payload to the target ClickUp channel.",
+        cta: "No action is required.",
+        reviewerMentions: [
+          { label: "Primary reviewer", userId: "primary-user-id" },
+          { label: "Secondary reviewer", userId: "secondary-user-id" },
+        ],
+      }),
+      {
+        personalToken: "token-123",
+        workspaceId: "workspace-1",
+        channelId: "channel-1",
+        primaryReviewerUserId: "primary-user-id",
+        secondaryReviewerUserId: "secondary-user-id",
+      },
+    );
+  });
 });

--- a/server/src/__tests__/company-awaiting-human-settings-route.test.ts
+++ b/server/src/__tests__/company-awaiting-human-settings-route.test.ts
@@ -1,6 +1,5 @@
-import express from "express";
-import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { companyAwaitingHumanSettingsRoutes } from "../routes/company-awaiting-human-settings.js";
 
 const mockCompanyService = vi.hoisted(() => ({
   list: vi.fn(),
@@ -35,7 +34,6 @@ const mockAwaitingHumanSettingsService = vi.hoisted(() => ({
   get: vi.fn(),
   update: vi.fn(),
   resolveProvider: vi.fn(),
-  resolveClickUpRuntimeConfig: vi.fn(),
   getStored: vi.fn(),
 }));
 
@@ -60,57 +58,92 @@ vi.mock("../services/index.js", () => ({
   logActivity: mockLogActivity,
 }));
 
+vi.mock("../routes/builder.js", () => ({
+  companyBuilderRoutes: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 vi.mock("../services/clickup-awaiting-human-transport.js", () => ({
   sendClickUpTransportTestMessage: mockSendClickUpTransportTestMessage,
 }));
 
-async function createApp() {
-  const [{ companyRoutes }, { errorHandler }] = await Promise.all([
-    vi.importActual<typeof import("../routes/companies.js")>("../routes/companies.js"),
-    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
-  ]);
-  const app = express();
-  app.use(express.json());
-  app.use((req, _res, next) => {
-    (req as any).actor = {
+type MockResponse = {
+  statusCode: number;
+  body: unknown;
+  status(code: number): MockResponse;
+  json(payload: unknown): MockResponse;
+};
+
+function createMockResponse(): MockResponse {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+async function runConnectionTestRoute(body: unknown) {
+  const router = companyAwaitingHumanSettingsRoutes({} as any);
+  const routeLayer = router.stack.find(
+    (layer: any) => layer.route?.path === "/connection-test" && layer.route?.methods?.post,
+  );
+  if (!routeLayer?.route?.stack?.length) {
+    throw new Error("connection-test route not found");
+  }
+  const [validateMiddleware, connectionTestHandler] = routeLayer.route.stack.map((layer: any) => layer.handle);
+  const req: any = {
+    body,
+    params: { companyId: "company-1" },
+    actor: {
       type: "board",
       userId: "user-1",
       source: "local_implicit",
-    };
-    next();
-  });
-  app.use("/api/companies", companyRoutes({} as any));
-  app.use(errorHandler);
-  return app;
+    },
+  };
+  const res = createMockResponse();
+
+  try {
+    validateMiddleware(req, res, () => undefined);
+    await connectionTestHandler(req, res, () => undefined);
+    return res;
+  } catch (error) {
+    const { errorHandler } = await vi.importActual<typeof import("../middleware/index.js")>(
+      "../middleware/index.js",
+    );
+    const errorRes = createMockResponse();
+    errorHandler(error as Error, req, errorRes as any, () => undefined);
+    return errorRes;
+  }
 }
 
 describe("PATCH /api/companies/:companyId/awaiting-human-settings", () => {
   beforeEach(() => {
     vi.resetModules();
-    vi.doUnmock("../routes/companies.js");
     vi.doUnmock("../routes/authz.js");
     vi.doUnmock("../middleware/index.js");
     vi.resetAllMocks();
   });
 
   it("rejects invalid payloads before company lookup runs", async () => {
-    const app = await createApp();
+    const res = await runConnectionTestRoute({
+      enabled: true,
+      provider: "clickup",
+      providerConfig: {
+        workspaceId: 123,
+        channelId: "channel-1",
+        primaryReviewerUserId: null,
+        secondaryReviewerUserId: null,
+      },
+    });
 
-    const res = await request(app)
-      .patch("/api/companies/company-1/awaiting-human-settings")
-      .send({
-        enabled: true,
-        provider: "clickup",
-        providerConfig: {
-          workspaceId: 123,
-          channelId: "channel-1",
-          primaryReviewerUserId: null,
-          secondaryReviewerUserId: null,
-        },
-      });
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toBe("Validation error");
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { error?: string } | undefined)?.error).toBe("Validation error");
     expect(mockCompanyService.getById).not.toHaveBeenCalled();
     expect(mockAwaitingHumanSettingsService.update).not.toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalled();
@@ -129,42 +162,40 @@ describe("PATCH /api/companies/:companyId/awaiting-human-settings", () => {
       externalId: "message-1",
     });
 
-    const app = await createApp();
+    const res = await runConnectionTestRoute({
+      provider: "clickup",
+      providerConfig: {
+        workspaceId: "workspace-1",
+        channelId: "channel-1",
+        primaryReviewerUserId: null,
+        secondaryReviewerUserId: null,
+      },
+      clickupPersonalToken: "token-123",
+    });
 
-    const res = await request(app)
-      .post("/api/companies/company-1/awaiting-human-settings/connection-test")
-      .send({
-        provider: "clickup",
-        providerConfig: {
-          workspaceId: "workspace-1",
-          channelId: "channel-1",
-          primaryReviewerUserId: null,
-          secondaryReviewerUserId: null,
-        },
-        clickupPersonalToken: "token-123",
-      });
-
-    expect(res.status).toBe(200);
+    expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
       status: "sent",
       channel: "clickup-chat",
       detail: "ClickUp bridge connection test succeeded. Message delivered to configured channel (message message-1).",
       externalId: "message-1",
     });
-    expect(mockSendClickUpTransportTestMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: "Bizbox ClickUp bridge connection test",
-        summary: "Bizbox completed a bridge transport test for ClickUp.",
-        body: "The configured bridge successfully delivered a test payload to the target ClickUp channel.",
-        link: "http://localhost:3100/CITAAAA/company/settings/awaiting-human",
-        cta: "No action is required.",
-      }),
-      {
-        personalToken: "token-123",
-        workspaceId: "workspace-1",
-        channelId: "channel-1",
-      },
-    );
+    const [transportPayload, transportOverrides] = mockSendClickUpTransportTestMessage.mock.calls[0] ?? [];
+    expect(transportPayload).toMatchObject({
+      title: "Bizbox ClickUp bridge connection test",
+      summary: "Bizbox completed a bridge transport test for ClickUp.",
+      body: "The configured bridge successfully delivered a test payload to the target ClickUp channel.",
+      link: "http://localhost:3100/CITAAAA/company/settings/awaiting-human",
+      cta: "No action is required.",
+      reviewerMentions: [],
+    });
+    expect(transportOverrides).toEqual({
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-1",
+      primaryReviewerUserId: null,
+      secondaryReviewerUserId: null,
+    });
     expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       action: "company.awaiting_human_settings.connection_tested",
     }));
@@ -175,7 +206,6 @@ describe("PATCH /api/companies/:companyId/awaiting-human-settings", () => {
       id: "company-1",
       name: "Bizbox",
     });
-    mockAwaitingHumanSettingsService.resolveClickUpRuntimeConfig.mockRejectedValueOnce(new Error("awaiting-human-bridge-disabled"));
     mockSendClickUpTransportTestMessage.mockResolvedValueOnce({
       status: "sent",
       channel: "clickup-chat",
@@ -183,23 +213,19 @@ describe("PATCH /api/companies/:companyId/awaiting-human-settings", () => {
       externalId: "message-2",
     });
 
-    const app = await createApp();
+    const res = await runConnectionTestRoute({
+      provider: "clickup",
+      connectionTestMode: "reviewers",
+      providerConfig: {
+        workspaceId: "workspace-1",
+        channelId: "channel-1",
+        primaryReviewerUserId: "primary-user-id",
+        secondaryReviewerUserId: "secondary-user-id",
+      },
+      clickupPersonalToken: "token-123",
+    });
 
-    const res = await request(app)
-      .post("/api/companies/company-1/awaiting-human-settings/connection-test")
-      .send({
-        provider: "clickup",
-        connectionTestMode: "reviewers",
-        providerConfig: {
-          workspaceId: "workspace-1",
-          channelId: "channel-1",
-          primaryReviewerUserId: "primary-user-id",
-          secondaryReviewerUserId: "secondary-user-id",
-        },
-        clickupPersonalToken: "token-123",
-      });
-
-    expect(res.status).toBe(200);
+    expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
       status: "sent",
       channel: "clickup-chat",

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { createServer } from "node:http";
 import { and, asc, eq } from "drizzle-orm";
 import { WebSocketServer } from "ws";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   agents,
   agentWakeupRequests,
@@ -18,6 +18,27 @@ import {
   issueComments,
   issues,
 } from "@paperclipai/db";
+vi.mock("@paperclipai/adapter-google-adk/server", () => ({
+  execute: async () => ({ exitCode: 0, signal: null, timedOut: false }),
+  testEnvironment: async () => ({
+    adapterType: "google_adk",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+}));
+vi.mock("@paperclipai/adapter-google-adk", () => ({
+  agentConfigurationDoc: "",
+  models: [],
+}));
+vi.mock("../otel.js", () => ({
+  recordComment: vi.fn(),
+  recordIssueStatusChanged: vi.fn(),
+  recordRunStatus: vi.fn(),
+}));
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => null),
+}));
 import { heartbeatService } from "../services/heartbeat.ts";
 
 function extractStructuredWakePayload(message: unknown): Record<string, unknown> | null {
@@ -236,8 +257,11 @@ describe("heartbeat comment wake batching", () => {
   let db!: ReturnType<typeof createDb>;
   let instance: EmbeddedPostgresInstance | null = null;
   let dataDir = "";
+  let previousBindEnv: string | undefined;
 
   beforeAll(async () => {
+    previousBindEnv = process.env.BIZBOX_BIND;
+    process.env.BIZBOX_BIND = "loopback";
     const started = await startTempDatabase();
     db = createDb(started.connectionString);
     instance = started.instance;
@@ -245,6 +269,11 @@ describe("heartbeat comment wake batching", () => {
   }, 45_000);
 
   afterAll(async () => {
+    if (previousBindEnv === undefined) {
+      delete process.env.BIZBOX_BIND;
+    } else {
+      process.env.BIZBOX_BIND = previousBindEnv;
+    }
     await closeDbClient(db);
     await instance?.stop();
     if (dataDir) {
@@ -679,6 +708,7 @@ describe("heartbeat comment wake batching", () => {
       });
 
       await heartbeat.cancelRun(firstRun!.id);
+      gateway.releaseFirstWait();
 
       await waitFor(() => gateway.getAgentPayloads().length === 2);
       const promotedPayload = gateway.getAgentPayloads()[1] ?? {};
@@ -697,7 +727,6 @@ describe("heartbeat comment wake batching", () => {
       });
       expect(String(promotedPayload.message ?? "")).toContain("Queued follow-up");
 
-      gateway.releaseFirstWait();
       await waitFor(async () => {
         const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
         return runs.length === 2 && runs.every((run) => ["cancelled", "succeeded"].includes(run.status));

--- a/server/src/routes/company-awaiting-human-settings.ts
+++ b/server/src/routes/company-awaiting-human-settings.ts
@@ -77,8 +77,14 @@ export function companyAwaitingHumanSettingsRoutes(db: Db) {
 
     const body = req.body as {
       provider?: "clickup" | null;
-      providerConfig?: { workspaceId: string | null; channelId: string | null } | null;
+      providerConfig?: {
+        workspaceId: string | null;
+        channelId: string | null;
+        primaryReviewerUserId?: string | null;
+        secondaryReviewerUserId?: string | null;
+      } | null;
       clickupPersonalToken?: string | null;
+      connectionTestMode?: "channel" | "reviewers";
     };
     const actor = getActorInfo(req);
     const stored = await settings.getStored(companyId);
@@ -103,19 +109,75 @@ export function companyAwaitingHumanSettingsRoutes(db: Db) {
       channelId: body.providerConfig !== undefined
         ? body.providerConfig?.channelId ?? null
         : storedConfig?.channelId ?? null,
+      primaryReviewerUserId: body.providerConfig !== undefined
+        ? body.providerConfig?.primaryReviewerUserId ?? null
+        : storedConfig?.primaryReviewerUserId ?? null,
+      secondaryReviewerUserId: body.providerConfig !== undefined
+        ? body.providerConfig?.secondaryReviewerUserId ?? null
+        : storedConfig?.secondaryReviewerUserId ?? null,
     };
 
+    const connectionTestMode = body.connectionTestMode ?? "channel";
+    const reviewerMentions = connectionTestMode === "reviewers"
+      ? [
+        {
+          label: "Primary reviewer",
+          userId: runtimeOverrides.primaryReviewerUserId,
+        },
+        {
+          label: "Secondary reviewer",
+          userId: runtimeOverrides.secondaryReviewerUserId,
+        },
+      ]
+      : [];
+    const hasReviewerMentionTarget = reviewerMentions.some((mention) => trimNullable(mention.userId));
+    if (connectionTestMode === "reviewers" && !hasReviewerMentionTarget) {
+      const skippedResult = {
+        status: "skipped" as const,
+        channel: "clickup-chat" as const,
+        detail: "missing-target: primary and secondary reviewer user IDs are not configured",
+      };
+      const redactedBody = "clickupPersonalToken" in body && body.clickupPersonalToken != null
+        ? { ...body, clickupPersonalToken: "[REDACTED]" }
+        : body;
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "company.awaiting_human_settings.connection_tested",
+        entityType: "company",
+        entityId: companyId,
+        details: {
+          ...redactedBody,
+          result: skippedResult,
+        },
+      });
+      res.json(skippedResult);
+      return;
+    }
+
     const result = await sendClickUpTransportTestMessage({
-      title: `${company.name} ClickUp bridge connection test`,
-      summary: "Bizbox completed a bridge transport test for ClickUp.",
-      body: "The configured bridge successfully delivered a test payload to the target ClickUp channel.",
+      title: connectionTestMode === "reviewers"
+        ? `${company.name} ClickUp reviewer mention test`
+        : `${company.name} ClickUp bridge connection test`,
+      summary: connectionTestMode === "reviewers"
+        ? "Bizbox completed a reviewer mention test for ClickUp."
+        : "Bizbox completed a bridge transport test for ClickUp.",
+      body: connectionTestMode === "reviewers"
+        ? "The configured bridge successfully delivered a reviewer mention test payload to the target ClickUp channel."
+        : "The configured bridge successfully delivered a test payload to the target ClickUp channel.",
       link: new URL(`/${company.issuePrefix}/company/settings/awaiting-human`, process.env.BIZBOX_API_URL ?? "http://localhost:3100").toString(),
       cta: "No action is required.",
+      reviewerMentions,
     }, runtimeOverrides);
     const publicResult = result.status === "sent"
       ? {
         ...result,
-        detail: `ClickUp bridge connection test succeeded. Message delivered to configured channel${result.externalId ? ` (message ${result.externalId})` : ""}.`,
+        detail: connectionTestMode === "reviewers"
+          ? `ClickUp reviewer mention test succeeded. Message delivered to configured channel${result.externalId ? ` (message ${result.externalId})` : ""}.`
+          : `ClickUp bridge connection test succeeded. Message delivered to configured channel${result.externalId ? ` (message ${result.externalId})` : ""}.`,
       }
       : result;
 

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -25,6 +25,10 @@ export interface ClickUpTransportTestNotification {
   link: string;
   body?: string | null;
   cta?: string | null;
+  reviewerMentions?: Array<{
+    label: string;
+    userId: string | null | undefined;
+  }>;
 }
 
 type ClickUpChatConfig = {
@@ -352,6 +356,18 @@ function renderClickUpTransportTestMessage(
   if (bodySection) {
     lines.push("");
     lines.push(bodySection);
+  }
+
+  if (notification.reviewerMentions?.length) {
+    const mentionLines = notification.reviewerMentions.map((mention) => {
+      const userMention = formatClickUpUserMention(mention.userId);
+      return `${mention.label}: ${userMention ?? "not configured"}`;
+    });
+    if (mentionLines.some((line) => !line.endsWith("not configured"))) {
+      lines.push("");
+      lines.push("Reviewer mention test:");
+      lines.push(...mentionLines);
+    }
   }
 
   if (notification.cta?.trim()) {

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -359,11 +359,14 @@ function renderClickUpTransportTestMessage(
   }
 
   if (notification.reviewerMentions?.length) {
-    const mentionLines = notification.reviewerMentions.map((mention) => {
-      const userMention = formatClickUpUserMention(mention.userId);
-      return `${mention.label}: ${userMention ?? "not configured"}`;
-    });
-    if (mentionLines.some((line) => !line.endsWith("not configured"))) {
+    const hasConfiguredReviewerMention = notification.reviewerMentions.some(
+      (mention) => formatClickUpUserMention(mention.userId) !== null,
+    );
+    if (hasConfiguredReviewerMention) {
+      const mentionLines = notification.reviewerMentions.map((mention) => {
+        const userMention = formatClickUpUserMention(mention.userId);
+        return `${mention.label}: ${userMention ?? "not configured"}`;
+      });
       lines.push("");
       lines.push("Reviewer mention test:");
       lines.push(...mentionLines);

--- a/ui/src/pages/CompanyAwaitingHumanSettings.tsx
+++ b/ui/src/pages/CompanyAwaitingHumanSettings.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/select";
 
 type AwaitingHumanProviderValue = "none" | "clickup";
+type ConnectionTestMode = "channel" | "reviewers";
 
 export function CompanyAwaitingHumanSettings() {
   const { selectedCompany, selectedCompanyId } = useCompany();
@@ -85,8 +86,8 @@ export function CompanyAwaitingHumanSettings() {
     },
   });
 
-  const connectionTestMutation = useMutation<ClickUpAwaitingHumanConnectionTestResult, Error>({
-    mutationFn: async () => {
+  const connectionTestMutation = useMutation<ClickUpAwaitingHumanConnectionTestResult, Error, ConnectionTestMode>({
+    mutationFn: async (connectionTestMode) => {
       if (!selectedCompany) {
         throw new Error("No company selected");
       }
@@ -103,6 +104,7 @@ export function CompanyAwaitingHumanSettings() {
           }
           : null,
         clickupPersonalToken: provider === "clickup" ? (personalToken.trim() || null) : null,
+        connectionTestMode,
       });
     },
   });
@@ -150,6 +152,7 @@ export function CompanyAwaitingHumanSettings() {
     || primaryReviewerUserId !== (settings?.providerConfig?.primaryReviewerUserId ?? "")
     || secondaryReviewerUserId !== (settings?.providerConfig?.secondaryReviewerUserId ?? "");
   const providerEnabled = provider !== "none";
+  const hasReviewerMentions = primaryReviewerUserId.trim().length > 0 || secondaryReviewerUserId.trim().length > 0;
   const hasStoredClickUpToken = settings?.hasStoredAuthToken ?? false;
 
   return (
@@ -308,17 +311,27 @@ export function CompanyAwaitingHumanSettings() {
               <div className="space-y-0.5">
                 <p className="text-xs font-medium text-foreground">Connection test</p>
                 <p className="text-[11px] text-muted-foreground">
-                  Sends a test message to the configured ClickUp channel using current fields.
+                  Sends a test message to the configured ClickUp channel and, if present, mentions the configured primary and secondary reviewers.
                 </p>
               </div>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => connectionTestMutation.mutate()}
-                disabled={!providerEnabled || connectionTestMutation.isPending}
-              >
-                {connectionTestMutation.isPending ? "Testing..." : "Test channel"}
-              </Button>
+              <div className="flex flex-wrap justify-end gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => connectionTestMutation.mutate("channel")}
+                  disabled={!providerEnabled || connectionTestMutation.isPending}
+                >
+                  {connectionTestMutation.isPending ? "Testing..." : "Test channel"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => connectionTestMutation.mutate("reviewers")}
+                  disabled={!providerEnabled || !hasReviewerMentions || connectionTestMutation.isPending}
+                >
+                  {connectionTestMutation.isPending ? "Testing..." : "Test reviewers"}
+                </Button>
+              </div>
             </div>
 
             {connectionTestMutation.data ? (

--- a/ui/src/pages/CompanyAwaitingHumanSettings.tsx
+++ b/ui/src/pages/CompanyAwaitingHumanSettings.tsx
@@ -36,6 +36,7 @@ export function CompanyAwaitingHumanSettings() {
   const [attachmentTaskId, setAttachmentTaskId] = useState("");
   const [primaryReviewerUserId, setPrimaryReviewerUserId] = useState("");
   const [secondaryReviewerUserId, setSecondaryReviewerUserId] = useState("");
+  const [lastConnectionTestMode, setLastConnectionTestMode] = useState<ConnectionTestMode | null>(null);
 
   useEffect(() => {
     setBreadcrumbs([
@@ -106,6 +107,9 @@ export function CompanyAwaitingHumanSettings() {
         clickupPersonalToken: provider === "clickup" ? (personalToken.trim() || null) : null,
         connectionTestMode,
       });
+    },
+    onMutate: (connectionTestMode) => {
+      setLastConnectionTestMode(connectionTestMode);
     },
   });
 
@@ -321,7 +325,7 @@ export function CompanyAwaitingHumanSettings() {
                   onClick={() => connectionTestMutation.mutate("channel")}
                   disabled={!providerEnabled || connectionTestMutation.isPending}
                 >
-                  {connectionTestMutation.isPending ? "Testing..." : "Test channel"}
+                  {connectionTestMutation.isPending && lastConnectionTestMode === "channel" ? "Testing..." : "Test channel"}
                 </Button>
                 <Button
                   size="sm"
@@ -329,7 +333,7 @@ export function CompanyAwaitingHumanSettings() {
                   onClick={() => connectionTestMutation.mutate("reviewers")}
                   disabled={!providerEnabled || !hasReviewerMentions || connectionTestMutation.isPending}
                 >
-                  {connectionTestMutation.isPending ? "Testing..." : "Test reviewers"}
+                  {connectionTestMutation.isPending && lastConnectionTestMode === "reviewers" ? "Testing..." : "Test reviewers"}
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
This pull request adds support for testing ClickUp reviewer mentions as part of the "awaiting human" settings for companies. It introduces a new "reviewers" connection test mode, updates the UI to allow triggering this test, and ensures that reviewer user IDs are handled and validated throughout the stack. The changes include updates to types, validators, API routes, service logic, and tests.

**Reviewer mention test mode support:**

* Added a `connectionTestMode` field (with values `"channel"` or `"reviewers"`) to the request types, validator schemas, and API routes, allowing the user to specify which type of connection test to run. [[1]](diffhunk://#diff-6b7b05c6b1c6881e63e0a16490fdfd94c44c724acef9c0a44f1fb6ae48141207R28) [[2]](diffhunk://#diff-3519649de5648d0f9124e79dd0406060b2e8c22e55d95e492edbd7e086b252d4R28) [[3]](diffhunk://#diff-87c40c8919d2660f32ee7f35d47aa996d9925056a4a380d29eef22bcb243933dL80-R87)
* Updated the ClickUp test message logic to render reviewer mentions when the "reviewers" mode is selected, including handling cases where reviewer user IDs are missing and logging appropriately. [[1]](diffhunk://#diff-87c40c8919d2660f32ee7f35d47aa996d9925056a4a380d29eef22bcb243933dR112-R180) [[2]](diffhunk://#diff-a084a1bea2027b213c3fc796be956c54196ae8832a4822937e3085218170f7e3R361-R372)

**UI enhancements:**

* Updated the `CompanyAwaitingHumanSettings` page to allow users to trigger either a channel test or a reviewer mention test, and to disable the reviewer test button if reviewer user IDs are not configured. [[1]](diffhunk://#diff-87c5aef4d1542985dfb91a425f071700bc23a9b8cf7009d8367e1d69e3abc166L311-R334) [[2]](diffhunk://#diff-87c5aef4d1542985dfb91a425f071700bc23a9b8cf7009d8367e1d69e3abc166R155)
* Modified the mutation logic to pass the selected `connectionTestMode` to the backend. [[1]](diffhunk://#diff-87c5aef4d1542985dfb91a425f071700bc23a9b8cf7009d8367e1d69e3abc166L88-R90) [[2]](diffhunk://#diff-87c5aef4d1542985dfb91a425f071700bc23a9b8cf7009d8367e1d69e3abc166R107)

**Type and schema updates:**

* Extended the provider config and notification types to include optional primary and secondary reviewer user IDs and reviewer mention information. [[1]](diffhunk://#diff-87c40c8919d2660f32ee7f35d47aa996d9925056a4a380d29eef22bcb243933dL80-R87) [[2]](diffhunk://#diff-a084a1bea2027b213c3fc796be956c54196ae8832a4822937e3085218170f7e3R28-R31)

**Testing improvements:**

* Added and updated tests to cover the new reviewer mention test mode, including checks for correct rendering and API integration. [[1]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984R435-R467) [[2]](diffhunk://#diff-d090b5958dfef84fdaacff8a606440f0016bfe44677398689fa545c3f3538641R172-R228)

These changes ensure that companies can now validate both general channel connectivity and reviewer mention functionality for ClickUp integration.