### PR TITLE
Enhance ClickUp approval workflow with final review and notifications

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -131,6 +131,7 @@ For `awaiting_human` ClickUp notifications:
 - Inbound approval polling still follows the tracked ClickUp message id, so renaming the approval channel does not change reconciliation behavior.
 - Positive replies/reactions accept the pending confirmation. Non-approval replies reject the confirmation and are forwarded into the issue as comments. Explicit negative reactions such as `thumbsdown` reject without forwarding comment text. Terminal main-message reactions are acknowledgement-oriented: `white_check_mark` for approved/rejected/superseded, `x` for failed retry/failed bridge cleanup.
 - For generic approval handoffs, set `primaryReviewerUserId` and `secondaryReviewerUserId` in the ClickUp awaiting-human provider config or via `CLICKUP_AWAITING_HUMAN_PRIMARY_REVIEWER_USER_ID` / `CLICKUP_AWAITING_HUMAN_SECONDARY_REVIEWER_USER_ID`. Bizbox renders those as ClickUp mention chips in the outbound approval message when the handoff includes approval context, and falls back to the primary reviewer for single-step approvals when the secondary reviewer is unset.
+- When both reviewers are configured, accepting the primary review creates a new final-review interaction and ClickUp handoff for the secondary reviewer. The issue remains `awaiting_human`, and the assignee is not woken until the final review is accepted.
 
 A review-driven regression briefly treated `clickupAgentUserId` as a hard inbound author gate and caused stuck live ClickUp polls. Keep the fields separate.
 

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -516,6 +516,10 @@ export type RequestConfirmationTarget =
 export interface RequestConfirmationPayload {
   version: 1;
   prompt: string;
+  approvalName?: string | null;
+  approvalStage?: "primary" | "final" | null;
+  requiresSecondReview?: boolean | null;
+  priorApprovalInteractionId?: string | null;
   acceptLabel?: string | null;
   rejectLabel?: string | null;
   rejectRequiresReason?: boolean;

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -354,6 +354,10 @@ export const requestConfirmationTargetSchema = z.discriminatedUnion("type", [
 export const requestConfirmationPayloadSchema = z.object({
   version: z.literal(1),
   prompt: z.string().trim().min(1).max(1000),
+  approvalName: z.string().trim().min(1).max(240).nullable().optional(),
+  approvalStage: z.enum(["primary", "final"]).nullable().optional(),
+  requiresSecondReview: z.boolean().nullable().optional(),
+  priorApprovalInteractionId: z.string().uuid().nullable().optional(),
   acceptLabel: z.string().trim().min(1).max(80).nullable().optional(),
   rejectLabel: z.string().trim().min(1).max(80).nullable().optional(),
   rejectRequiresReason: z.boolean().optional(),

--- a/server/src/__tests__/awaiting-human-bridge.test.ts
+++ b/server/src/__tests__/awaiting-human-bridge.test.ts
@@ -1509,6 +1509,10 @@ describeEmbeddedPostgres("awaitingHumanBridgeService", () => {
 
   it("hands primary approval to the secondary reviewer before waking the agent", async () => {
     const seeded = await seedAwaitingHumanInteraction();
+    await db
+      .update(issueThreadInteractions)
+      .set({ payload: { version: 1, prompt: "Approve this plan?", requiresSecondReview: true } })
+      .where(eq(issueThreadInteractions.id, seeded.interactionId));
     await db.insert(companyAwaitingHumanSettings).values({
       companyId: seeded.companyId,
       enabled: true,

--- a/server/src/__tests__/awaiting-human-bridge.test.ts
+++ b/server/src/__tests__/awaiting-human-bridge.test.ts
@@ -4,8 +4,10 @@ import {
   agents,
   agentWakeupRequests,
   awaitingHumanBridgeInboundEvents,
+  awaitingHumanNotificationOutbox,
   activityLog,
   companies,
+  companyAwaitingHumanSettings,
   createDb,
   goals,
   issues,
@@ -43,6 +45,7 @@ describeEmbeddedPostgres("awaitingHumanBridgeService", () => {
   afterEach(async () => {
     await db.delete(activityLog);
     await db.delete(agentWakeupRequests);
+    await db.delete(awaitingHumanNotificationOutbox);
     await db.delete(issueComments);
     await db.delete(awaitingHumanBridgeInboundEvents);
     await db.delete(awaitingHumanBridges);
@@ -50,6 +53,7 @@ describeEmbeddedPostgres("awaitingHumanBridgeService", () => {
     await db.delete(issues);
     await db.delete(goals);
     await db.delete(agents);
+    await db.delete(companyAwaitingHumanSettings);
     await db.delete(companies);
     vi.restoreAllMocks();
   });
@@ -1501,6 +1505,135 @@ describeEmbeddedPostgres("awaitingHumanBridgeService", () => {
       status: "closed",
       closeOutcome: "approved",
     }));
+  });
+
+  it("hands primary approval to the secondary reviewer before waking the agent", async () => {
+    const seeded = await seedAwaitingHumanInteraction();
+    await db.insert(companyAwaitingHumanSettings).values({
+      companyId: seeded.companyId,
+      enabled: true,
+      provider: "clickup",
+      providerConfigJson: {
+        authTokenRef: null,
+        workspaceId: "workspace-1",
+        channelId: "channel-1",
+        attachmentTaskId: null,
+        primaryReviewerUserId: "primary-reviewer",
+        secondaryReviewerUserId: "secondary-reviewer",
+      },
+    });
+
+    const send = vi.fn(async () => ({
+      externalThreadId: randomUUID(),
+      externalMessageId: randomUUID(),
+      nextPollAt: new Date("2026-06-12T01:00:00.000Z"),
+    }));
+    const poll = vi.fn(async () => ({
+      status: "ok" as const,
+      detail: "ok",
+      events: [{
+        kind: "reply" as const,
+        externalEventId: randomUUID(),
+        body: "Approve",
+      }],
+    }));
+    const service = awaitingHumanBridgeService(db, {
+      resolveProviderForCompany: async () => "clickup",
+      hasAdapter: () => true,
+      resolveAdapter: () => ({
+        send,
+        poll,
+        close: vi.fn(async () => {}),
+      }),
+    });
+
+    const primaryBridge = await service.openOrReuseForInteraction({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      interactionId: seeded.interactionId,
+      agentId: seeded.agentId,
+      ...approvalNotification(),
+    });
+
+    await service.pollBridge(primaryBridge.id, new Date("2026-06-12T00:45:17.268Z"));
+
+    const interactionsAfterPrimary = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.issueId, seeded.issueId))
+      .orderBy(asc(issueThreadInteractions.createdAt));
+    expect(interactionsAfterPrimary).toHaveLength(2);
+    expect(interactionsAfterPrimary[0]).toMatchObject({
+      id: seeded.interactionId,
+      status: "accepted",
+      payload: {
+        approvalStage: "primary",
+        requiresSecondReview: true,
+      },
+    });
+    const finalInteraction = interactionsAfterPrimary[1]!;
+    expect(finalInteraction).toMatchObject({
+      status: "pending",
+      continuationPolicy: "wake_assignee_on_accept",
+      payload: {
+        approvalStage: "final",
+        requiresSecondReview: true,
+        priorApprovalInteractionId: seeded.interactionId,
+      },
+    });
+
+    const wakesAfterPrimary = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, seeded.agentId));
+    expect(wakesAfterPrimary).toHaveLength(0);
+
+    const outboxRows = await db
+      .select()
+      .from(awaitingHumanNotificationOutbox)
+      .where(eq(awaitingHumanNotificationOutbox.issueId, seeded.issueId));
+    expect(outboxRows).toHaveLength(1);
+    expect(outboxRows[0]?.notification).toMatchObject({
+      interactionId: finalInteraction.id,
+      approvalContext: {
+        approvalStage: "final",
+        requiresSecondReview: true,
+      },
+    });
+
+    const finalBridge = await service.openForPendingInteraction({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      interactionId: finalInteraction.id,
+    });
+    expect(finalBridge).not.toBeNull();
+    expect(send).toHaveBeenLastCalledWith(expect.objectContaining({
+      interactionId: finalInteraction.id,
+      notification: expect.objectContaining({
+        approvalContext: expect.objectContaining({
+          approvalStage: "final",
+          requiresSecondReview: true,
+        }),
+      }),
+    }));
+
+    await service.pollBridge(finalBridge!.id, new Date("2026-06-12T00:46:17.268Z"));
+
+    const [resolvedFinalInteraction] = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, finalInteraction.id));
+    expect(resolvedFinalInteraction?.status).toBe("accepted");
+
+    const wakesAfterFinal = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, seeded.agentId));
+    expect(wakesAfterFinal).toHaveLength(1);
+    expect(wakesAfterFinal[0]?.payload).toMatchObject({
+      interactionId: finalInteraction.id,
+      interactionStatus: "accepted",
+    });
   });
 
   it("dedupes an approval signal if closeBridge fails after the transaction commits", async () => {

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -35,6 +35,12 @@ vi.mock("../telemetry.js", () => ({
   getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
 }));
 
+vi.mock("../services/awaiting-human-settings.js", () => ({
+  awaitingHumanSettingsService: () => ({
+    get: vi.fn(async () => ({ enabled: false, provider: null, providerConfig: null })),
+  }),
+}));
+
 vi.mock("../middleware/logger.js", () => ({
   logger: {
     info: vi.fn(),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2920,7 +2920,7 @@ export function issueRoutes(
 
       res.json(
         advancedToFinalReview
-          ? await issueThreadInteractionService(db).getById(interaction.id) ?? interaction
+          ? await issueThreadInteractionService(db).getById(advancedToFinalReview.finalInteractionId) ?? interaction
           : interaction,
       );
     },

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2901,7 +2901,7 @@ export function issueRoutes(
         outcome: "superseded",
         reason: "Issue thread interaction resolved via UI.",
       });
-      await finalizeAcceptedInteractionResolution({
+      const advancedToFinalReview = await finalizeAcceptedInteractionResolution({
         db,
         heartbeat,
         interaction,
@@ -2918,7 +2918,11 @@ export function issueRoutes(
         source: "issue.interaction.accept",
       });
 
-      res.json(interaction);
+      res.json(
+        advancedToFinalReview
+          ? await issueThreadInteractionService(db).getById(interaction.id) ?? interaction
+          : interaction,
+      );
     },
   );
 

--- a/server/src/services/awaiting-human-bridge.ts
+++ b/server/src/services/awaiting-human-bridge.ts
@@ -465,6 +465,13 @@ function buildBridgeNotification(input: {
       labels: ["awaiting_human", "request_confirmation"],
       kind: interaction.kind,
       interactionId: interaction.id,
+      approvalContext: interaction.payload.approvalStage
+        ? {
+          approvalName: interaction.payload.approvalName ?? null,
+          approvalStage: interaction.payload.approvalStage,
+          requiresSecondReview: interaction.payload.requiresSecondReview ?? false,
+        }
+        : null,
       target: {
         label: interaction.payload.target?.label ?? null,
         href: interaction.payload.target?.href ?? null,

--- a/server/src/services/issue-interaction-resolution-effects.ts
+++ b/server/src/services/issue-interaction-resolution-effects.ts
@@ -85,6 +85,7 @@ type ResolutionMetadata = {
 
 async function advanceToFinalApprovalReview(input: {
   db: Db;
+  logActivity: (db: Db, input: LogActivityInput) => Promise<void>;
   issue: {
     id: string;
     companyId: string;
@@ -96,11 +97,9 @@ async function advanceToFinalApprovalReview(input: {
   interaction: IssueThreadInteraction;
   actor: { actorType: "user" | "agent" | "system"; actorId: string; agentId?: string | null };
 }) {
-  if (
-    input.interaction.kind !== "request_confirmation"
-    || input.interaction.status !== "accepted"
-    || input.interaction.payload.approvalStage === "final"
-  ) {
+  if (input.interaction.kind !== "request_confirmation") return false;
+  const interaction = input.interaction;
+  if (interaction.status !== "accepted" || interaction.payload.approvalStage === "final") {
     return false;
   }
 
@@ -113,12 +112,12 @@ async function advanceToFinalApprovalReview(input: {
     : null;
   if (!settings.enabled || !primaryReviewerUserId || !secondaryReviewerUserId) return false;
 
-  const finalIdempotencyKey = `approval-final:${input.interaction.id}`;
+  const finalIdempotencyKey = `approval-final:${interaction.id}`;
   const finalPayload = {
-    ...input.interaction.payload,
+    ...interaction.payload,
     approvalStage: "final" as const,
     requiresSecondReview: true,
-    priorApprovalInteractionId: input.interaction.id,
+    priorApprovalInteractionId: interaction.id,
   };
   const transition = await input.db.transaction(async (tx) => {
     const txDb = tx as unknown as Db;
@@ -133,13 +132,13 @@ async function advanceToFinalApprovalReview(input: {
       .update(issueThreadInteractions)
       .set({
         payload: {
-          ...input.interaction.payload,
+          ...interaction.payload,
           approvalStage: "primary",
           requiresSecondReview: true,
         },
         updatedAt: new Date(),
       })
-      .where(eq(issueThreadInteractions.id, input.interaction.id));
+      .where(eq(issueThreadInteractions.id, interaction.id));
 
     const [createdFinalInteraction] = await txDb
       .insert(issueThreadInteractions)
@@ -148,14 +147,14 @@ async function advanceToFinalApprovalReview(input: {
         issueId: issueRow.id,
         kind: "request_confirmation",
         status: "pending",
-        continuationPolicy: input.interaction.continuationPolicy,
+        continuationPolicy: interaction.continuationPolicy,
         idempotencyKey: finalIdempotencyKey,
-        sourceCommentId: input.interaction.sourceCommentId ?? null,
-        sourceRunId: input.interaction.sourceRunId ?? null,
-        title: input.interaction.title ?? null,
-        summary: input.interaction.summary ?? null,
-        createdByAgentId: input.interaction.createdByAgentId ?? null,
-        createdByUserId: input.interaction.createdByUserId ?? null,
+        sourceCommentId: interaction.sourceCommentId ?? null,
+        sourceRunId: interaction.sourceRunId ?? null,
+        title: interaction.title ?? null,
+        summary: interaction.summary ?? null,
+        createdByAgentId: interaction.createdByAgentId ?? null,
+        createdByUserId: interaction.createdByUserId ?? null,
         payload: finalPayload,
       })
       .onConflictDoNothing()
@@ -177,24 +176,24 @@ async function advanceToFinalApprovalReview(input: {
     const issuePathId = issueRow.identifier ?? issueRow.id;
     const notification = {
       title: `${issuePathId} needs final approval`,
-      summary: input.interaction.summary ?? input.interaction.payload.prompt,
+      summary: interaction.summary ?? interaction.payload.prompt,
       link: `/issues/${issuePathId}`,
       cta: "Reply with Approve, Reject, or Change followed by feedback.",
       labels: ["awaiting_human", "request_confirmation", "final_approval"],
       kind: "request_confirmation",
       interactionId: finalInteraction.id,
       body: [
-        input.interaction.payload.prompt,
-        input.interaction.payload.detailsMarkdown ?? null,
+        interaction.payload.prompt,
+        interaction.payload.detailsMarkdown ?? null,
       ].filter(Boolean).join("\n\n"),
       approvalContext: {
-        approvalName: input.interaction.payload.approvalName ?? null,
+        approvalName: interaction.payload.approvalName ?? null,
         approvalStage: "final" as const,
         requiresSecondReview: true,
       },
       target: {
-        label: input.interaction.payload.target?.label ?? null,
-        href: input.interaction.payload.target?.href ?? null,
+        label: interaction.payload.target?.label ?? null,
+        href: interaction.payload.target?.href ?? null,
       },
     };
     await txDb
@@ -224,7 +223,7 @@ async function advanceToFinalApprovalReview(input: {
     entityType: "issue",
     entityId: issueRow.id,
     details: {
-      previousInteractionId: input.interaction.id,
+      previousInteractionId: interaction.id,
       interactionId: finalInteraction.id,
       approvalStage: "final",
       primaryReviewerUserId,
@@ -233,7 +232,7 @@ async function advanceToFinalApprovalReview(input: {
     },
   });
 
-  return true;
+  return { finalInteractionId: finalInteraction.id };
 }
 
 export async function finalizeAcceptedInteractionResolution(input: {
@@ -328,8 +327,9 @@ export async function finalizeAcceptedInteractionResolution(input: {
     });
   }
 
-  if (await advanceToFinalApprovalReview(input)) {
-    return true;
+  const advanced = await advanceToFinalApprovalReview(input);
+  if (advanced) {
+    return advanced;
   }
 
   await queueResolvedInteractionContinuationWakeup({

--- a/server/src/services/issue-interaction-resolution-effects.ts
+++ b/server/src/services/issue-interaction-resolution-effects.ts
@@ -99,7 +99,11 @@ async function advanceToFinalApprovalReview(input: {
 }) {
   if (input.interaction.kind !== "request_confirmation") return false;
   const interaction = input.interaction;
-  if (interaction.status !== "accepted" || interaction.payload.approvalStage === "final") {
+  if (
+    interaction.status !== "accepted"
+    || interaction.payload.approvalStage === "final"
+    || (!interaction.payload.requiresSecondReview && interaction.payload.approvalStage !== "primary")
+  ) {
     return false;
   }
 

--- a/server/src/services/issue-interaction-resolution-effects.ts
+++ b/server/src/services/issue-interaction-resolution-effects.ts
@@ -1,7 +1,14 @@
-import type { Db } from "@paperclipai/db";
+import {
+  awaitingHumanNotificationOutbox,
+  issueThreadInteractions,
+  issues,
+  type Db,
+} from "@paperclipai/db";
 import type { IssueThreadInteraction } from "@paperclipai/shared";
+import { and, eq } from "drizzle-orm";
 import { logger } from "../middleware/logger.js";
 import type { LogActivityInput } from "./activity-log.js";
+import { awaitingHumanSettingsService } from "./awaiting-human-settings.js";
 import { queueIssueAssignmentWakeup, type IssueAssignmentWakeupDeps } from "./issue-assignment-wakeup.js";
 
 export function isClosedIssueStatus(status: string | null | undefined): status is "done" | "cancelled" {
@@ -75,6 +82,159 @@ type ResolutionMetadata = {
   externalMessageId?: string | null;
   externalEventId?: string | null;
 };
+
+async function advanceToFinalApprovalReview(input: {
+  db: Db;
+  issue: {
+    id: string;
+    companyId: string;
+    identifier?: string | null;
+    status: string;
+    assigneeAgentId: string | null;
+    assigneeUserId?: string | null;
+  };
+  interaction: IssueThreadInteraction;
+  actor: { actorType: "user" | "agent" | "system"; actorId: string; agentId?: string | null };
+}) {
+  if (
+    input.interaction.kind !== "request_confirmation"
+    || input.interaction.status !== "accepted"
+    || input.interaction.payload.approvalStage === "final"
+  ) {
+    return false;
+  }
+
+  const settings = await awaitingHumanSettingsService(input.db).get(input.issue.companyId);
+  const primaryReviewerUserId = settings.provider === "clickup"
+    ? settings.providerConfig?.primaryReviewerUserId?.trim()
+    : null;
+  const secondaryReviewerUserId = settings.provider === "clickup"
+    ? settings.providerConfig?.secondaryReviewerUserId?.trim()
+    : null;
+  if (!settings.enabled || !primaryReviewerUserId || !secondaryReviewerUserId) return false;
+
+  const finalIdempotencyKey = `approval-final:${input.interaction.id}`;
+  const finalPayload = {
+    ...input.interaction.payload,
+    approvalStage: "final" as const,
+    requiresSecondReview: true,
+    priorApprovalInteractionId: input.interaction.id,
+  };
+  const transition = await input.db.transaction(async (tx) => {
+    const txDb = tx as unknown as Db;
+    const [issueRow] = await txDb
+      .select()
+      .from(issues)
+      .where(eq(issues.id, input.issue.id))
+      .limit(1);
+    if (!issueRow || issueRow.status !== "awaiting_human") return null;
+
+    await txDb
+      .update(issueThreadInteractions)
+      .set({
+        payload: {
+          ...input.interaction.payload,
+          approvalStage: "primary",
+          requiresSecondReview: true,
+        },
+        updatedAt: new Date(),
+      })
+      .where(eq(issueThreadInteractions.id, input.interaction.id));
+
+    const [createdFinalInteraction] = await txDb
+      .insert(issueThreadInteractions)
+      .values({
+        companyId: issueRow.companyId,
+        issueId: issueRow.id,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: input.interaction.continuationPolicy,
+        idempotencyKey: finalIdempotencyKey,
+        sourceCommentId: input.interaction.sourceCommentId ?? null,
+        sourceRunId: input.interaction.sourceRunId ?? null,
+        title: input.interaction.title ?? null,
+        summary: input.interaction.summary ?? null,
+        createdByAgentId: input.interaction.createdByAgentId ?? null,
+        createdByUserId: input.interaction.createdByUserId ?? null,
+        payload: finalPayload,
+      })
+      .onConflictDoNothing()
+      .returning();
+    const finalInteraction = createdFinalInteraction ?? await txDb
+      .select()
+      .from(issueThreadInteractions)
+      .where(and(
+        eq(issueThreadInteractions.companyId, issueRow.companyId),
+        eq(issueThreadInteractions.issueId, issueRow.id),
+        eq(issueThreadInteractions.idempotencyKey, finalIdempotencyKey),
+      ))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!finalInteraction) {
+      throw new Error("Failed to create final approval interaction");
+    }
+
+    const issuePathId = issueRow.identifier ?? issueRow.id;
+    const notification = {
+      title: `${issuePathId} needs final approval`,
+      summary: input.interaction.summary ?? input.interaction.payload.prompt,
+      link: `/issues/${issuePathId}`,
+      cta: "Reply with Approve, Reject, or Change followed by feedback.",
+      labels: ["awaiting_human", "request_confirmation", "final_approval"],
+      kind: "request_confirmation",
+      interactionId: finalInteraction.id,
+      body: [
+        input.interaction.payload.prompt,
+        input.interaction.payload.detailsMarkdown ?? null,
+      ].filter(Boolean).join("\n\n"),
+      approvalContext: {
+        approvalName: input.interaction.payload.approvalName ?? null,
+        approvalStage: "final" as const,
+        requiresSecondReview: true,
+      },
+      target: {
+        label: input.interaction.payload.target?.label ?? null,
+        href: input.interaction.payload.target?.href ?? null,
+      },
+    };
+    await txDb
+      .insert(awaitingHumanNotificationOutbox)
+      .values({
+        companyId: issueRow.companyId,
+        issueId: issueRow.id,
+        dedupeKey: `interaction:${finalInteraction.id}`,
+        handoffKind: "request_confirmation",
+        status: "pending",
+        notification,
+        reviewFile: null,
+      })
+      .onConflictDoNothing();
+
+    return { issueRow, finalInteraction, notification };
+  });
+  if (!transition) return false;
+  const { issueRow, finalInteraction, notification } = transition;
+
+  await input.logActivity(input.db, {
+    companyId: issueRow.companyId,
+    actorType: input.actor.actorType,
+    actorId: input.actor.actorId,
+    agentId: input.actor.agentId ?? null,
+    action: "issue.awaiting_human.approval_stage_advanced",
+    entityType: "issue",
+    entityId: issueRow.id,
+    details: {
+      previousInteractionId: input.interaction.id,
+      interactionId: finalInteraction.id,
+      approvalStage: "final",
+      primaryReviewerUserId,
+      secondaryReviewerUserId,
+      notification,
+    },
+  });
+
+  return true;
+}
 
 export async function finalizeAcceptedInteractionResolution(input: {
   db: Db;
@@ -168,6 +328,10 @@ export async function finalizeAcceptedInteractionResolution(input: {
     });
   }
 
+  if (await advanceToFinalApprovalReview(input)) {
+    return true;
+  }
+
   await queueResolvedInteractionContinuationWakeup({
     heartbeat: input.heartbeat,
     issue: continuationWakeIssue,
@@ -175,4 +339,5 @@ export async function finalizeAcceptedInteractionResolution(input: {
     actor: input.actor,
     source: input.source,
   });
+  return false;
 }

--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -184,6 +184,41 @@ describe("IssueThreadInteractionCard", () => {
     );
   });
 
+  it("labels final review requests and completed primary reviews", () => {
+    const finalHost = renderCard({
+      interaction: {
+        ...pendingRequestConfirmationInteraction,
+        id: "final-review",
+        payload: {
+          ...pendingRequestConfirmationInteraction.payload,
+          approvalStage: "final",
+          requiresSecondReview: true,
+          priorApprovalInteractionId: pendingRequestConfirmationInteraction.id,
+        },
+      },
+    });
+    expect(finalHost.textContent).toContain("Final approval required");
+
+    act(() => root?.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+
+    const primaryHost = renderCard({
+      interaction: {
+        ...pendingRequestConfirmationInteraction,
+        status: "accepted",
+        payload: {
+          ...pendingRequestConfirmationInteraction.payload,
+          approvalStage: "primary",
+          requiresSecondReview: true,
+        },
+        result: { version: 1, outcome: "accepted" },
+      },
+    });
+    expect(primaryHost.textContent).toContain("Primary review approved");
+  });
+
   it("labels accept-only continuation policies in the card header", () => {
     const host = renderCard({
       interaction: {

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -910,7 +910,12 @@ function RequestConfirmationResolution({
   if (interaction.status === "accepted") {
     return (
       <div className="flex flex-wrap items-center gap-2 text-sm leading-6 text-foreground">
-        <span className="font-medium">Confirmed</span>
+        <span className="font-medium">
+          {interaction.payload.approvalStage === "primary"
+          || (interaction.payload.requiresSecondReview && interaction.payload.approvalStage !== "final")
+            ? "Primary review approved"
+            : "Confirmed"}
+        </span>
         <RequestConfirmationTargetChip interaction={interaction} target={target} />
       </div>
     );
@@ -1050,6 +1055,11 @@ function RequestConfirmationCard({
     <div className="space-y-4">
       {interaction.status === "pending" ? (
         <div className="space-y-3 rounded-sm border border-border/70 bg-background/75 p-4">
+          {interaction.payload.approvalStage === "final" ? (
+            <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700 dark:text-amber-300">
+              Final approval required
+            </div>
+          ) : null}
           <div className="text-sm leading-6 text-foreground">
             {interaction.payload.prompt}
           </div>

--- a/ui/src/lib/issue-thread-interactions.test.ts
+++ b/ui/src/lib/issue-thread-interactions.test.ts
@@ -124,6 +124,45 @@ describe("issue thread interaction helpers", () => {
         answers: [{ questionId: "question-1", optionIds: ["option-1"] }],
       },
     })).toBe("Answered 1 question");
+
+    expect(buildIssueThreadInteractionSummary({
+      id: "interaction-primary-approved",
+      companyId: "company-1",
+      issueId: "issue-1",
+      kind: "request_confirmation",
+      status: "accepted",
+      continuationPolicy: "wake_assignee_on_accept",
+      createdAt: "2026-06-12T00:40:47.055Z",
+      updatedAt: "2026-06-12T00:45:17.268Z",
+      payload: {
+        version: 1,
+        prompt: "Approve?",
+        approvalStage: "primary",
+        requiresSecondReview: true,
+      },
+      result: {
+        version: 1,
+        outcome: "accepted",
+      },
+    })).toBe("Primary review approved");
+
+    expect(buildIssueThreadInteractionSummary({
+      id: "interaction-final-pending",
+      companyId: "company-1",
+      issueId: "issue-1",
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee_on_accept",
+      createdAt: "2026-06-12T00:45:17.300Z",
+      updatedAt: "2026-06-12T00:45:17.300Z",
+      payload: {
+        version: 1,
+        prompt: "Approve?",
+        approvalStage: "final",
+        requiresSecondReview: true,
+        priorApprovalInteractionId: "interaction-primary-approved",
+      },
+    })).toBe("Requested final approval");
   });
 
   it("maps stored option ids back to labels for answered summaries", () => {

--- a/ui/src/lib/issue-thread-interactions.ts
+++ b/ui/src/lib/issue-thread-interactions.ts
@@ -72,7 +72,12 @@ export function buildIssueThreadInteractionSummary(
   }
 
   if (interaction.kind === "request_confirmation") {
-    if (interaction.status === "accepted") return "Confirmed request";
+    if (interaction.status === "accepted") {
+      return interaction.payload.approvalStage === "primary"
+        || (interaction.payload.requiresSecondReview && interaction.payload.approvalStage !== "final")
+        ? "Primary review approved"
+        : "Confirmed request";
+    }
     if (interaction.status === "rejected") return "Declined request";
     if (interaction.status === "expired") {
       const outcome = interaction.result?.outcome;
@@ -80,7 +85,9 @@ export function buildIssueThreadInteractionSummary(
       if (outcome === "stale_target") return "Confirmation expired after target changed";
       return "Confirmation expired";
     }
-    return "Requested confirmation";
+    return interaction.payload.approvalStage === "final"
+      ? "Requested final approval"
+      : "Requested confirmation";
   }
 
   const count = interaction.payload.questions.length;


### PR DESCRIPTION
This pull request implements support for multi-stage approval workflows in the "awaiting human" (ClickUp) provider, specifically enabling a primary and secondary (final) reviewer flow for request confirmation interactions. When both reviewers are configured, accepting the primary review now triggers a new final-review interaction and notification for the secondary reviewer, and the issue remains in the `awaiting_human` state until the final review is accepted. The changes span backend logic, validation, notification handling, and UI updates to reflect the new approval stages.

**Multi-stage approval workflow logic:**

* Added logic to detect when both primary and secondary reviewers are configured for a company, and on primary approval, create a new "final approval" interaction and notification, keeping the issue in `awaiting_human` until the final review is accepted. This includes new database operations and activity logging for the approval stage advancement. [[1]](diffhunk://#diff-10a6ad65cbf16a8e13fd4409c80253bd41789f0d4fc7d85f55007fb276924fa1R86-R238) [[2]](diffhunk://#diff-10a6ad65cbf16a8e13fd4409c80253bd41789f0d4fc7d85f55007fb276924fa1R331-R342) [[3]](diffhunk://#diff-e80a71553f161363b7a3fc25018f288df58941381605bd46f3484e2d56099310L2904-R2904) [[4]](diffhunk://#diff-e80a71553f161363b7a3fc25018f288df58941381605bd46f3484e2d56099310L2921-R2925) [[5]](diffhunk://#diff-3e6d58e87c820a548c3943f14dd07beac67a2ffa27cf15fb650623b9e0f19f4cR134) [[6]](diffhunk://#diff-7fc4367371e6f461fca8ddd0261b663bf8a5c4e89cf64025e051f00c4f61234cR1510-R1638)

**Schema and validation updates:**

* Extended `RequestConfirmationPayload` and its validation schema to include `approvalName`, `approvalStage` ("primary" or "final"), `requiresSecondReview`, and `priorApprovalInteractionId` fields to support tracking multi-stage approval context. [[1]](diffhunk://#diff-e04b861e7d25216490d941dd4c267e0061ac9a0be8b8a57136ba4a158d72958fR519-R522) [[2]](diffhunk://#diff-be1822c6d17a3c9abfe9d6f815fe09e8712a04f64aab5cc13d45f8824dc09410R357-R360)

**Notification and outbox enhancements:**

* Updated notification construction to include `approvalContext` (with approval stage and reviewer requirements) and ensured correct outbox handling for final approval notifications. [[1]](diffhunk://#diff-88366c2d5e4803161e140c2a308839b9302c56dc52491b25a4b6656b1bb7eb5eR468-R474) [[2]](diffhunk://#diff-10a6ad65cbf16a8e13fd4409c80253bd41789f0d4fc7d85f55007fb276924fa1R86-R238) [[3]](diffhunk://#diff-7fc4367371e6f461fca8ddd0261b663bf8a5c4e89cf64025e051f00c4f61234cR7-R10) [[4]](diffhunk://#diff-7fc4367371e6f461fca8ddd0261b663bf8a5c4e89cf64025e051f00c4f61234cR48-R56)

**UI and summary improvements:**

* Updated UI components and summary helpers to display "Primary review approved" and "Final approval required" labels, and tested these new states to ensure correct rendering and summaries for each approval stage. [[1]](diffhunk://#diff-9e63254dcccf581d362e7734325aa93b34ec9e7dffb6e83944cd55aa9ae059e7L913-R918) [[2]](diffhunk://#diff-9e63254dcccf581d362e7734325aa93b34ec9e7dffb6e83944cd55aa9ae059e7R1058-R1062) [[3]](diffhunk://#diff-36dcfbb7c8dcc14a78e49efd682d0a5c5d707a79b8487cf1bedee663e2248c0cR127-R165) [[4]](diffhunk://#diff-ef09638634e18976703f8c9b4c81739f7b7bc605d98ab3205a22a4ba5bcf5e1cR187-R221)

**Documentation:**

* Added documentation describing the new multi-reviewer approval flow and its behavior in the ClickUp integration.