### PR TITLE
community: Build Log — Week of 2026-06-07

### DIFF
--- a/community/build-logs/2026-06-07.md
+++ b/community/build-logs/2026-06-07.md
@@ -1,0 +1,89 @@
+---
+title: "Bizbox Build Log — Week of 2026-06-07"
+slug: build-log-2026-06-07
+date: 2026-06-12
+channels: [github-discussions, dev.to]
+repo: zesthq/bizbox
+releases: [v2026.605.0, v2026.603.0, v2026.602.1, v2026.602.0]
+status: draft
+---
+
+# Bizbox Build Log — Week of 2026-06-07
+
+*The Build Log is a weekly snapshot of what the Bizbox team shipped, decided, traded off, and is still wrestling with. It's written for developers building on Bizbox — no marketing gloss.*
+
+*Activity covered: June 1–7, 2026 · Published: June 12, 2026*
+
+---
+
+## Shipped this week
+
+### 🟢 Workflows platform: human-in-the-loop is live
+**Release v2026.605.0 · v2026.603.0**
+
+The big story this cycle is the Workflows primitive reaching its first complete end-to-end state. Two weeks of work landed almost back-to-back:
+
+**[PR #86](https://github.com/zesthq/bizbox/pull/86) — Company-scoped Workflows with ADK pipeline runs** *(DennisDenuto)*
+Workflows are now a first-class company primitive in Bizbox — separate from issues and routines. Each Workflow maps to a Google ADK pipeline. The runtime records individual runs, tracks live phase state as a renderable graph, gates human handoffs, and persists deliverables. Database schema, API routes, and JWT-protected runtime callbacks all shipped together.
+
+**[PR #91](https://github.com/zesthq/bizbox/pull/91) — Workflow handoff to ClickUp** *(angelofallars)*
+This is the "last mile" for interactive Workflows. When ADK Python code calls `input()`, Bizbox now intercepts that call and routes the prompt to a human via ClickUp. The run parks itself and waits. When the human replies, the pipeline resumes. Two fixes came along for the ride: the `input()` monkey-patch is now portable across Python environments (an edge case that was quietly breaking some pipelines), and failed workflow runs no longer submit deliverables.
+
+**[PR #93](https://github.com/zesthq/bizbox/pull/93) — Top-level docs updated for Workflows + Google ADK** *(ralphbibera)*
+README, PRODUCT, and SPEC now reflect shipped reality: Workflows surface, Google ADK adapter, and the expanded company model. ADK is in the Works With table. This is a maintenance merge but it matters — the docs were lagging behind the code.
+
+**[PR #87](https://github.com/zesthq/bizbox/pull/87) — `fix(google-adk): strip frontmatter from AGENTS.md instructions`** *(ralphbibera)*  
+**Release v2026.602.1**
+The Google ADK adapter was passing raw YAML frontmatter directly to `adk run`, causing it to exit with an invalid input error. Fixed by stripping everything above the first `---` fence before the instructions are handed to the adapter. Real breakage fixed silently — this one was happening in production.
+
+**[PR #88](https://github.com/zesthq/bizbox/pull/88) — `Enhance issue origin handling with deduplication and tasks`** *(adPalafox)*  
+**Release v2026.602.0**
+Added SHA-256 fingerprint deduplication for suggested-task bundles. Without this, replaying or resubmitting a suggested-task payload would create duplicate child issues. Now it's idempotent.
+
+---
+
+### 🔧 Fix: ClickUp test link was missing the company slug
+**[PR #95](https://github.com/zesthq/bizbox/pull/95)** *(ralphbibera)*
+
+The "test connection" button on the ClickUp awaiting-human settings page was generating a link without the company slug. That meant the test notification landed nowhere useful. Fixed at the route level. Regression test added.
+
+*Not yet in a tagged release — expect this to ship in the next canary cut (blocked on the canary CI failure detailed below).*
+
+---
+
+## Decisions
+
+**Workflows are a separate primitive, not an extension of routines or issues.**
+This was a deliberate design choice in PR #86. Routines are recurring scheduled tasks; issues are discrete work items. Workflows are something different: multi-step ADK pipelines with phases, human gates, and deliverables. Keeping them separate means the data model stays clean and the UI can render them distinctly. The trade-off is more surface area to maintain and a steeper learning curve for users who ask "when do I use a routine vs. a workflow?" *(ADR to follow.)*
+
+**`input()` interception as the handoff mechanism.**
+PR #91 chose to intercept Python's `input()` rather than require ADK workflows to call a Bizbox-specific SDK function. The rationale is ergonomics: existing ADK pipeline code "just works" without modification. The cost is that `input()` monkey-patching is fragile — different Python environments initialise the builtins module at different points, which is why a portability fix shipped in the same PR. See [ADR 0001 — awaiting-human bridge](https://github.com/zesthq/bizbox/blob/master/docs/adr/0001-awaiting-human-bridge.md) for the bridge lifecycle, adapter registry, and runner/adapter split; a narrower ADR covering the `input()` interception mechanism specifically is to follow.
+
+---
+
+## Trade-offs
+
+**Monkey-patching `input()` across Python environments.**
+The fix in PR #91 addressed the known portability gap, but monkey-patching builtins is inherently brittle. If an ADK workflow uses `input()` in a subprocess or a thread before the patch lands, the intercept won't fire and the pipeline will block silently. This is a known risk the team is holding — the alternative (a first-party SDK call) would require ADK pipeline authors to change their code.
+
+**Workflows ship without retry policies.**
+PR #86's first cut does not include retry semantics for failed pipeline phases. If a phase errors out, the run fails. Whether that's the right default (fail fast) or a gap (users expect retry) is something the team is watching in early usage. Open issue: what's the right automatic retry behaviour for a human-gated phase that times out?
+
+---
+
+## Open challenges
+
+**⚠️ Canary publish CI failure on master (June 5)**
+The `Release` workflow's `publish_canary` step failed after the PR #95 merge ([run #26999915272](https://github.com/zesthq/bizbox/actions/runs/26999915272)). Docker build and lockfile refresh succeeded on the same run. The root cause isn't surfaced in the job logs accessible via API. **This is blocking the canary release of PR #95.** The team needs to triage this before the next cut.
+
+**PR #96 — Improve workflow ClickUp handoff lifecycle** *(shipped post-cutoff)*
+When a Workflow times out or is interrupted mid-handoff, the ClickUp prompt was still showing a success reaction — making it look alive to the human on the other end. [PR #96](https://github.com/zesthq/bizbox/pull/96) (cerkiner) fixes the cleanup path so termination closes the ClickUp side too. *Merged June 10 — after the June 1–7 coverage window; full coverage in next week's Build Log.*
+
+**PR #90 — Reviewer routing in ClickUp approval flows** *(shipped post-cutoff)*
+[PR #90](https://github.com/zesthq/bizbox/pull/90) (adPalafox) adds per-company primary and secondary reviewer IDs to the ClickUp awaiting-human approval context. This is important for teams with dedicated approvers — right now every handoff goes to a generic channel. *Merged June 9 — after the June 1–7 coverage window; full coverage in next week's Build Log.*
+
+---
+
+*Built on [`zesthq/bizbox`](https://github.com/zesthq/bizbox) · Releases [v2026.602.0](https://github.com/zesthq/bizbox/releases/tag/v2026.602.0), [v2026.602.1](https://github.com/zesthq/bizbox/releases/tag/v2026.602.1), [v2026.603.0](https://github.com/zesthq/bizbox/releases/tag/v2026.603.0) and [v2026.605.0](https://github.com/zesthq/bizbox/releases/tag/v2026.605.0) · [All open PRs](https://github.com/zesthq/bizbox/pulls)*
+
+*Release labels follow the scheme `vYYYY.MMDD.patch` — e.g. `v2026.605.0` = first cut on June 5, 2026.*


### PR DESCRIPTION
Adds the Build Log for the week of 2026-06-07 covering the Workflows platform reaching end-to-end state.

## What is in this Build Log

- Workflows as a first-class primitive (PR #86 · v2026.603.0)
- ClickUp human-handoff routing via `input()` intercept (PR #91 · v2026.605.0)
- AGENTS.md frontmatter fix for Google ADK (PR #87 · v2026.602.1)
- Suggested task deduplication (PR #88 · v2026.602.0)
- Docs refresh for Workflows + ADK (PR #93 · v2026.605.0)
- ClickUp test-link slug fix (PR #95)
- Post-cutoff: PR #96 merged June 10 (workflow ClickUp handoff timeout cleanup)
- Open challenge: canary CI still failing on master

## Review chain

- Tech Review (CITAAAA-314): FAIL → corrections applied
- Tech Re-check (CITAAAA-318): ✅ PASS
- DevRel Lead editorial review: ✅ PASS
- **Pending:** Dennis approval

Channels on merge: `github-discussions`, `dev.to`