### PR TITLE
Refactor reviewerMentions to reviewerTargets and update logic

### DIFF
--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -488,12 +488,43 @@ describe("getClickUpChatMessageReplies", () => {
 });
 
 describe("sendAwaitingHumanNotification review context", () => {
-  it("renders approval stage and reviewer mentions for generic approval routing", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      status: 201,
-      text: async () => JSON.stringify({ id: "message-review" }),
-    });
+  it("renders approval stage and notifies reviewers by direct message", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "message-review" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Policy Owner" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ id: "dm-channel-primary" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "dm-message-primary" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ user: { name: "Secondary Lead" } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ id: "dm-channel-secondary" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "dm-message-secondary" }),
+      });
     globalThis.fetch = fetchMock as typeof fetch;
 
     const result = await sendAwaitingHumanNotification({
@@ -520,11 +551,12 @@ describe("sendAwaitingHumanNotification review context", () => {
     });
 
     expect(result.status).toBe("sent");
-    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    const body = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
     expect(body.content).toContain("Approval: Policy approval");
     expect(body.content).toContain("Approval stage: primary review");
-    expect(body.content).toContain("Reviewer: clickup://user/primary-user-id");
-    expect(body.content).toContain("Next reviewer: clickup://user/secondary-user-id");
+    expect(body.content).toContain("Primary reviewer: notified in a direct message to Policy Owner.");
+    expect(body.content).toContain("Next step: the secondary reviewer, Policy Owner, will be notified if the approval is accepted.");
+    expect(body.content).not.toContain("clickup://user/");
     expect(body.content).toContain("Next step:");
   });
 });
@@ -631,22 +663,53 @@ describe("sendAwaitingHumanNotificationReply", () => {
   });
 });
 
-describe("sendClickUpTransportTestMessage reviewer mentions", () => {
-  it("renders reviewer mention links when reviewer testing is requested", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      status: 201,
-      text: async () => JSON.stringify({ id: "message-reviewers" }),
-    });
+describe("sendClickUpTransportTestMessage reviewer notifications", () => {
+  it("renders reviewer direct message prompts and sends them in order", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "message-reviewers" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Primary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ id: "dm-channel-primary" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "dm-message-primary" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ user: { name: "Secondary Lead" } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ id: "dm-channel-secondary" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "dm-message-secondary" }),
+      });
     globalThis.fetch = fetchMock as typeof fetch;
 
     const result = await sendClickUpTransportTestMessage({
-      title: "Bizbox ClickUp reviewer mention test",
-      summary: "Bizbox completed a reviewer mention test for ClickUp.",
-      body: "The configured bridge successfully delivered a reviewer mention test payload to the target ClickUp channel.",
+      title: "Bizbox ClickUp reviewer notification test",
+      summary: "Bizbox completed a reviewer notification test for ClickUp.",
+      body: "The configured bridge successfully delivered a reviewer notification test payload to the target ClickUp channel.",
       link: "https://bizbox.example/company/settings/awaiting-human",
       cta: "No action is required.",
-      reviewerMentions: [
+      reviewerTargets: [
         { label: "Primary reviewer", userId: "primary-user-id" },
         { label: "Secondary reviewer", userId: "secondary-user-id" },
       ],
@@ -658,12 +721,28 @@ describe("sendClickUpTransportTestMessage reviewer mentions", () => {
 
     expect(result.status).toBe("sent");
     const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
-    expect(body.content).toContain("Reviewer mention test:");
-    expect(body.content).toContain("Primary reviewer: clickup://user/primary-user-id");
-    expect(body.content).toContain("Secondary reviewer: clickup://user/secondary-user-id");
+    expect(body.content).toContain("Reviewer notification test:");
+    expect(body.content).toContain("Primary reviewer: notified in a direct message");
+    expect(body.content).toContain("Secondary reviewer: notified in a direct message");
+    expect(body.content).not.toContain("clickup://user/");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.clickup.com/api/v2/team/workspace-1/user/primary-user-id",
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      "https://api.clickup.com/api/v2/team/workspace-1/user/secondary-user-id",
+      expect.anything(),
+    );
+    expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain("Hi Primary Lead,");
+    expect(String(fetchMock.mock.calls[6]?.[1]?.body)).toContain("Hi Secondary Lead,");
+    expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain(
+      "Original approval thread: https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/message-reviewers/replies",
+    );
   });
 
-  it("omits the reviewer section when no reviewer mentions are configured", async () => {
+  it("omits the reviewer section when no reviewer targets are configured", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
       status: 201,
@@ -672,12 +751,12 @@ describe("sendClickUpTransportTestMessage reviewer mentions", () => {
     globalThis.fetch = fetchMock as typeof fetch;
 
     const result = await sendClickUpTransportTestMessage({
-      title: "Bizbox ClickUp reviewer mention test",
-      summary: "Bizbox completed a reviewer mention test for ClickUp.",
-      body: "The configured bridge successfully delivered a reviewer mention test payload to the target ClickUp channel.",
+      title: "Bizbox ClickUp reviewer notification test",
+      summary: "Bizbox completed a reviewer notification test for ClickUp.",
+      body: "The configured bridge successfully delivered a reviewer notification test payload to the target ClickUp channel.",
       link: "https://bizbox.example/company/settings/awaiting-human",
       cta: "No action is required.",
-      reviewerMentions: [
+      reviewerTargets: [
         { label: "Primary reviewer", userId: null },
         { label: "Secondary reviewer", userId: undefined },
       ],
@@ -689,8 +768,51 @@ describe("sendClickUpTransportTestMessage reviewer mentions", () => {
 
     expect(result.status).toBe("sent");
     const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
-    expect(body.content).not.toContain("Reviewer mention test:");
+    expect(body.content).not.toContain("Reviewer notification test:");
     expect(body.content).not.toContain("not configured");
+  });
+
+  it("falls back to the raw user id when the ClickUp display name cannot be resolved", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "message-reviewers" }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => JSON.stringify({ message: "Not found" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ id: "dm-channel-primary" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "dm-message-primary" }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendClickUpTransportTestMessage({
+      title: "Bizbox ClickUp reviewer notification test",
+      summary: "Bizbox completed a reviewer notification test for ClickUp.",
+      body: "The configured bridge successfully delivered a reviewer notification test payload to the target ClickUp channel.",
+      link: "https://bizbox.example/company/settings/awaiting-human",
+      cta: "No action is required.",
+      reviewerTargets: [
+        { label: "Primary reviewer", userId: "primary-user-id" },
+      ],
+    }, {
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-9",
+    });
+
+    expect(result.status).toBe("sent");
+    expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain("Hi primary-user-id,");
   });
 });
 

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -544,7 +544,7 @@ describe("sendAwaitingHumanNotification review context", () => {
     const body = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
     expect(body.content).toContain("Approval: Policy approval");
     expect(body.content).toContain("Approval stage: primary review");
-    expect(body.content).toContain("Primary reviewer: notified in a direct message to Primary Lead.");
+    expect(body.content).toContain("Primary reviewer: a direct message will be sent to Primary Lead.");
     expect(body.content).toContain("Next step: the secondary reviewer, Secondary Lead, will be notified if the approval is accepted.");
     expect(body.content).not.toContain("clickup://user/");
     expect(body.content).toContain("Next step:");
@@ -673,7 +673,7 @@ describe("sendAwaitingHumanNotification review context", () => {
     expect(result.status).toBe("sent");
     const body = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
     expect(body.content).toContain("Approval stage: final check");
-    expect(body.content).toContain("Reviewer: notified in a direct message to Secondary Lead.");
+    expect(body.content).toContain("Reviewer: a direct message will be sent to Secondary Lead.");
     expect(body.content).toContain("Next step: the final reviewer handles the approval after the primary review clears.");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clickup.com/api/v2/team/workspace-1/user/primary-user-id",
@@ -845,17 +845,22 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "message-reviewers" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
         text: async () => JSON.stringify({ id: "dm-channel-primary" }),
       })
       .mockResolvedValueOnce({
         ok: true,
         status: 201,
         text: async () => JSON.stringify({ id: "dm-message-primary" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -888,8 +893,8 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
     expect(result.status).toBe("sent");
     const body = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
     expect(body.content).toContain("Reviewer notification test:");
-    expect(body.content).toContain("Primary reviewer: notified in a direct message");
-    expect(body.content).toContain("Secondary reviewer: notified in a direct message");
+    expect(body.content).toContain("Primary reviewer: a direct message will be sent");
+    expect(body.content).toContain("Secondary reviewer: a direct message will be sent");
     expect(body.content).not.toContain("clickup://user/");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clickup.com/api/v2/team/workspace-1/user/primary-user-id",
@@ -899,8 +904,49 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
       "https://api.clickup.com/api/v2/team/workspace-1/user/secondary-user-id",
       expect.anything(),
     );
+    expect(String(fetchMock.mock.calls[4]?.[1]?.body)).toContain("Hi Primary Lead,");
+    expect(String(fetchMock.mock.calls[6]?.[1]?.body)).toContain("Hi Secondary Lead,");
     expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("/chat/channels/direct_message")).length).toBe(2);
     expect(fetchMock).toHaveBeenCalledTimes(7);
+  });
+
+  it("does not claim reviewer DM delivery when a direct message fails", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never);
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Primary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "message-reviewers" }),
+      })
+      .mockRejectedValueOnce(new Error("ClickUp DM unavailable"));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendClickUpTransportTestMessage({
+      title: "Bizbox ClickUp reviewer notification test",
+      summary: "Bizbox completed a reviewer notification test for ClickUp.",
+      link: "https://bizbox.example/company/settings/awaiting-human",
+      reviewerTargets: [
+        { label: "Primary reviewer", userId: "primary-user-id" },
+      ],
+    }, {
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-9",
+    });
+
+    expect(result.status).toBe("sent");
+    const body = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(body.content).toContain("Primary reviewer: a direct message will be sent");
+    expect(body.content).not.toContain("notified in a direct message");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "primary-user-id" }),
+      "clickup awaiting human reviewer DM failed",
+    );
   });
 
   it("omits the reviewer section when no reviewer targets are configured", async () => {

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -492,13 +492,18 @@ describe("sendAwaitingHumanNotification review context", () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
-        status: 201,
-        text: async () => JSON.stringify({ id: "message-review" }),
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Primary Lead" } } }),
       })
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        text: async () => JSON.stringify({ member: { user: { username: "Policy Owner" } } }),
+        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "message-review" }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -509,11 +514,6 @@ describe("sendAwaitingHumanNotification review context", () => {
         ok: true,
         status: 201,
         text: async () => JSON.stringify({ id: "dm-message-primary" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ user: { name: "Secondary Lead" } }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -554,10 +554,22 @@ describe("sendAwaitingHumanNotification review context", () => {
     const body = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
     expect(body.content).toContain("Approval: Policy approval");
     expect(body.content).toContain("Approval stage: primary review");
-    expect(body.content).toContain("Primary reviewer: notified in a direct message to Policy Owner.");
-    expect(body.content).toContain("Next step: the secondary reviewer, Policy Owner, will be notified if the approval is accepted.");
+    expect(body.content).toContain("Primary reviewer: notified in a direct message to Primary Lead.");
+    expect(body.content).toContain("Next step: the secondary reviewer, Secondary Lead, will be notified if the approval is accepted.");
     expect(body.content).not.toContain("clickup://user/");
     expect(body.content).toContain("Next step:");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.clickup.com/api/v2/team/workspace-1/user/primary-user-id",
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.clickup.com/api/v2/team/workspace-1/user/secondary-user-id",
+      expect.anything(),
+    );
+    expect(String(fetchMock.mock.calls[4]?.[1]?.body)).toContain("Hi Primary Lead,");
+    expect(String(fetchMock.mock.calls[6]?.[1]?.body)).toContain("Hi Secondary Lead,");
   });
 });
 

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -571,16 +571,6 @@ describe("sendAwaitingHumanNotification review context", () => {
         ok: true,
         status: 201,
         text: async () => JSON.stringify({ id: "message-review" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ id: "dm-channel-secondary" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        text: async () => JSON.stringify({ id: "dm-message-secondary" }),
       });
     globalThis.fetch = fetchMock as typeof fetch;
 
@@ -1019,8 +1009,21 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
     });
 
     expect(result.status).toBe("sent");
-    const requestBodies = fetchMock.mock.calls.map(([, init]) => String((init as { body?: unknown } | undefined)?.body ?? ""));
-    expect(requestBodies.some((body) => body.includes("Hi primary-user-id,"))).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/channels/direct_message",
+      expect.objectContaining({
+        body: JSON.stringify({ user_ids: ["primary-user-id"] }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/channels/dm-channel-primary/messages",
+      expect.objectContaining({
+        body: expect.stringContaining("Hi primary-user-id,"),
+      }),
+    );
   });
 });
 

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -628,6 +628,67 @@ describe("sendAwaitingHumanNotification review context", () => {
     expect(body.content).not.toContain("Primary reviewer: notified in a direct message to Secondary Lead.");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps the secondary reviewer name visible in final-stage approval messages", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Primary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "message-final" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ id: "dm-channel-secondary" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "dm-message-secondary" }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotification({
+      companyId: "company-1",
+      issueId: "issue-1",
+      handoffKind: "request_confirmation",
+      notification: {
+        title: "BIZ-35 needs confirmation",
+        summary: "Please review the approval item.",
+        link: "https://bizbox.example/issues/BIZ-35",
+        cta: "Reply in Bizbox.",
+        labels: ["awaiting_human", "request_confirmation"],
+        approvalContext: {
+          approvalName: "Policy approval",
+          approvalStage: "final",
+          requiresSecondReview: true,
+        },
+      },
+    }, {
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-9",
+      primaryReviewerUserId: "primary-user-id",
+      secondaryReviewerUserId: "secondary-user-id",
+    });
+
+    expect(result.status).toBe("sent");
+    const body = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
+    expect(body.content).toContain("Approval stage: final check");
+    expect(body.content).toContain("Reviewer: notified in a direct message to Secondary Lead.");
+    expect(body.content).toContain("Next step: the final reviewer handles the approval after the primary review clears.");
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
 });
 
 describe("sendAwaitingHumanNotificationReply", () => {
@@ -733,6 +794,62 @@ describe("sendAwaitingHumanNotificationReply", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body)).content).toContain("Approval: Policy approval");
+  });
+
+  it("keeps the secondary reviewer name visible in final-stage approval replies", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Primary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "question-reply-2" }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotificationReply("thread-root-1", {
+      companyId: "company-1",
+      issueId: "handoff-1",
+      handoffKind: "approval",
+      notification: {
+        title: "Workflow approval required",
+        summary: "Landing page approval required",
+        body: "Please approve this change.",
+        link: "",
+        cta: "Reply with: approve or reject.",
+        labels: ["workflow_handoff", "approval"],
+        approvalContext: {
+          approvalName: "Policy approval",
+          approvalStage: "final",
+          requiresSecondReview: true,
+        },
+      },
+    }, {
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-9",
+      primaryReviewerUserId: "primary-user-id",
+      secondaryReviewerUserId: "secondary-user-id",
+    });
+
+    expect(result).toEqual({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId: "question-reply-2",
+    });
+    const body = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
+    expect(body.content).toContain("Approval stage: final check");
+    expect(body.content).toContain("Reviewer: notified in a direct message to Secondary Lead.");
+    expect(body.content).toContain("Next step: the final reviewer handles the approval after the primary review clears.");
   });
 
   it("keeps long workflow approval replies intact instead of applying the short channel-message cap", async () => {

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -744,22 +744,11 @@ describe("sendAwaitingHumanNotificationReply", () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
 
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ member: { user: { username: "Primary Lead" } } }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        text: async () => JSON.stringify({ id: "question-reply-1" }),
-      });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ id: "question-reply-1" }),
+    });
     globalThis.fetch = fetchMock as typeof fetch;
 
     const result = await sendAwaitingHumanNotificationReply("thread-root-1", {
@@ -792,64 +781,8 @@ describe("sendAwaitingHumanNotificationReply", () => {
       detail: "sent",
       externalId: "question-reply-1",
     });
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body)).content).toContain("Approval: Policy approval");
-  });
-
-  it("keeps the secondary reviewer name visible in final-stage approval replies", async () => {
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ member: { user: { username: "Primary Lead" } } }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        text: async () => JSON.stringify({ id: "question-reply-2" }),
-      });
-    globalThis.fetch = fetchMock as typeof fetch;
-
-    const result = await sendAwaitingHumanNotificationReply("thread-root-1", {
-      companyId: "company-1",
-      issueId: "handoff-1",
-      handoffKind: "approval",
-      notification: {
-        title: "Workflow approval required",
-        summary: "Landing page approval required",
-        body: "Please approve this change.",
-        link: "",
-        cta: "Reply with: approve or reject.",
-        labels: ["workflow_handoff", "approval"],
-        approvalContext: {
-          approvalName: "Policy approval",
-          approvalStage: "final",
-          requiresSecondReview: true,
-        },
-      },
-    }, {
-      personalToken: "token-123",
-      workspaceId: "workspace-1",
-      channelId: "channel-9",
-      primaryReviewerUserId: "primary-user-id",
-      secondaryReviewerUserId: "secondary-user-id",
-    });
-
-    expect(result).toEqual({
-      status: "sent",
-      channel: "clickup-chat",
-      detail: "sent",
-      externalId: "question-reply-2",
-    });
-    const body = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
-    expect(body.content).toContain("Approval stage: final check");
-    expect(body.content).toContain("Reviewer: notified in a direct message to Secondary Lead.");
-    expect(body.content).toContain("Next step: the final reviewer handles the approval after the primary review clears.");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)).content).toContain("Approval: Policy approval");
   });
 
   it("keeps long workflow approval replies intact instead of applying the short channel-message cap", async () => {
@@ -931,7 +864,7 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        text: async () => JSON.stringify({ user: { name: "Secondary Lead" } }),
+        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
       })
       .mockResolvedValueOnce({
         ok: true,

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -569,7 +569,7 @@ describe("sendAwaitingHumanNotification review context", () => {
       expect.anything(),
     );
     expect(String(fetchMock.mock.calls[4]?.[1]?.body)).toContain("Hi Primary Lead,");
-    expect(String(fetchMock.mock.calls[6]?.[1]?.body)).toContain("Hi Secondary Lead,");
+    expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 
   it("keeps the primary reviewer label un-attributed when only a secondary reviewer is configured", async () => {
@@ -626,7 +626,7 @@ describe("sendAwaitingHumanNotification review context", () => {
     expect(body.content).toContain("Primary reviewer: notified in a direct message.");
     expect(body.content).toContain("Next step: the secondary reviewer, Secondary Lead, will be notified if the approval is accepted.");
     expect(body.content).not.toContain("Primary reviewer: notified in a direct message to Secondary Lead.");
-    expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain("Hi Secondary Lead,");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -863,7 +863,7 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
     expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain("Hi Primary Lead,");
     expect(String(fetchMock.mock.calls[6]?.[1]?.body)).toContain("Hi Secondary Lead,");
     expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain(
-      "Original approval thread: https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/message-reviewers/replies",
+      "Original approval thread: https://bizbox.example/company/settings/awaiting-human",
     );
   });
 

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -514,16 +514,6 @@ describe("sendAwaitingHumanNotification review context", () => {
         ok: true,
         status: 201,
         text: async () => JSON.stringify({ id: "dm-message-primary" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ id: "dm-channel-secondary" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        text: async () => JSON.stringify({ id: "dm-message-secondary" }),
       });
     globalThis.fetch = fetchMock as typeof fetch;
 
@@ -558,13 +548,11 @@ describe("sendAwaitingHumanNotification review context", () => {
     expect(body.content).toContain("Next step: the secondary reviewer, Secondary Lead, will be notified if the approval is accepted.");
     expect(body.content).not.toContain("clickup://user/");
     expect(body.content).toContain("Next step:");
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      1,
+    expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clickup.com/api/v2/team/workspace-1/user/primary-user-id",
       expect.anything(),
     );
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
+    expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clickup.com/api/v2/team/workspace-1/user/secondary-user-id",
       expect.anything(),
     );
@@ -623,9 +611,9 @@ describe("sendAwaitingHumanNotification review context", () => {
     const body = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
     expect(body.content).toContain("Approval: Policy approval");
     expect(body.content).toContain("Approval stage: primary review");
-    expect(body.content).toContain("Primary reviewer: notified in a direct message.");
+    expect(body.content).toContain("Primary reviewer: not configured.");
     expect(body.content).toContain("Next step: the secondary reviewer, Secondary Lead, will be notified if the approval is accepted.");
-    expect(body.content).not.toContain("Primary reviewer: notified in a direct message to Secondary Lead.");
+    expect(body.content).not.toContain("Primary reviewer: notified in a direct message.");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -687,6 +675,14 @@ describe("sendAwaitingHumanNotification review context", () => {
     expect(body.content).toContain("Approval stage: final check");
     expect(body.content).toContain("Reviewer: notified in a direct message to Secondary Lead.");
     expect(body.content).toContain("Next step: the final reviewer handles the approval after the primary review clears.");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.clickup.com/api/v2/team/workspace-1/user/primary-user-id",
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.clickup.com/api/v2/team/workspace-1/user/secondary-user-id",
+      expect.anything(),
+    );
     expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 });
@@ -843,11 +839,6 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
-        status: 201,
-        text: async () => JSON.stringify({ id: "message-reviewers" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         status: 200,
         text: async () => JSON.stringify({ member: { user: { username: "Primary Lead" } } }),
       })
@@ -895,26 +886,21 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
     });
 
     expect(result.status).toBe("sent");
-    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    const body = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
     expect(body.content).toContain("Reviewer notification test:");
     expect(body.content).toContain("Primary reviewer: notified in a direct message");
     expect(body.content).toContain("Secondary reviewer: notified in a direct message");
     expect(body.content).not.toContain("clickup://user/");
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
+    expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clickup.com/api/v2/team/workspace-1/user/primary-user-id",
       expect.anything(),
     );
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      5,
+    expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clickup.com/api/v2/team/workspace-1/user/secondary-user-id",
       expect.anything(),
     );
-    expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain("Hi Primary Lead,");
-    expect(String(fetchMock.mock.calls[6]?.[1]?.body)).toContain("Hi Secondary Lead,");
-    expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain(
-      "Original approval thread: https://bizbox.example/company/settings/awaiting-human",
-    );
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("/chat/channels/direct_message")).length).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(7);
   });
 
   it("omits the reviewer section when no reviewer targets are configured", async () => {
@@ -950,14 +936,14 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
   it("falls back to the raw user id when the ClickUp display name cannot be resolved", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        text: async () => JSON.stringify({ id: "message-reviewers" }),
-      })
-      .mockResolvedValueOnce({
         ok: false,
         status: 404,
         text: async () => JSON.stringify({ message: "Not found" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "message-reviewers" }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -987,7 +973,8 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
     });
 
     expect(result.status).toBe("sent");
-    expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain("Hi primary-user-id,");
+    const requestBodies = fetchMock.mock.calls.map(([, init]) => String((init as { body?: unknown } | undefined)?.body ?? ""));
+    expect(requestBodies.some((body) => body.includes("Hi primary-user-id,"))).toBe(true);
   });
 });
 

--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -571,6 +571,63 @@ describe("sendAwaitingHumanNotification review context", () => {
     expect(String(fetchMock.mock.calls[4]?.[1]?.body)).toContain("Hi Primary Lead,");
     expect(String(fetchMock.mock.calls[6]?.[1]?.body)).toContain("Hi Secondary Lead,");
   });
+
+  it("keeps the primary reviewer label un-attributed when only a secondary reviewer is configured", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "message-review" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ id: "dm-channel-secondary" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "dm-message-secondary" }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotification({
+      companyId: "company-1",
+      issueId: "issue-1",
+      handoffKind: "request_confirmation",
+      notification: {
+        title: "BIZ-35 needs confirmation",
+        summary: "Please review the approval item.",
+        link: "https://bizbox.example/issues/BIZ-35",
+        cta: "Reply in Bizbox.",
+        labels: ["awaiting_human", "request_confirmation"],
+        approvalContext: {
+          approvalName: "Policy approval",
+          requiresSecondReview: true,
+        },
+      },
+    }, {
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-9",
+      primaryReviewerUserId: null,
+      secondaryReviewerUserId: "secondary-user-id",
+    });
+
+    expect(result.status).toBe("sent");
+    const body = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(body.content).toContain("Approval: Policy approval");
+    expect(body.content).toContain("Approval stage: primary review");
+    expect(body.content).toContain("Primary reviewer: notified in a direct message.");
+    expect(body.content).toContain("Next step: the secondary reviewer, Secondary Lead, will be notified if the approval is accepted.");
+    expect(body.content).not.toContain("Primary reviewer: notified in a direct message to Secondary Lead.");
+    expect(String(fetchMock.mock.calls[3]?.[1]?.body)).toContain("Hi Secondary Lead,");
+  });
 });
 
 describe("sendAwaitingHumanNotificationReply", () => {
@@ -620,6 +677,62 @@ describe("sendAwaitingHumanNotificationReply", () => {
       content: "**Workflow input required**\n\nWhich city should I check?\n\nReply with your response.",
       content_format: "text/md",
     });
+  });
+
+  it("does not resend reviewer DMs when posting an approval reply", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Primary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ member: { user: { username: "Secondary Lead" } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => JSON.stringify({ id: "question-reply-1" }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await sendAwaitingHumanNotificationReply("thread-root-1", {
+      companyId: "company-1",
+      issueId: "handoff-1",
+      handoffKind: "approval",
+      notification: {
+        title: "Workflow approval required",
+        summary: "Landing page approval required",
+        body: "Please approve this change.",
+        link: "",
+        cta: "Reply with: approve or reject.",
+        labels: ["workflow_handoff", "approval"],
+        approvalContext: {
+          approvalName: "Policy approval",
+          requiresSecondReview: true,
+        },
+      },
+    }, {
+      personalToken: "token-123",
+      workspaceId: "workspace-1",
+      channelId: "channel-9",
+      primaryReviewerUserId: "primary-user-id",
+      secondaryReviewerUserId: "secondary-user-id",
+    });
+
+    expect(result).toEqual({
+      status: "sent",
+      channel: "clickup-chat",
+      detail: "sent",
+      externalId: "question-reply-1",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body)).content).toContain("Approval: Policy approval");
   });
 
   it("keeps long workflow approval replies intact instead of applying the short channel-message cap", async () => {

--- a/server/src/__tests__/company-awaiting-human-settings-route.test.ts
+++ b/server/src/__tests__/company-awaiting-human-settings-route.test.ts
@@ -187,7 +187,7 @@ describe("PATCH /api/companies/:companyId/awaiting-human-settings", () => {
       body: "The configured bridge successfully delivered a test payload to the target ClickUp channel.",
       link: "http://localhost:3100/CITAAAA/company/settings/awaiting-human",
       cta: "No action is required.",
-      reviewerMentions: [],
+      reviewerTargets: [],
     });
     expect(transportOverrides).toEqual({
       personalToken: "token-123",
@@ -201,7 +201,7 @@ describe("PATCH /api/companies/:companyId/awaiting-human-settings", () => {
     }));
   });
 
-  it("sends reviewer mention test message when requested", async () => {
+  it("sends reviewer notification test message when requested", async () => {
     mockCompanyService.getById.mockResolvedValueOnce({
       id: "company-1",
       name: "Bizbox",
@@ -229,16 +229,16 @@ describe("PATCH /api/companies/:companyId/awaiting-human-settings", () => {
     expect(res.body).toEqual({
       status: "sent",
       channel: "clickup-chat",
-      detail: "ClickUp reviewer mention test succeeded. Message delivered to configured channel (message message-2).",
+      detail: "ClickUp reviewer notification test succeeded. Message delivered to configured channel (message message-2).",
       externalId: "message-2",
     });
     expect(mockSendClickUpTransportTestMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: "Bizbox ClickUp reviewer mention test",
-        summary: "Bizbox completed a reviewer mention test for ClickUp.",
-        body: "The configured bridge successfully delivered a reviewer mention test payload to the target ClickUp channel.",
+        title: "Bizbox ClickUp reviewer notification test",
+        summary: "Bizbox completed a reviewer notification test for ClickUp.",
+        body: "The configured bridge successfully delivered a reviewer notification test payload to the target ClickUp channel.",
         cta: "No action is required.",
-        reviewerMentions: [
+        reviewerTargets: [
           { label: "Primary reviewer", userId: "primary-user-id" },
           { label: "Secondary reviewer", userId: "secondary-user-id" },
         ],

--- a/server/src/routes/company-awaiting-human-settings.ts
+++ b/server/src/routes/company-awaiting-human-settings.ts
@@ -118,7 +118,7 @@ export function companyAwaitingHumanSettingsRoutes(db: Db) {
     };
 
     const connectionTestMode = body.connectionTestMode ?? "channel";
-    const reviewerMentions = connectionTestMode === "reviewers"
+    const reviewerTargets = connectionTestMode === "reviewers"
       ? [
         {
           label: "Primary reviewer",
@@ -130,8 +130,8 @@ export function companyAwaitingHumanSettingsRoutes(db: Db) {
         },
       ]
       : [];
-    const hasReviewerMentionTarget = reviewerMentions.some((mention) => trimNullable(mention.userId));
-    if (connectionTestMode === "reviewers" && !hasReviewerMentionTarget) {
+    const hasReviewerTarget = reviewerTargets.some((mention) => trimNullable(mention.userId));
+    if (connectionTestMode === "reviewers" && !hasReviewerTarget) {
       const skippedResult = {
         status: "skipped" as const,
         channel: "clickup-chat" as const,
@@ -160,23 +160,23 @@ export function companyAwaitingHumanSettingsRoutes(db: Db) {
 
     const result = await sendClickUpTransportTestMessage({
       title: connectionTestMode === "reviewers"
-        ? `${company.name} ClickUp reviewer mention test`
+        ? `${company.name} ClickUp reviewer notification test`
         : `${company.name} ClickUp bridge connection test`,
       summary: connectionTestMode === "reviewers"
-        ? "Bizbox completed a reviewer mention test for ClickUp."
+        ? "Bizbox completed a reviewer notification test for ClickUp."
         : "Bizbox completed a bridge transport test for ClickUp.",
       body: connectionTestMode === "reviewers"
-        ? "The configured bridge successfully delivered a reviewer mention test payload to the target ClickUp channel."
+        ? "The configured bridge successfully delivered a reviewer notification test payload to the target ClickUp channel."
         : "The configured bridge successfully delivered a test payload to the target ClickUp channel.",
       link: new URL(`/${company.issuePrefix}/company/settings/awaiting-human`, process.env.BIZBOX_API_URL ?? "http://localhost:3100").toString(),
       cta: "No action is required.",
-      reviewerMentions,
+      reviewerTargets,
     }, runtimeOverrides);
     const publicResult = result.status === "sent"
       ? {
         ...result,
         detail: connectionTestMode === "reviewers"
-          ? `ClickUp reviewer mention test succeeded. Message delivered to configured channel${result.externalId ? ` (message ${result.externalId})` : ""}.`
+          ? `ClickUp reviewer notification test succeeded. Message delivered to configured channel${result.externalId ? ` (message ${result.externalId})` : ""}.`
           : `ClickUp bridge connection test succeeded. Message delivered to configured channel${result.externalId ? ` (message ${result.externalId})` : ""}.`,
       }
       : result;

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -297,7 +297,7 @@ async function maybeSendClickUpReviewerDirectMessages(input: {
 
   for (const reviewer of targets) {
     try {
-      const displayName = reviewer.displayName ?? await fetchClickUpUserDisplayName(input.config, reviewer.userId) ?? reviewer.userId;
+      const displayName = reviewer.displayName ?? reviewer.userId;
       const dmChannel = await createClickUpDirectMessageChannel(input.config, reviewer.userId);
       const dmContent = [
         `Hi ${displayName},`,

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -74,6 +74,12 @@ type ClickUpTransportMessageResult = AwaitingHumanNotificationResult & {
 type ClickUpReviewerTarget = {
   label: string;
   userId: string;
+  displayName: string | null;
+};
+
+type ClickUpReviewerInput = {
+  label: string;
+  userId: string | null | undefined;
   displayName?: string | null;
 };
 
@@ -217,6 +223,12 @@ async function resolveClickUpReviewerTargets(
   })));
 }
 
+function isClickUpReviewerTarget(
+  reviewer: ClickUpReviewerTarget | null,
+): reviewer is ClickUpReviewerTarget {
+  return reviewer !== null;
+}
+
 async function createClickUpDirectMessageChannel(
   config: ClickUpChatConfig,
   userId: string,
@@ -272,7 +284,7 @@ async function maybeSendClickUpReviewerDirectMessages(input: {
   config: ClickUpChatConfig;
   title: string;
   threadLink: string;
-  reviewers: Array<ClickUpReviewerTarget | { label: string; userId: string | null | undefined }>;
+  reviewers: ClickUpReviewerInput[];
 }) {
   const targets = input.reviewers
     .map((reviewer) => {
@@ -281,11 +293,11 @@ async function maybeSendClickUpReviewerDirectMessages(input: {
         ? {
           label: reviewer.label,
           userId,
-          displayName: "displayName" in reviewer ? reviewer.displayName ?? null : null,
+          displayName: reviewer.displayName ?? null,
         }
         : null;
     })
-    .filter((reviewer): reviewer is ClickUpReviewerTarget => reviewer !== null);
+    .filter(isClickUpReviewerTarget);
 
   for (const reviewer of targets) {
     try {
@@ -508,8 +520,8 @@ function pickReviewerDisplayName(
   const preferred = approvalReviewers?.[preferredIndex] ?? null;
   const fallback = approvalReviewers?.[fallbackIndex] ?? null;
   return preferred?.displayName
-    ?? fallback?.displayName
     ?? preferred?.userId
+    ?? fallback?.displayName
     ?? fallback?.userId
     ?? null;
 }

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -146,10 +146,6 @@ function readClickUpUserName(payload: Record<string, unknown>) {
   return readString(user.username) ?? readString(user.name);
 }
 
-function buildClickUpChatThreadLink(workspaceId: string, messageId: string) {
-  return `https://api.clickup.com/api/v3/workspaces/${encodeURIComponent(workspaceId)}/chat/messages/${encodeURIComponent(messageId)}/replies`;
-}
-
 function parseClickUpCreateChatMessageResponse(rawText: string) {
   const payload = JSON.parse(rawText) as Record<string, unknown>;
   const data = payload.data && typeof payload.data === "object"
@@ -283,7 +279,7 @@ async function sendClickUpDirectMessage(
 async function maybeSendClickUpReviewerDirectMessages(input: {
   config: ClickUpChatConfig;
   title: string;
-  threadLink: string;
+  threadLink?: string | null;
   reviewers: ClickUpReviewerInput[];
 }) {
   const targets = input.reviewers
@@ -307,10 +303,11 @@ async function maybeSendClickUpReviewerDirectMessages(input: {
         `Hi ${displayName},`,
         "",
         `You were notified in ClickUp about ${truncateText(input.title, 120)}.`,
-        "",
-        `Original approval thread: ${input.threadLink}`,
-      ].join("\n");
-      await sendClickUpDirectMessage(input.config, dmChannel.channelId, dmContent);
+      ];
+      if (input.threadLink) {
+        dmContent.push("", `Original approval thread: ${input.threadLink}`);
+      }
+      await sendClickUpDirectMessage(input.config, dmChannel.channelId, dmContent.join("\n"));
     } catch (error) {
       logger.warn({
         userId: reviewer.userId,
@@ -835,17 +832,20 @@ export async function sendAwaitingHumanNotification(
       { label: "Secondary reviewer", userId: approvalRoute.nextReviewerUserId },
     ])
     : [];
+  const currentReviewerTargets = approvalRoute
+    ? approvalReviewers.filter((reviewer) => reviewer.userId === approvalRoute.currentReviewerUserId)
+    : [];
   const result = await postClickUpChatMessage(
     renderClickUpMessage(input.notification, config, { approvalReviewers }),
     overrides,
   );
   if (result.status === "sent" && approvalRoute && result.externalId) {
-    const threadLink = result.messageLink ?? buildClickUpChatThreadLink(config.workspaceId, result.externalId);
+    const threadLink = result.messageLink ?? readString(input.notification.link);
     await maybeSendClickUpReviewerDirectMessages({
       config,
       title: input.notification.title,
       threadLink,
-      reviewers: approvalReviewers,
+      reviewers: currentReviewerTargets,
     });
   }
   const { messageLink: _messageLink, ...publicResult } = result;
@@ -894,7 +894,7 @@ export async function sendClickUpTransportTestMessage(
     overrides,
   );
   if (result.status === "sent" && result.externalId && notification.reviewerTargets?.length) {
-    const threadLink = result.messageLink ?? buildClickUpChatThreadLink(config.workspaceId, result.externalId);
+    const threadLink = result.messageLink ?? readString(notification.link);
     await maybeSendClickUpReviewerDirectMessages({
       config,
       title: notification.title,

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -535,11 +535,10 @@ function renderApprovalContextSection(
   lines.push(`Approval stage: ${formatApprovalStage(route.approvalStage)}`);
 
   const reviewerLabel = route.approvalStage === "primary" ? "Primary reviewer" : "Reviewer";
-  const currentReviewerDisplayName = route.approvalStage === "primary"
-    ? pickReviewerDisplayName(approvalReviewers, "Primary reviewer")
-    : route.requiresSecondReview
-      ? pickReviewerDisplayName(approvalReviewers, "Secondary reviewer")
-      : pickReviewerDisplayName(approvalReviewers, "Primary reviewer");
+  const currentReviewer = approvalReviewers?.find(
+    (candidate) => candidate.userId === route.currentReviewerUserId,
+  ) ?? null;
+  const currentReviewerDisplayName = currentReviewer?.displayName ?? currentReviewer?.userId ?? null;
   lines.push(currentReviewerDisplayName
     ? `${reviewerLabel}: notified in a direct message to ${currentReviewerDisplayName}.`
     : `${reviewerLabel}: notified in a direct message.`);
@@ -858,14 +857,6 @@ export async function sendAwaitingHumanNotificationReply(
   overrides?: ClickUpAwaitingHumanConfigOverrides,
 ): Promise<AwaitingHumanNotificationResult> {
   const config = readClickUpChatConfig(overrides);
-  const approvalContext = input.notification.approvalContext;
-  const approvalRoute = approvalContext ? resolveApprovalFlowRoute(approvalContext, config) : null;
-  const approvalReviewers = approvalRoute
-    ? await resolveClickUpReviewerTargets(config, [
-      { label: "Primary reviewer", userId: config.primaryReviewerUserId },
-      { label: "Secondary reviewer", userId: config.secondaryReviewerUserId },
-    ])
-    : [];
   const result = await postClickUpChatMessageReply(
     parentMessageId,
     renderClickUpMessage(
@@ -875,7 +866,6 @@ export async function sendAwaitingHumanNotificationReply(
         maxChars: CLICKUP_CHAT_REPLY_MESSAGE_MAX_CHARS,
         preserveBody: true,
         includeCtaWithBody: true,
-        approvalReviewers,
       },
     ),
     overrides,

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -28,7 +28,7 @@ export interface ClickUpTransportTestNotification {
   link: string;
   body?: string | null;
   cta?: string | null;
-  reviewerMentions?: Array<{
+  reviewerTargets?: Array<{
     label: string;
     userId: string | null | undefined;
   }>;
@@ -66,6 +66,16 @@ export interface ClickUpChatMessageReply {
   content: string | null;
   dateMs: number | null;
 }
+
+type ClickUpTransportMessageResult = AwaitingHumanNotificationResult & {
+  messageLink: string | null;
+};
+
+type ClickUpReviewerTarget = {
+  label: string;
+  userId: string;
+  displayName?: string | null;
+};
 
 function compactWhitespace(value: string) {
   return value.split(/\s+/).filter(Boolean).join(" ");
@@ -115,6 +125,188 @@ function readString(value: unknown) {
   return typeof value === "string" && value.trim().length > 0
     ? value.trim()
     : null;
+}
+
+function readClickUpUserName(payload: Record<string, unknown>) {
+  const member = payload.member && typeof payload.member === "object"
+    ? payload.member as Record<string, unknown>
+    : null;
+  const user = member?.user && typeof member.user === "object"
+    ? member.user as Record<string, unknown>
+    : payload.user && typeof payload.user === "object"
+      ? payload.user as Record<string, unknown>
+      : null;
+  if (!user) return null;
+  return readString(user.username) ?? readString(user.name);
+}
+
+function buildClickUpChatThreadLink(workspaceId: string, messageId: string) {
+  return `https://api.clickup.com/api/v3/workspaces/${encodeURIComponent(workspaceId)}/chat/messages/${encodeURIComponent(messageId)}/replies`;
+}
+
+function parseClickUpCreateChatMessageResponse(rawText: string) {
+  const payload = JSON.parse(rawText) as Record<string, unknown>;
+  const data = payload.data && typeof payload.data === "object"
+    ? payload.data as Record<string, unknown>
+    : payload;
+  const messageId = readString(data.id) ?? readString(payload.id);
+  if (!messageId) {
+    throw new Error(`clickup chat message response missing message id:${rawText.slice(0, 240)}`);
+  }
+  const replyLink = readString(
+    (data.links && typeof data.links === "object" ? (data.links as Record<string, unknown>).replies : null)
+      ?? (payload.links && typeof payload.links === "object" ? (payload.links as Record<string, unknown>).replies : null),
+  );
+  return {
+    messageId,
+    messageLink: replyLink ?? readString(data.url) ?? readString(payload.url) ?? null,
+  };
+}
+
+function parseClickUpCreateChatChannelResponse(rawText: string) {
+  const payload = JSON.parse(rawText) as Record<string, unknown>;
+  const data = payload.data && typeof payload.data === "object"
+    ? payload.data as Record<string, unknown>
+    : payload;
+  const channelId = readString(data.id) ?? readString(payload.id);
+  if (!channelId) {
+    throw new Error(`clickup DM channel response missing channel id:${rawText.slice(0, 240)}`);
+  }
+  return { channelId };
+}
+
+async function fetchClickUpUserDisplayName(
+  config: ClickUpChatConfig,
+  userId: string,
+) {
+  const response = await fetchText(
+    `https://api.clickup.com/api/v2/team/${encodeURIComponent(config.workspaceId)}/user/${encodeURIComponent(userId)}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: config.personalToken,
+        Accept: "application/json",
+      },
+    },
+  );
+  if (!response.ok || !response.text.trim()) return null;
+  try {
+    const payload = JSON.parse(response.text) as Record<string, unknown>;
+    const name = readClickUpUserName(payload);
+    return name && name.trim().length > 0 ? name.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveClickUpReviewerTargets(
+  config: ClickUpChatConfig,
+  reviewers: Array<{ label: string; userId: string | null | undefined }>,
+): Promise<ClickUpReviewerTarget[]> {
+  const targets = reviewers
+    .map((reviewer) => {
+      const userId = readString(reviewer.userId);
+      return userId ? { label: reviewer.label, userId } : null;
+    })
+    .filter((reviewer): reviewer is { label: string; userId: string } => reviewer !== null);
+
+  return Promise.all(targets.map(async (reviewer) => ({
+    label: reviewer.label,
+    userId: reviewer.userId,
+    displayName: await fetchClickUpUserDisplayName(config, reviewer.userId),
+  })));
+}
+
+async function createClickUpDirectMessageChannel(
+  config: ClickUpChatConfig,
+  userId: string,
+) {
+  const response = await fetchText(
+    `https://api.clickup.com/api/v3/workspaces/${encodeURIComponent(config.workspaceId)}/chat/channels/direct_message`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: config.personalToken,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        user_ids: [userId],
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`http-error:${response.status}:${truncateText(response.text, 240)}`);
+  }
+  return parseClickUpCreateChatChannelResponse(response.text);
+}
+
+async function sendClickUpDirectMessage(
+  config: ClickUpChatConfig,
+  channelId: string,
+  content: string,
+) {
+  const response = await fetchText(
+    `https://api.clickup.com/api/v3/workspaces/${encodeURIComponent(config.workspaceId)}/chat/channels/${encodeURIComponent(channelId)}/messages`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: config.personalToken,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "message",
+        content,
+        content_format: "text/md",
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`http-error:${response.status}:${truncateText(response.text, 240)}`);
+  }
+
+  return parseClickUpCreateChatMessageResponse(response.text);
+}
+
+async function maybeSendClickUpReviewerDirectMessages(input: {
+  config: ClickUpChatConfig;
+  title: string;
+  threadLink: string;
+  reviewers: Array<ClickUpReviewerTarget | { label: string; userId: string | null | undefined }>;
+}) {
+  const targets = input.reviewers
+    .map((reviewer) => {
+      const userId = readString(reviewer.userId);
+      return userId
+        ? {
+          label: reviewer.label,
+          userId,
+          displayName: "displayName" in reviewer ? reviewer.displayName ?? null : null,
+        }
+        : null;
+    })
+    .filter((reviewer): reviewer is ClickUpReviewerTarget => reviewer !== null);
+
+  for (const reviewer of targets) {
+    try {
+      const displayName = reviewer.displayName ?? await fetchClickUpUserDisplayName(input.config, reviewer.userId) ?? reviewer.userId;
+      const dmChannel = await createClickUpDirectMessageChannel(input.config, reviewer.userId);
+      const dmContent = [
+        `Hi ${displayName},`,
+        "",
+        `You were notified in ClickUp about ${truncateText(input.title, 120)}.`,
+        "",
+        `Original approval thread: ${input.threadLink}`,
+      ].join("\n");
+      await sendClickUpDirectMessage(input.config, dmChannel.channelId, dmContent);
+    } catch (error) {
+      logger.warn({
+        userId: reviewer.userId,
+        label: reviewer.label,
+        err: error,
+      }, "clickup awaiting human reviewer DM failed");
+    }
+  }
 }
 
 async function readCompanyClickUpOverrides(
@@ -303,18 +495,29 @@ function extractReplyRowsFromRows(rows: ClickUpReplyMessageResponse[]): ClickUpC
 function extractReplyRows(payload: ClickUpGetChatMessageRepliesResponse): ClickUpChatMessageReply[] {
   return extractReplyRowsFromRows(Array.isArray(payload.data) ? payload.data : []);
 }
-function formatClickUpUserMention(userId: string | null | undefined) {
-  const trimmed = readString(userId);
-  return trimmed ? `clickup://user/${trimmed}` : null;
-}
 
 function formatApprovalStage(stage: "primary" | "final") {
   return stage === "primary" ? "primary review" : "final check";
 }
 
+function pickReviewerDisplayName(
+  approvalReviewers: ClickUpReviewerTarget[] | undefined,
+  preferredIndex: number,
+  fallbackIndex: number,
+) {
+  const preferred = approvalReviewers?.[preferredIndex] ?? null;
+  const fallback = approvalReviewers?.[fallbackIndex] ?? null;
+  return preferred?.displayName
+    ?? fallback?.displayName
+    ?? preferred?.userId
+    ?? fallback?.userId
+    ?? null;
+}
+
 function renderApprovalContextSection(
   notification: AwaitingHumanNotificationPayload,
   config: ClickUpChatConfig,
+  approvalReviewers?: ClickUpReviewerTarget[],
 ) {
   const approvalContext = notification.approvalContext;
   if (!approvalContext) return null;
@@ -326,29 +529,23 @@ function renderApprovalContextSection(
   }
   lines.push(`Approval stage: ${formatApprovalStage(route.approvalStage)}`);
 
-  const currentReviewerMention = formatClickUpUserMention(route.currentReviewerUserId);
-  if (currentReviewerMention) {
-    lines.push(`Reviewer: ${currentReviewerMention}`);
-  } else {
-    lines.push("Reviewer: not configured");
-  }
+  const reviewerLabel = route.approvalStage === "primary" ? "Primary reviewer" : "Reviewer";
+  const currentReviewerDisplayName = route.approvalStage === "primary"
+    ? pickReviewerDisplayName(approvalReviewers, 0, 1)
+    : pickReviewerDisplayName(approvalReviewers, 1, 0);
+  lines.push(currentReviewerDisplayName
+    ? `${reviewerLabel}: notified in a direct message to ${currentReviewerDisplayName}.`
+    : `${reviewerLabel}: notified in a direct message.`);
 
-  if (route.nextReviewerUserId) {
-    const nextReviewerMention = formatClickUpUserMention(route.nextReviewerUserId);
-    lines.push(`Next reviewer: ${nextReviewerMention ?? "not configured"}`);
-  }
-
-  if (route.approvalStage === "primary" && route.requiresSecondReview) {
-    const nextReviewerMention = formatClickUpUserMention(route.nextReviewerUserId);
-    lines.push(
-      `Next step: ${currentReviewerMention ?? "the reviewer"} checks first, then ${nextReviewerMention ?? "the secondary reviewer"} handles the final check if approved.`,
-    );
-  } else if (route.approvalStage === "final" && route.requiresSecondReview) {
-    lines.push(
-      `Next step: ${currentReviewerMention ?? "the reviewer"} handles the final check after the primary review clears.`,
-    );
+  if (route.requiresSecondReview && route.approvalStage === "primary") {
+    const nextReviewerDisplayName = pickReviewerDisplayName(approvalReviewers, 1, 0);
+    lines.push(nextReviewerDisplayName
+      ? `Next step: the secondary reviewer, ${nextReviewerDisplayName}, will be notified if the approval is accepted.`
+      : "Next step: the secondary reviewer will be notified if the approval is accepted.");
+  } else if (route.requiresSecondReview && route.approvalStage === "final") {
+    lines.push("Next step: the final reviewer handles the approval after the primary review clears.");
   } else {
-    lines.push(`Next step: ${currentReviewerMention ?? "the reviewer"} handles the approval.`);
+    lines.push("Next step: the reviewer handles the approval in ClickUp.");
   }
 
   return lines.join("\n");
@@ -361,6 +558,7 @@ function renderClickUpMessage(
     maxChars?: number;
     preserveBody?: boolean;
     includeCtaWithBody?: boolean;
+    approvalReviewers?: ClickUpReviewerTarget[];
   },
 ) {
   const maxChars = options?.maxChars ?? CLICKUP_CHAT_MESSAGE_MAX_CHARS;
@@ -368,7 +566,7 @@ function renderClickUpMessage(
   const bodySection = options?.preserveBody
     ? formatFullBodySection(notification.body)
     : formatBodySection(notification.body);
-  const approvalSection = renderApprovalContextSection(notification, config);
+  const approvalSection = renderApprovalContextSection(notification, config, options?.approvalReviewers);
   const lines = [`**${title}**`];
 
   if (bodySection) {
@@ -430,18 +628,17 @@ function renderClickUpTransportTestMessage(
     lines.push(bodySection);
   }
 
-  if (notification.reviewerMentions?.length) {
-    const hasConfiguredReviewerMention = notification.reviewerMentions.some(
-      (mention) => formatClickUpUserMention(mention.userId) !== null,
+  if (notification.reviewerTargets?.length) {
+    const hasConfiguredReviewerTarget = notification.reviewerTargets.some(
+      (mention) => readString(mention.userId) !== null,
     );
-    if (hasConfiguredReviewerMention) {
-      const mentionLines = notification.reviewerMentions.map((mention) => {
-        const userMention = formatClickUpUserMention(mention.userId);
-        return `${mention.label}: ${userMention ?? "not configured"}`;
+    if (hasConfiguredReviewerTarget) {
+      const reviewerLines = notification.reviewerTargets.map((mention) => {
+        return `${mention.label}: notified in a direct message${readString(mention.userId) ? "" : " (not configured)"}`;
       });
       lines.push("");
-      lines.push("Reviewer mention test:");
-      lines.push(...mentionLines);
+      lines.push("Reviewer notification test:");
+      lines.push(...reviewerLines);
     }
   }
 
@@ -458,13 +655,14 @@ function renderClickUpTransportTestMessage(
 async function postClickUpChatMessage(
   content: string,
   overrides?: ClickUpAwaitingHumanConfigOverrides,
-): Promise<AwaitingHumanNotificationResult> {
+): Promise<ClickUpTransportMessageResult> {
   const config = readClickUpChatConfig(overrides);
   if (!config.personalToken) {
     return {
       status: "skipped",
       channel: "clickup-chat",
       detail: "missing-credential: CLICKUP_PERSONAL_TOKEN",
+      messageLink: null,
     };
   }
   if (!config.workspaceId) {
@@ -472,6 +670,7 @@ async function postClickUpChatMessage(
       status: "skipped",
       channel: "clickup-chat",
       detail: "missing-target: CLICKUP_WORKSPACE_ID",
+      messageLink: null,
     };
   }
 
@@ -483,6 +682,7 @@ async function postClickUpChatMessage(
         channel: "clickup-chat",
         detail:
           "missing-target: CLICKUP_AWAITING_HUMAN_CHANNEL_ID (or CLICKUP_ENGINEERING_CHANNEL_ID)",
+        messageLink: null,
       };
     }
 
@@ -507,24 +707,27 @@ async function postClickUpChatMessage(
         status: "failed",
         channel: "clickup-chat",
         detail: `http-error:${response.status}:${truncateText(response.text, 240)}`,
+        messageLink: null,
       };
     }
 
-    const externalId = response.text.trim().length > 0
-      ? parseClickUpCreateChatMessageResponse(response.text).messageId
+    const parsedMessage = response.text.trim().length > 0
+      ? parseClickUpCreateChatMessageResponse(response.text)
       : null;
 
     return {
       status: "sent",
       channel: "clickup-chat",
       detail: "sent",
-      externalId,
+      externalId: parsedMessage?.messageId ?? null,
+      messageLink: parsedMessage?.messageLink ?? null,
     };
   } catch (error) {
     return {
       status: "failed",
       channel: "clickup-chat",
       detail: error instanceof Error ? error.message : String(error),
+      messageLink: null,
     };
   }
 }
@@ -533,13 +736,14 @@ async function postClickUpChatMessageReply(
   parentMessageId: string,
   content: string,
   overrides?: ClickUpAwaitingHumanConfigOverrides,
-): Promise<AwaitingHumanNotificationResult> {
+): Promise<ClickUpTransportMessageResult> {
   const config = readClickUpChatConfig(overrides);
   if (!config.personalToken) {
     return {
       status: "skipped",
       channel: "clickup-chat",
       detail: "missing-credential: CLICKUP_PERSONAL_TOKEN",
+      messageLink: null,
     };
   }
   if (!config.workspaceId) {
@@ -547,6 +751,7 @@ async function postClickUpChatMessageReply(
       status: "skipped",
       channel: "clickup-chat",
       detail: "missing-target: CLICKUP_WORKSPACE_ID",
+      messageLink: null,
     };
   }
 
@@ -556,6 +761,7 @@ async function postClickUpChatMessageReply(
       status: "skipped",
       channel: "clickup-chat",
       detail: "missing-target: parent-message-id",
+      messageLink: null,
     };
   }
 
@@ -581,24 +787,27 @@ async function postClickUpChatMessageReply(
         status: "failed",
         channel: "clickup-chat",
         detail: `http-error:${response.status}:${truncateText(response.text, 240)}`,
+        messageLink: null,
       };
     }
 
-    const externalId = response.text.trim().length > 0
-      ? parseClickUpCreateChatMessageResponse(response.text).messageId
+    const parsedMessage = response.text.trim().length > 0
+      ? parseClickUpCreateChatMessageResponse(response.text)
       : null;
 
     return {
       status: "sent",
       channel: "clickup-chat",
       detail: "sent",
-      externalId,
+      externalId: parsedMessage?.messageId ?? null,
+      messageLink: parsedMessage?.messageLink ?? null,
     };
   } catch (error) {
     return {
       status: "failed",
       channel: "clickup-chat",
       detail: error instanceof Error ? error.message : String(error),
+      messageLink: null,
     };
   }
 }
@@ -608,10 +817,29 @@ export async function sendAwaitingHumanNotification(
   overrides?: ClickUpAwaitingHumanConfigOverrides,
 ): Promise<AwaitingHumanNotificationResult> {
   const config = readClickUpChatConfig(overrides);
-  return postClickUpChatMessage(
-    renderClickUpMessage(input.notification, config),
+  const approvalContext = input.notification.approvalContext;
+  const approvalRoute = approvalContext ? resolveApprovalFlowRoute(approvalContext, config) : null;
+  const approvalReviewers = approvalRoute
+    ? await resolveClickUpReviewerTargets(config, [
+      { label: "Primary reviewer", userId: approvalRoute.currentReviewerUserId },
+      { label: "Secondary reviewer", userId: approvalRoute.nextReviewerUserId },
+    ])
+    : [];
+  const result = await postClickUpChatMessage(
+    renderClickUpMessage(input.notification, config, { approvalReviewers }),
     overrides,
   );
+  if (result.status === "sent" && approvalRoute && result.externalId) {
+    const threadLink = result.messageLink ?? buildClickUpChatThreadLink(config.workspaceId, result.externalId);
+    await maybeSendClickUpReviewerDirectMessages({
+      config,
+      title: input.notification.title,
+      threadLink,
+      reviewers: approvalReviewers,
+    });
+  }
+  const { messageLink: _messageLink, ...publicResult } = result;
+  return publicResult;
 }
 
 export async function sendAwaitingHumanNotificationReply(
@@ -620,7 +848,15 @@ export async function sendAwaitingHumanNotificationReply(
   overrides?: ClickUpAwaitingHumanConfigOverrides,
 ): Promise<AwaitingHumanNotificationResult> {
   const config = readClickUpChatConfig(overrides);
-  return postClickUpChatMessageReply(
+  const approvalContext = input.notification.approvalContext;
+  const approvalRoute = approvalContext ? resolveApprovalFlowRoute(approvalContext, config) : null;
+  const approvalReviewers = approvalRoute
+    ? await resolveClickUpReviewerTargets(config, [
+      { label: "Primary reviewer", userId: approvalRoute.currentReviewerUserId },
+      { label: "Secondary reviewer", userId: approvalRoute.nextReviewerUserId },
+    ])
+    : [];
+  const result = await postClickUpChatMessageReply(
     parentMessageId,
     renderClickUpMessage(
       input.notification,
@@ -629,25 +865,44 @@ export async function sendAwaitingHumanNotificationReply(
         maxChars: CLICKUP_CHAT_REPLY_MESSAGE_MAX_CHARS,
         preserveBody: true,
         includeCtaWithBody: true,
+        approvalReviewers,
       },
     ),
     overrides,
   );
+  if (result.status === "sent" && approvalRoute) {
+    await maybeSendClickUpReviewerDirectMessages({
+      config,
+      title: input.notification.title,
+      threadLink: buildClickUpChatThreadLink(config.workspaceId, parentMessageId.trim()),
+      reviewers: approvalReviewers,
+    });
+  }
+  const { messageLink: _messageLink, ...publicResult } = result;
+  return publicResult;
 }
 
 export async function sendClickUpTransportTestMessage(
   notification: ClickUpTransportTestNotification,
   overrides?: ClickUpAwaitingHumanConfigOverrides,
 ): Promise<AwaitingHumanNotificationResult> {
-  return postClickUpChatMessage(
+  const config = readClickUpChatConfig(overrides);
+  const result = await postClickUpChatMessage(
     renderClickUpTransportTestMessage(notification),
     overrides,
   );
+  if (result.status === "sent" && result.externalId && notification.reviewerTargets?.length) {
+    const threadLink = result.messageLink ?? buildClickUpChatThreadLink(config.workspaceId, result.externalId);
+    await maybeSendClickUpReviewerDirectMessages({
+      config,
+      title: notification.title,
+      threadLink,
+      reviewers: notification.reviewerTargets,
+    });
+  }
+  const { messageLink: _messageLink, ...publicResult } = result;
+  return publicResult;
 }
-
-type ClickUpCreateChatMessageResponse = {
-  id: string;
-};
 
 type ClickUpAttachmentsAttachment = {
   date_updated: number;
@@ -673,13 +928,6 @@ type ClickUpApiErrorResponse = {
   trace_id: number | null;
   timestamp: number;
 };
-
-function parseClickUpCreateChatMessageResponse(rawText: string) {
-  const payload = JSON.parse(rawText) as ClickUpCreateChatMessageResponse;
-  return {
-    messageId: payload.id,
-  };
-}
 
 function parseClickUpAttachmentResponse(rawText: string) {
   const payload = JSON.parse(rawText) as ClickUpAttachmentsAttachment;

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -540,7 +540,7 @@ function renderApprovalContextSection(
   ) ?? null;
   const currentReviewerDisplayName = currentReviewer?.displayName ?? currentReviewer?.userId ?? null;
   lines.push(route.currentReviewerUserId
-    ? `${reviewerLabel}: notified in a direct message to ${currentReviewerDisplayName ?? "the reviewer"}.`
+    ? `${reviewerLabel}: a direct message will be sent to ${currentReviewerDisplayName ?? "the reviewer"}.`
     : `${reviewerLabel}: not configured.`);
 
   if (route.requiresSecondReview && route.approvalStage === "primary") {
@@ -640,7 +640,9 @@ function renderClickUpTransportTestMessage(
     );
     if (hasConfiguredReviewerTarget) {
       const reviewerLines = notification.reviewerTargets.map((mention) => {
-        return `${mention.label}: notified in a direct message${readString(mention.userId) ? "" : " (not configured)"}`;
+        return readString(mention.userId)
+          ? `${mention.label}: a direct message will be sent`
+          : `${mention.label}: not configured`;
       });
       lines.push("");
       lines.push("Reviewer notification test:");

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -514,15 +514,11 @@ function formatApprovalStage(stage: "primary" | "final") {
 
 function pickReviewerDisplayName(
   approvalReviewers: ClickUpReviewerTarget[] | undefined,
-  preferredIndex: number,
-  fallbackIndex: number,
+  reviewerLabel: string,
 ) {
-  const preferred = approvalReviewers?.[preferredIndex] ?? null;
-  const fallback = approvalReviewers?.[fallbackIndex] ?? null;
-  return preferred?.displayName
-    ?? preferred?.userId
-    ?? fallback?.displayName
-    ?? fallback?.userId
+  const reviewer = approvalReviewers?.find((candidate) => candidate.label === reviewerLabel) ?? null;
+  return reviewer?.displayName
+    ?? reviewer?.userId
     ?? null;
 }
 
@@ -543,14 +539,16 @@ function renderApprovalContextSection(
 
   const reviewerLabel = route.approvalStage === "primary" ? "Primary reviewer" : "Reviewer";
   const currentReviewerDisplayName = route.approvalStage === "primary"
-    ? pickReviewerDisplayName(approvalReviewers, 0, 1)
-    : pickReviewerDisplayName(approvalReviewers, 1, 0);
+    ? pickReviewerDisplayName(approvalReviewers, "Primary reviewer")
+    : route.requiresSecondReview
+      ? pickReviewerDisplayName(approvalReviewers, "Secondary reviewer")
+      : pickReviewerDisplayName(approvalReviewers, "Primary reviewer");
   lines.push(currentReviewerDisplayName
     ? `${reviewerLabel}: notified in a direct message to ${currentReviewerDisplayName}.`
     : `${reviewerLabel}: notified in a direct message.`);
 
   if (route.requiresSecondReview && route.approvalStage === "primary") {
-    const nextReviewerDisplayName = pickReviewerDisplayName(approvalReviewers, 1, 0);
+    const nextReviewerDisplayName = pickReviewerDisplayName(approvalReviewers, "Secondary reviewer");
     lines.push(nextReviewerDisplayName
       ? `Next step: the secondary reviewer, ${nextReviewerDisplayName}, will be notified if the approval is accepted.`
       : "Next step: the secondary reviewer will be notified if the approval is accepted.");
@@ -882,14 +880,6 @@ export async function sendAwaitingHumanNotificationReply(
     ),
     overrides,
   );
-  if (result.status === "sent" && approvalRoute) {
-    await maybeSendClickUpReviewerDirectMessages({
-      config,
-      title: input.notification.title,
-      threadLink: buildClickUpChatThreadLink(config.workspaceId, parentMessageId.trim()),
-      reviewers: approvalReviewers,
-    });
-  }
   const { messageLink: _messageLink, ...publicResult } = result;
   return publicResult;
 }

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -539,9 +539,9 @@ function renderApprovalContextSection(
     (candidate) => candidate.userId === route.currentReviewerUserId,
   ) ?? null;
   const currentReviewerDisplayName = currentReviewer?.displayName ?? currentReviewer?.userId ?? null;
-  lines.push(currentReviewerDisplayName
-    ? `${reviewerLabel}: notified in a direct message to ${currentReviewerDisplayName}.`
-    : `${reviewerLabel}: notified in a direct message.`);
+  lines.push(route.currentReviewerUserId
+    ? `${reviewerLabel}: notified in a direct message to ${currentReviewerDisplayName ?? "the reviewer"}.`
+    : `${reviewerLabel}: not configured.`);
 
   if (route.requiresSecondReview && route.approvalStage === "primary") {
     const nextReviewerDisplayName = pickReviewerDisplayName(approvalReviewers, "Secondary reviewer");
@@ -879,17 +879,20 @@ export async function sendClickUpTransportTestMessage(
   overrides?: ClickUpAwaitingHumanConfigOverrides,
 ): Promise<AwaitingHumanNotificationResult> {
   const config = readClickUpChatConfig(overrides);
+  const reviewerTargets = notification.reviewerTargets?.length
+    ? await resolveClickUpReviewerTargets(config, notification.reviewerTargets)
+    : [];
   const result = await postClickUpChatMessage(
     renderClickUpTransportTestMessage(notification),
     overrides,
   );
-  if (result.status === "sent" && result.externalId && notification.reviewerTargets?.length) {
+  if (result.status === "sent" && result.externalId && reviewerTargets.length) {
     const threadLink = result.messageLink ?? readString(notification.link);
     await maybeSendClickUpReviewerDirectMessages({
       config,
       title: notification.title,
       threadLink,
-      reviewers: notification.reviewerTargets,
+      reviewers: reviewerTargets,
     });
   }
   const { messageLink: _messageLink, ...publicResult } = result;

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -828,8 +828,8 @@ export async function sendAwaitingHumanNotification(
   const approvalRoute = approvalContext ? resolveApprovalFlowRoute(approvalContext, config) : null;
   const approvalReviewers = approvalRoute
     ? await resolveClickUpReviewerTargets(config, [
-      { label: "Primary reviewer", userId: approvalRoute.currentReviewerUserId },
-      { label: "Secondary reviewer", userId: approvalRoute.nextReviewerUserId },
+      { label: "Primary reviewer", userId: config.primaryReviewerUserId },
+      { label: "Secondary reviewer", userId: config.secondaryReviewerUserId },
     ])
     : [];
   const currentReviewerTargets = approvalRoute
@@ -862,8 +862,8 @@ export async function sendAwaitingHumanNotificationReply(
   const approvalRoute = approvalContext ? resolveApprovalFlowRoute(approvalContext, config) : null;
   const approvalReviewers = approvalRoute
     ? await resolveClickUpReviewerTargets(config, [
-      { label: "Primary reviewer", userId: approvalRoute.currentReviewerUserId },
-      { label: "Secondary reviewer", userId: approvalRoute.nextReviewerUserId },
+      { label: "Primary reviewer", userId: config.primaryReviewerUserId },
+      { label: "Secondary reviewer", userId: config.secondaryReviewerUserId },
     ])
     : [];
   const result = await postClickUpChatMessageReply(


### PR DESCRIPTION
This pull request updates the ClickUp notification and testing logic to move from "reviewer mentions" (using ClickUp user links) to direct reviewer notifications via direct messages. It also improves test coverage for various reviewer notification scenarios, including error handling and fallback behaviors. The changes primarily affect tests, route handlers, and payload construction for ClickUp integration.

**Transition from reviewer mentions to direct reviewer notifications:**

* Replaces all usage and references of `reviewerMentions` with `reviewerTargets` throughout test cases and route logic, reflecting the move from mentioning reviewers in messages to sending them direct messages. [[1]](diffhunk://#diff-d090b5958dfef84fdaacff8a606440f0016bfe44677398689fa545c3f3538641L190-R190) [[2]](diffhunk://#diff-d090b5958dfef84fdaacff8a606440f0016bfe44677398689fa545c3f3538641L232-R241) [[3]](diffhunk://#diff-87c40c8919d2660f32ee7f35d47aa996d9925056a4a380d29eef22bcb243933dL121-R121) [[4]](diffhunk://#diff-87c40c8919d2660f32ee7f35d47aa996d9925056a4a380d29eef22bcb243933dL133-R134) [[5]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L634-R883) [[6]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L660-R952) [[7]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L675-R966) [[8]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L692-R1024)

**Expanded and improved test coverage:**

* Adds new test cases to ensure:
  - Reviewers are notified by direct message instead of mention links.
  - Reviewer names are resolved and fallback to raw user IDs if display names cannot be fetched.
  - Direct messages are not resent on approval replies.
  - Reviewer notification is only claimed if DM delivery succeeds, with warnings logged on failures.
  - Reviewer notification sections are omitted if no reviewers are configured. [[1]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L523-R686) [[2]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984R739-R783) [[3]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L660-R952) [[4]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L675-R966) [[5]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L692-R1024)

**Test and route handler messaging updates:**

* Updates test and route handler descriptions and payloads to use "reviewer notification" language instead of "reviewer mention", ensuring consistency in user-facing and internal messages. [[1]](diffhunk://#diff-d090b5958dfef84fdaacff8a606440f0016bfe44677398689fa545c3f3538641L204-R204) [[2]](diffhunk://#diff-d090b5958dfef84fdaacff8a606440f0016bfe44677398689fa545c3f3538641L232-R241) [[3]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L634-R883) [[4]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L660-R952) [[5]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L675-R966)

**Reviewer notification logic and fallback improvements:**

* Ensures that reviewer DMs are only marked as delivered if the API call succeeds, with appropriate logging if it fails, and falls back to using the user ID if the display name cannot be resolved from ClickUp. [[1]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L660-R952) [[2]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L692-R1024)

**General test and code consistency:**

* Refactors test code to align with the new reviewer notification approach, including updating assertions, payload construction, and mock API call expectations. [[1]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L491-R516) [[2]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L523-R686) [[3]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984L634-R883)

These changes ensure a more robust and user-friendly reviewer notification system for ClickUp integrations, with improved test reliability and clearer messaging.