### PR TITLE
Refactor ClickUp reviewer routing and notification handling

### DIFF
--- a/server/src/__tests__/awaiting-human-handoff.test.ts
+++ b/server/src/__tests__/awaiting-human-handoff.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Db } from "@paperclipai/db";
 
+const mockResolveClickUpRuntimeConfig = vi.hoisted(() => vi.fn().mockResolvedValue({
+  enabled: true,
+  provider: "clickup",
+  personalToken: "token-123",
+  workspaceId: "workspace-1",
+  channelId: "channel-1",
+  attachmentTaskId: null,
+  primaryReviewerUserId: null,
+  secondaryReviewerUserId: null,
+}));
+
 vi.mock("../services/activity-log.js", () => ({
   logActivity: vi.fn().mockResolvedValue(undefined),
 }));
@@ -11,6 +22,12 @@ vi.mock("../services/awaiting-human-notifications.js", () => ({
     channel: "clickup-chat",
     detail: "enqueued",
   }),
+}));
+
+vi.mock("../services/awaiting-human-settings.js", () => ({
+  awaitingHumanSettingsService: vi.fn(() => ({
+    resolveClickUpRuntimeConfig: mockResolveClickUpRuntimeConfig,
+  })),
 }));
 
 const { logActivity } = await import("../services/activity-log.js");
@@ -135,6 +152,52 @@ describe("maybeLogAwaitingHumanHandoff", () => {
         notification: expect.objectContaining({
           approvalContext: {
             approvalName: "Policy approval",
+            approvalStage: null,
+            requiresSecondReview: true,
+          },
+        }),
+      }),
+    );
+  });
+
+  it("infers ClickUp reviewer routing for request_confirmation handoffs when reviewer IDs are configured", async () => {
+    process.env.BIZBOX_PUBLIC_URL = "https://bizbox.example";
+    mockResolveClickUpRuntimeConfig.mockResolvedValueOnce({
+      enabled: true,
+      provider: "clickup",
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-1",
+      attachmentTaskId: null,
+      primaryReviewerUserId: "primary-user-id",
+      secondaryReviewerUserId: "secondary-user-id",
+    });
+
+    const created = await maybeLogAwaitingHumanHandoff(mockDbWithAwaitingHumanRows(), {
+      previousIssue: basePreviousIssue,
+      updatedIssue: baseUpdatedIssue,
+      source: "issue_thread_interactions.create",
+      handoffKind: "request_confirmation",
+      actor: baseActor,
+      interaction: {
+        id: "interaction-review-1",
+        kind: "request_confirmation",
+        title: null,
+        summary: null,
+        payload: {
+          version: 1,
+          prompt: "Approve the finance article before it goes to the final reviewer.",
+        },
+      },
+    });
+
+    expect(created).toBe(true);
+    expect(enqueueAwaitingHumanNotification).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        notification: expect.objectContaining({
+          approvalContext: {
+            approvalName: null,
             approvalStage: null,
             requiresSecondReview: true,
           },

--- a/server/src/__tests__/awaiting-human-handoff.test.ts
+++ b/server/src/__tests__/awaiting-human-handoff.test.ts
@@ -16,12 +16,20 @@ vi.mock("../services/activity-log.js", () => ({
   logActivity: vi.fn().mockResolvedValue(undefined),
 }));
 
+const mockLoggerWarn = vi.hoisted(() => vi.fn());
+
 vi.mock("../services/awaiting-human-notifications.js", () => ({
   enqueueAwaitingHumanNotification: vi.fn().mockResolvedValue({
     status: "enqueued",
     channel: "clickup-chat",
     detail: "enqueued",
   }),
+}));
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    warn: mockLoggerWarn,
+  },
 }));
 
 vi.mock("../services/awaiting-human-settings.js", () => ({
@@ -158,6 +166,51 @@ describe("maybeLogAwaitingHumanHandoff", () => {
         }),
       }),
     );
+    expect(logActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          approvalContext: {
+            approvalName: "Policy approval",
+            approvalStage: null,
+            requiresSecondReview: true,
+          },
+        }),
+      }),
+    );
+  });
+
+  it("warns when ClickUp approval context lookup fails", async () => {
+    process.env.BIZBOX_PUBLIC_URL = "https://bizbox.example";
+    mockResolveClickUpRuntimeConfig.mockRejectedValueOnce(new Error("lookup failed"));
+
+    const created = await maybeLogAwaitingHumanHandoff(mockDbWithAwaitingHumanRows(), {
+      previousIssue: basePreviousIssue,
+      updatedIssue: baseUpdatedIssue,
+      source: "issue_thread_interactions.create",
+      handoffKind: "request_confirmation",
+      actor: baseActor,
+      interaction: {
+        id: "interaction-review-2",
+        kind: "request_confirmation",
+        title: null,
+        summary: null,
+        payload: {
+          version: 1,
+          prompt: "Approve the finance article before it goes to the final reviewer.",
+        },
+      },
+    });
+
+    expect(created).toBe(true);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.any(Error),
+        companyId: "company-1",
+        issueId: "issue-1",
+      }),
+      "failed to resolve ClickUp approval context",
+    );
   });
 
   it("infers ClickUp reviewer routing for request_confirmation handoffs when reviewer IDs are configured", async () => {
@@ -196,6 +249,18 @@ describe("maybeLogAwaitingHumanHandoff", () => {
       expect.anything(),
       expect.objectContaining({
         notification: expect.objectContaining({
+          approvalContext: {
+            approvalName: null,
+            approvalStage: null,
+            requiresSecondReview: true,
+          },
+        }),
+      }),
+    );
+    expect(logActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
           approvalContext: {
             approvalName: null,
             approvalStage: null,

--- a/server/src/__tests__/awaiting-human-handoff.test.ts
+++ b/server/src/__tests__/awaiting-human-handoff.test.ts
@@ -213,6 +213,32 @@ describe("maybeLogAwaitingHumanHandoff", () => {
     );
   });
 
+  it("silently skips approval context resolution when ClickUp is disabled", async () => {
+    process.env.BIZBOX_PUBLIC_URL = "https://bizbox.example";
+    mockResolveClickUpRuntimeConfig.mockRejectedValueOnce(new Error("awaiting-human-bridge-disabled"));
+
+    const created = await maybeLogAwaitingHumanHandoff(mockDbWithAwaitingHumanRows(), {
+      previousIssue: basePreviousIssue,
+      updatedIssue: baseUpdatedIssue,
+      source: "issue_thread_interactions.create",
+      handoffKind: "request_confirmation",
+      actor: baseActor,
+      interaction: {
+        id: "interaction-review-3",
+        kind: "request_confirmation",
+        title: null,
+        summary: null,
+        payload: {
+          version: 1,
+          prompt: "Approve the finance article before it goes to the final reviewer.",
+        },
+      },
+    });
+
+    expect(created).toBe(true);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
   it("infers ClickUp reviewer routing for request_confirmation handoffs when reviewer IDs are configured", async () => {
     process.env.BIZBOX_PUBLIC_URL = "https://bizbox.example";
     mockResolveClickUpRuntimeConfig.mockResolvedValueOnce({

--- a/server/src/services/awaiting-human-handoff.ts
+++ b/server/src/services/awaiting-human-handoff.ts
@@ -304,6 +304,9 @@ async function resolveApprovalContext(
       requiresSecondReview: Boolean(secondaryReviewerUserId),
     };
   } catch (err) {
+    if (err instanceof Error && err.message === "awaiting-human-bridge-disabled") {
+      return null;
+    }
     logger.warn(
       {
         err,

--- a/server/src/services/awaiting-human-handoff.ts
+++ b/server/src/services/awaiting-human-handoff.ts
@@ -303,21 +303,28 @@ async function resolveApprovalContext(
       approvalStage: null,
       requiresSecondReview: Boolean(secondaryReviewerUserId),
     };
-  } catch {
+  } catch (err) {
+    logger.warn(
+      {
+        err,
+        companyId: input.updatedIssue.companyId,
+        issueId: input.updatedIssue.id,
+      },
+      "failed to resolve ClickUp approval context",
+    );
     return null;
   }
 }
 
 async function buildNotification(
-  db: Db,
   input: AwaitingHumanHandoffInput,
+  approvalContext: ApprovalFlowContext | null,
   link: string,
   needsHumanInput: string,
   audienceUserId: string | null,
 ): Promise<AwaitingHumanNotificationPayload> {
   const label = input.updatedIssue.identifier ?? truncateText(input.updatedIssue.title, 48);
   const isQuestionHandoff = input.handoffKind === "ask_user_questions";
-  const approvalContext = await resolveApprovalContext(db, input);
   return {
     title: truncateText(
       isQuestionHandoff
@@ -399,9 +406,10 @@ export async function maybeLogAwaitingHumanHandoff(
   if (await hasLoggedAwaitingHumanHandoff(db, input, dedupeKey)) return false;
   const audienceUserId = resolveAudienceUserId(input);
   const notificationLink = issueUrl ?? issuePath;
+  const approvalContext = await resolveApprovalContext(db, input);
   const notification = await buildNotification(
-    db,
     input,
+    approvalContext,
     notificationLink,
     needsHumanInput,
     audienceUserId,
@@ -497,7 +505,7 @@ export async function maybeLogAwaitingHumanHandoff(
       interactionKind: input.interaction?.kind ?? null,
       blockerIssueId: firstBlocker?.id ?? null,
       blockerIdentifier: firstBlocker?.identifier ?? null,
-      approvalContext: input.approvalContext ?? null,
+      approvalContext,
       dedupeKey,
       notification,
       notificationDelivery: {

--- a/server/src/services/awaiting-human-handoff.ts
+++ b/server/src/services/awaiting-human-handoff.ts
@@ -10,6 +10,7 @@ import {
   type AwaitingHumanNotificationPayload,
 } from "./awaiting-human-notifications.js";
 import type { ApprovalFlowContext } from "./approval-flow-routing.js";
+import { awaitingHumanSettingsService } from "./awaiting-human-settings.js";
 import { logActivity } from "./activity-log.js";
 import { logger } from "../middleware/logger.js";
 
@@ -276,21 +277,47 @@ function resolveAudienceUserId(input: AwaitingHumanHandoffInput) {
   return userIds.length === 1 ? userIds[0] : null;
 }
 
-function buildNotification(
+async function resolveApprovalContext(
+  db: Db,
+  input: AwaitingHumanHandoffInput,
+): Promise<ApprovalFlowContext | null> {
+  if (input.approvalContext) {
+    return {
+      approvalName: input.approvalContext.approvalName ?? null,
+      approvalStage: input.approvalContext.approvalStage ?? null,
+      requiresSecondReview: input.approvalContext.requiresSecondReview ?? null,
+    };
+  }
+  if (input.handoffKind !== "request_confirmation") return null;
+
+  try {
+    const runtime = await awaitingHumanSettingsService(db).resolveClickUpRuntimeConfig(
+      input.updatedIssue.companyId,
+    );
+    const primaryReviewerUserId = runtime.primaryReviewerUserId?.trim() ?? "";
+    const secondaryReviewerUserId = runtime.secondaryReviewerUserId?.trim() ?? "";
+    if (!primaryReviewerUserId && !secondaryReviewerUserId) return null;
+
+    return {
+      approvalName: null,
+      approvalStage: null,
+      requiresSecondReview: Boolean(secondaryReviewerUserId),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function buildNotification(
+  db: Db,
   input: AwaitingHumanHandoffInput,
   link: string,
   needsHumanInput: string,
   audienceUserId: string | null,
-): AwaitingHumanNotificationPayload {
+): Promise<AwaitingHumanNotificationPayload> {
   const label = input.updatedIssue.identifier ?? truncateText(input.updatedIssue.title, 48);
   const isQuestionHandoff = input.handoffKind === "ask_user_questions";
-  const approvalContext = input.approvalContext
-    ? {
-      approvalName: input.approvalContext.approvalName ?? null,
-      approvalStage: input.approvalContext.approvalStage ?? null,
-      requiresSecondReview: input.approvalContext.requiresSecondReview ?? null,
-    }
-    : null;
+  const approvalContext = await resolveApprovalContext(db, input);
   return {
     title: truncateText(
       isQuestionHandoff
@@ -372,7 +399,13 @@ export async function maybeLogAwaitingHumanHandoff(
   if (await hasLoggedAwaitingHumanHandoff(db, input, dedupeKey)) return false;
   const audienceUserId = resolveAudienceUserId(input);
   const notificationLink = issueUrl ?? issuePath;
-  const notification = buildNotification(input, notificationLink, needsHumanInput, audienceUserId);
+  const notification = await buildNotification(
+    db,
+    input,
+    notificationLink,
+    needsHumanInput,
+    audienceUserId,
+  );
   const firstBlocker = input.blockers?.[0] ?? null;
 
   if (input.emitIssueUpdatedActivity) {

--- a/server/src/services/issue-interaction-resolution-effects.ts
+++ b/server/src/services/issue-interaction-resolution-effects.ts
@@ -8,7 +8,7 @@ export function isClosedIssueStatus(status: string | null | undefined): status i
   return status === "done" || status === "cancelled";
 }
 
-export function queueResolvedInteractionContinuationWakeup(input: {
+export async function queueResolvedInteractionContinuationWakeup(input: {
   heartbeat: IssueAssignmentWakeupDeps;
   issue: { id: string; assigneeAgentId: string | null; status: string };
   interaction: Pick<
@@ -17,7 +17,7 @@ export function queueResolvedInteractionContinuationWakeup(input: {
   >;
   actor: { actorType: "user" | "agent" | "system"; actorId: string };
   source: string;
-}) {
+}): Promise<void> {
   if (
     input.interaction.continuationPolicy !== "wake_assignee"
     && input.interaction.continuationPolicy !== "wake_assignee_on_accept"
@@ -29,7 +29,7 @@ export function queueResolvedInteractionContinuationWakeup(input: {
   if (input.interaction.status === "expired") return;
   if (!input.issue.assigneeAgentId || isClosedIssueStatus(input.issue.status)) return;
 
-  void input.heartbeat.wakeup(input.issue.assigneeAgentId, {
+  await input.heartbeat.wakeup(input.issue.assigneeAgentId, {
     source: "automation",
     triggerDetail: "system",
     reason: "issue_commented",
@@ -168,7 +168,7 @@ export async function finalizeAcceptedInteractionResolution(input: {
     });
   }
 
-  queueResolvedInteractionContinuationWakeup({
+  await queueResolvedInteractionContinuationWakeup({
     heartbeat: input.heartbeat,
     issue: continuationWakeIssue,
     interaction: input.interaction,


### PR DESCRIPTION
This pull request enhances the reviewer routing logic for "request_confirmation" handoffs by automatically inferring approval context from ClickUp reviewer configuration, and updates the notification construction flow to support this. The main changes add logic to fetch reviewer IDs from ClickUp settings, update the notification payload accordingly, and expand test coverage for this scenario.

**Reviewer routing and approval context inference:**

* Added `resolveApprovalContext` to fetch reviewer IDs from ClickUp config and infer `requiresSecondReview` for "request_confirmation" handoffs, updating the approval context in notifications.
* Modified `buildNotification` to be async and use the new approval context resolution logic, ensuring notifications reflect reviewer configuration.
* Updated `maybeLogAwaitingHumanHandoff` to await the new async notification builder.

**Testing improvements:**

* Added a test to verify that reviewer routing is inferred when reviewer IDs are configured in ClickUp settings.
* Mocked the ClickUp runtime config and settings service in tests to support the new reviewer routing logic. [[1]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9R4-R14) [[2]](diffhunk://#diff-fd9bdab9f2e4f3f3d3b38587d75dada4b58774190b43d89d6cde5d18cd559ca9R27-R32)

**Dependency injection:**

* Imported `awaitingHumanSettingsService` in the handoff service to support runtime config resolution.