### PR TITLE
Fix redirect link for ClickUp

### DIFF
--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -557,6 +557,9 @@ describe("sendAwaitingHumanNotification review context", () => {
       expect.anything(),
     );
     expect(String(fetchMock.mock.calls[4]?.[1]?.body)).toContain("Hi Primary Lead,");
+    expect(String(fetchMock.mock.calls[4]?.[1]?.body)).toContain(
+      "Original approval thread: https://app.clickup.com/workspace-1/chat/r/channel-9/t/message-review",
+    );
     expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 
@@ -665,6 +668,9 @@ describe("sendAwaitingHumanNotification review context", () => {
     expect(body.content).toContain("Approval stage: final check");
     expect(body.content).toContain("Reviewer: a direct message will be sent to Secondary Lead.");
     expect(body.content).toContain("Next step: the final reviewer handles the approval after the primary review clears.");
+    expect(String(fetchMock.mock.calls[4]?.[1]?.body)).toContain(
+      "Original approval thread: https://app.clickup.com/workspace-1/chat/r/channel-9/t/message-final",
+    );
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.clickup.com/api/v2/team/workspace-1/user/primary-user-id",
       expect.anything(),
@@ -895,7 +901,13 @@ describe("sendClickUpTransportTestMessage reviewer notifications", () => {
       expect.anything(),
     );
     expect(String(fetchMock.mock.calls[4]?.[1]?.body)).toContain("Hi Primary Lead,");
+    expect(String(fetchMock.mock.calls[4]?.[1]?.body)).toContain(
+      "Original approval thread: https://app.clickup.com/workspace-1/chat/r/channel-9/t/message-reviewers",
+    );
     expect(String(fetchMock.mock.calls[6]?.[1]?.body)).toContain("Hi Secondary Lead,");
+    expect(String(fetchMock.mock.calls[6]?.[1]?.body)).toContain(
+      "Original approval thread: https://app.clickup.com/workspace-1/chat/r/channel-9/t/message-reviewers",
+    );
     expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("/chat/channels/direct_message")).length).toBe(2);
     expect(fetchMock).toHaveBeenCalledTimes(7);
   });

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -165,6 +165,18 @@ function parseClickUpCreateChatMessageResponse(rawText: string) {
   };
 }
 
+function buildClickUpChatMessageAppUrl(
+  workspaceId: string,
+  channelId: string,
+  messageId: string,
+) {
+  const trimmedWorkspaceId = workspaceId.trim();
+  const trimmedChannelId = channelId.trim();
+  const trimmedMessageId = messageId.trim();
+  if (!trimmedWorkspaceId || !trimmedChannelId || !trimmedMessageId) return null;
+  return `https://app.clickup.com/${encodeURIComponent(trimmedWorkspaceId)}/chat/r/${encodeURIComponent(trimmedChannelId)}/t/${encodeURIComponent(trimmedMessageId)}`;
+}
+
 function parseClickUpCreateChatChannelResponse(rawText: string) {
   const payload = JSON.parse(rawText) as Record<string, unknown>;
   const data = payload.data && typeof payload.data === "object"
@@ -841,7 +853,9 @@ export async function sendAwaitingHumanNotification(
     overrides,
   );
   if (result.status === "sent" && approvalRoute && result.externalId) {
-    const threadLink = result.messageLink ?? readString(input.notification.link);
+    const threadLink = buildClickUpChatMessageAppUrl(config.workspaceId, config.channelId, result.externalId)
+      ?? result.messageLink
+      ?? readString(input.notification.link);
     await maybeSendClickUpReviewerDirectMessages({
       config,
       title: input.notification.title,
@@ -889,7 +903,9 @@ export async function sendClickUpTransportTestMessage(
     overrides,
   );
   if (result.status === "sent" && result.externalId && reviewerTargets.length) {
-    const threadLink = result.messageLink ?? readString(notification.link);
+    const threadLink = buildClickUpChatMessageAppUrl(config.workspaceId, config.channelId, result.externalId)
+      ?? result.messageLink
+      ?? readString(notification.link);
     await maybeSendClickUpReviewerDirectMessages({
       config,
       title: notification.title,


### PR DESCRIPTION
This pull request enhances the ClickUp notification system by ensuring that direct message notifications to reviewers and leads include a link back to the original approval thread in the ClickUp app. The changes improve the user experience by making it easier for recipients to reference the relevant discussion thread. The most important changes are:

**Feature Enhancements:**

* Added a new helper function `buildClickUpChatMessageAppUrl` to reliably construct a direct link to the ClickUp chat message thread using workspace, channel, and message IDs.
* Updated both `sendAwaitingHumanNotification` and `sendClickUpTransportTestMessage` to use the new `buildClickUpChatMessageAppUrl` helper, ensuring that notifications consistently include a direct link to the original approval thread. [[1]](diffhunk://#diff-a084a1bea2027b213c3fc796be956c54196ae8832a4822937e3085218170f7e3L844-R858) [[2]](diffhunk://#diff-a084a1bea2027b213c3fc796be956c54196ae8832a4822937e3085218170f7e3L892-R908)

**Testing Improvements:**

* Enhanced tests in `clickup-awaiting-human-transport.test.ts` to assert that the notification body contains the correct "Original approval thread" link for different review contexts and reviewer notifications. [[1]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984R560-R562) [[2]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984R671-R673) [[3]](diffhunk://#diff-e1c56fbf50265095adb4ffc98ec0169ced90d97d85d50d79a069b2c4cc9e7984R904-R910)