### PR TITLE
Refactor approval logic for simplified final review conditions

### DIFF
--- a/server/src/__tests__/awaiting-human-bridge.test.ts
+++ b/server/src/__tests__/awaiting-human-bridge.test.ts
@@ -1509,10 +1509,6 @@ describeEmbeddedPostgres("awaitingHumanBridgeService", () => {
 
   it("hands primary approval to the secondary reviewer before waking the agent", async () => {
     const seeded = await seedAwaitingHumanInteraction();
-    await db
-      .update(issueThreadInteractions)
-      .set({ payload: { version: 1, prompt: "Approve this plan?", requiresSecondReview: true } })
-      .where(eq(issueThreadInteractions.id, seeded.interactionId));
     await db.insert(companyAwaitingHumanSettings).values({
       companyId: seeded.companyId,
       enabled: true,

--- a/server/src/services/issue-interaction-resolution-effects.ts
+++ b/server/src/services/issue-interaction-resolution-effects.ts
@@ -99,11 +99,7 @@ async function advanceToFinalApprovalReview(input: {
 }) {
   if (input.interaction.kind !== "request_confirmation") return false;
   const interaction = input.interaction;
-  if (
-    interaction.status !== "accepted"
-    || interaction.payload.approvalStage === "final"
-    || (!interaction.payload.requiresSecondReview && interaction.payload.approvalStage !== "primary")
-  ) {
+  if (interaction.status !== "accepted" || interaction.payload.approvalStage === "final") {
     return false;
   }
 


### PR DESCRIPTION

## Thinking Path

> - Bizbox orchestrates AI agents that pause on `awaiting_human` when they need sign-off before proceeding
> - The ClickUp bridge adapter delivers those sign-off requests as chat messages and polls for replies
> - PR #106 introduced a two-stage approval flow: when a company configures both `primaryReviewerUserId` and `secondaryReviewerUserId`, accepting the primary review should create a pending final-review interaction for the secondary reviewer rather than immediately waking the agent
> - A Greptile review comment on that PR correctly flagged a theoretical risk: the gating function `advanceToFinalApprovalReview` would trigger on _all_ `request_confirmation` interactions when dual reviewers are configured, not just ones explicitly tagged as approval-workflow interactions
> - To address that concern, a guard was added requiring `interaction.payload.requiresSecondReview === true` or `approvalStage === "primary"` before advancing to the final stage
> - Live production testing against CITAA-429 revealed the guard was wrong in practice: agents create `request_confirmation` interactions with plain payloads — `{ version: 1, prompt: "..." }` — no `requiresSecondReview` field, no `approvalStage` field; the gate was therefore unreachable for real traffic and the bridge closed after the primary approval, waking the agent without secondary review
> - The correct opt-in signal is the company-level settings, not per-interaction payload flags: if both reviewer IDs are configured and enabled, _all_ accepted confirmations should go through both stages
> - This PR reverts the over-restrictive payload guard and removes the test scaffolding that was added to work around it

## What Changed

- **`server/src/services/issue-interaction-resolution-effects.ts`**: Removed the `requiresSecondReview` / `approvalStage !== "primary"` condition from the `advanceToFinalApprovalReview` guard. The function now advances to final review for any accepted `request_confirmation` interaction that is not already at `approvalStage: "final"`, whenever the company has both reviewer IDs configured in ClickUp settings. This matches the original intent of PR #106 and is consistent with how agents create interactions in practice.

- **`server/src/__tests__/awaiting-human-bridge.test.ts`**: Removed the DB patch that forced `requiresSecondReview: true` onto the seeded interaction's payload. That step was introduced specifically to satisfy the now-removed guard. The integration test now reflects real agent behavior: a plain `{ version: 1, prompt: "..." }` payload should still trigger the two-stage flow when company settings have dual reviewers.

## Verification

```sh
pnpm test
```

The integration test `"hands primary approval to the secondary reviewer before waking the agent"` covers the full flow: primary bridge receives an approval reply → no agent wakeup queued → final interaction created in `pending` state → outbox entry written → final bridge opened and sent to secondary reviewer → final approval reply received → agent wakeup queued for the final interaction.

Manual verification: configure both `primaryReviewerUserId` and `secondaryReviewerUserId` in Company → ClickUp settings, trigger an agent `request_confirmation`, approve in ClickUp as the primary reviewer — confirm the ClickUp channel receives a second message addressed to the secondary reviewer before the agent resumes.

## Risks

The two-stage flow now applies to **all** `request_confirmation` interactions for companies with dual reviewers configured — not just those explicitly tagged. This is the intended behavior, but it means any company that configures a secondary reviewer will require two approvals for every agent confirmation, including routine "do you want to proceed?" checks. The opt-out is removing the `secondaryReviewerUserId` from settings. This is a deliberate product decision and is consistent with the two-reviewer setup implying a dual-gate policy.

Low schema/migration risk — no data model changes in this PR.

## Model Used

OpenCode · GitHub Copilot · claude-sonnet-4.6 · 200k context · tool use + code execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge