### PR TITLE
Fix workflow temp runtime permissions

### DIFF
--- a/server/src/__tests__/workflows-runtime.test.ts
+++ b/server/src/__tests__/workflows-runtime.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { analyzeWorkflowProject } from "../services/workflows-runtime.js";
+import { analyzeWorkflowProject, prepareInstrumentedWorkflowRuntime } from "../services/workflows-runtime.js";
 
 describe("workflows runtime analysis", () => {
   const tempRoots: string[] = [];
@@ -38,5 +38,51 @@ root_agent = root
     const analysis = await analyzeWorkflowProject(agentPath);
     expect(analysis.pipelineDefinition.phases.map((phase) => phase.label)).toContain("Reviewer");
     expect(analysis.pipelineDefinition.phases.map((phase) => phase.label)).toContain("build_outline");
+  });
+
+  it("makes workflow temp runtime traversable to sandboxed subprocesses", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-workflow-runtime-"));
+    tempRoots.push(root);
+
+    const agentDir = path.join(root, "agent");
+    const skillDir = path.join(agentDir, "skills", "clickup-social-signals");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# ClickUp Social Signals\n", "utf8");
+    await fs.writeFile(path.join(agentDir, "agent.py"), "root_agent = None\n", "utf8");
+
+    const prepared = await prepareInstrumentedWorkflowRuntime({
+      workflowId: "workflow-1",
+      runId: "run-1",
+      companyId: "company-1",
+      runToken: "token-1",
+      runnerConfig: {
+        agentPath: agentDir,
+        cwd: agentDir,
+      },
+      analysis: {
+        sourceHash: "hash-1",
+        entrypoint: "agent/agent.py",
+        pipelineDefinition: {
+          entrypoint: "agent/agent.py",
+          generatedAt: new Date(0).toISOString(),
+          phases: [],
+        },
+        files: [],
+        rootDir: root,
+        entryPath: path.join(agentDir, "agent.py"),
+        executionTargetPath: agentDir,
+      },
+    });
+    tempRoots.push(prepared.tempRoot);
+
+    const tempRootMode = (await fs.stat(prepared.tempRoot)).mode & 0o777;
+    const helperMode = (await fs.stat(path.join(prepared.tempRoot, "sitecustomize.py"))).mode & 0o777;
+    const copiedSkillDirMode = (await fs.stat(path.join(prepared.tempRoot, "project", "agent", "skills", "clickup-social-signals"))).mode & 0o777;
+    const copiedSkillFileMode = (await fs.stat(path.join(prepared.tempRoot, "project", "agent", "skills", "clickup-social-signals", "SKILL.md"))).mode & 0o777;
+
+    expect(tempRootMode).toBe(0o755);
+    expect(helperMode).toBe(0o644);
+    expect(copiedSkillDirMode).toBe(0o755);
+    expect(copiedSkillFileMode).toBe(0o644);
   });
 });

--- a/server/src/services/workflows-runtime.ts
+++ b/server/src/services/workflows-runtime.ts
@@ -804,6 +804,7 @@ export async function prepareInstrumentedWorkflowRuntime(input: {
   runToken: string;
 }) : Promise<PreparedWorkflowRuntime> {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), `bizbox-workflow-${input.runId}-`));
+  await fs.chmod(tempRoot, 0o755);
   const copiedRoot = path.join(tempRoot, "project");
   await fs.cp(input.analysis.rootDir, copiedRoot, { recursive: true });
 
@@ -817,7 +818,9 @@ export async function prepareInstrumentedWorkflowRuntime(input: {
     await instrumentPythonFile(path.join(copiedRoot, relativePath), entries);
   }
 
-  await fs.writeFile(path.join(tempRoot, "bizbox_workflow_runtime.py"), buildRuntimeHelperModule(), "utf8");
+  const runtimeHelperPath = path.join(tempRoot, "bizbox_workflow_runtime.py");
+  const siteCustomizePath = path.join(tempRoot, "sitecustomize.py");
+  await fs.writeFile(runtimeHelperPath, buildRuntimeHelperModule(), "utf8");
   // Use sitecustomize.py so the monkey-patch fires unconditionally before any user code runs.
   // .pth files are only processed from site-packages directories — not from arbitrary PYTHONPATH
   // entries — so the .pth approach silently does nothing in venv environments. sitecustomize.py,
@@ -825,7 +828,11 @@ export async function prepareInstrumentedWorkflowRuntime(input: {
   // interpreter itself, making it reliable in venvs. If the agent project already ships its own
   // sitecustomize.py it will be shadowed, but that is an acceptable trade-off given that the
   // alternative (input() hitting EOF in a non-interactive subprocess) is a hard crash.
-  await fs.writeFile(path.join(tempRoot, "sitecustomize.py"), "import bizbox_workflow_runtime\n", "utf8");
+  await fs.writeFile(siteCustomizePath, "import bizbox_workflow_runtime\n", "utf8");
+  await Promise.all([
+    fs.chmod(runtimeHelperPath, 0o644),
+    fs.chmod(siteCustomizePath, 0o644),
+  ]);
 
   const copiedAgentPath = (() => {
     const mapped = maybeMapIntoCopiedTree(input.analysis.rootDir, copiedRoot, input.analysis.executionTargetPath);


### PR DESCRIPTION
## Thinking Path

> - Bizbox is control plane for autonomous AI companies, with workflows as one execution surface for governed multi-step agent work.
> - Workflow runs stage a temporary project copy before invoking the Google ADK runner so the board can execute agent logic with runtime instrumentation and audit visibility.
> - That staging layer sits between workflow orchestration and adapter process launch, so filesystem accessibility there affects whether sandboxed or subprocess-based execution can read copied project content.
> - We hit a bug where files under a staged path like `/tmp/bizbox-workflow-.../project/agent/skills/clickup-social-signals` existed but were not fully accessible.
> - Root cause was the workflow temp root created by `fs.mkdtemp(...)` keeping `0700` permissions, which blocked traversal even though nested copied directories and files were otherwise readable.
> - This pull request fixes the temp runtime staging permissions at creation time and adds a regression test at the staging seam.
> - The benefit is that workflow runs can execute copied agent projects and skill folders in sandboxed/subprocess environments without hidden temp-root permission failures.

## What Changed

- Updated `server/src/services/workflows-runtime.ts` so staged workflow temp roots are chmodded to `0755` immediately after `mkdtemp(...)`.
- Normalized injected runtime helper file permissions (`bizbox_workflow_runtime.py` and `sitecustomize.py`) to `0644` after writing them.
- Added regression coverage in `server/src/__tests__/workflows-runtime.test.ts` proving the staged runtime root, helper files, and copied skill paths are traversable/readable.

## Verification

- Ran:
  - `pnpm vitest run server/src/__tests__/workflows-runtime.test.ts server/src/__tests__/workflow-service-run-manual.test.ts`
- Confirmed new regression test fails before fix because temp root mode is `0700` and passes after fix with `0755` / `0644` expectations.

## Risks

- Low risk. Change is isolated to workflow temp runtime staging.
- Behavioral shift: workflow temp root is now world-readable/traversable on local filesystem (`0755`) for duration of run. This is intentional to support sandboxed/subprocess access, but reviewers should confirm no sensitive-only content is unexpectedly staged there beyond what workflow execution already copies.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI coding agent via pi harness/API; exact model ID not exposed in this environment. Tool-enabled session with repository reads, code edits, bash execution, and targeted test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
