### PR TITLE
fix: use canonical deliverable download links

### DIFF
--- a/ui/src/pages/DeliverableDetail.test.tsx
+++ b/ui/src/pages/DeliverableDetail.test.tsx
@@ -116,7 +116,7 @@ describe("DeliverableDetail page", () => {
     expect(container.textContent).toContain("PAP-12");
 
     const downloadLinks = Array.from(container.querySelectorAll("a")).filter(
-      (a) => a.getAttribute("href") === "/api/attachments/abc/content",
+      (a) => a.getAttribute("href") === "/api/deliverables/deliverable-1/content",
     );
     expect(downloadLinks.length).toBeGreaterThan(0);
     expect(downloadLinks[0]!.getAttribute("download")).toBe("report.pdf");

--- a/ui/src/pages/DeliverableDetail.test.tsx
+++ b/ui/src/pages/DeliverableDetail.test.tsx
@@ -137,6 +137,23 @@ describe("DeliverableDetail page", () => {
     expect(img?.getAttribute("src")).toBe("/api/attachments/abc/content");
   });
 
+  it("uses the canonical download route in the generic fallback", async () => {
+    getMock.mockResolvedValue({
+      ...baseDetail,
+      contentType: "application/octet-stream",
+      preview: null,
+    });
+
+    await renderAt(container, "/deliverables/deliverable-1");
+    await flushReact();
+    await flushReact();
+
+    const downloadLinks = Array.from(container.querySelectorAll("a")).filter(
+      (a) => a.getAttribute("href") === "/api/deliverables/deliverable-1/content",
+    );
+    expect(downloadLinks.length).toBeGreaterThan(0);
+  });
+
   it("renders markdown previews inline for text deliverables", async () => {
     getMock.mockResolvedValue({
       ...baseDetail,

--- a/ui/src/pages/DeliverableDetail.tsx
+++ b/ui/src/pages/DeliverableDetail.tsx
@@ -162,7 +162,7 @@ function ArtifactPreview({ data }: { data: DeliverableDetailType }) {
         </p>
       </div>
       <Button asChild size="sm" variant="outline">
-        <a href={contentPath} download={originalFilename ?? undefined}>
+        <a href={`/api/deliverables/${data.id}/content`} download={originalFilename ?? undefined}>
           <Download className="h-3.5 w-3.5 mr-1.5" />
           Download
         </a>

--- a/ui/src/pages/DeliverableDetail.tsx
+++ b/ui/src/pages/DeliverableDetail.tsx
@@ -63,7 +63,7 @@ export function DeliverableDetail() {
 }
 
 function DeliverableDetailView({ data }: { data: DeliverableDetailType }) {
-  const downloadHref = data.contentPath;
+  const downloadHref = `/api/deliverables/${data.id}/content`;
   const downloadName = data.originalFilename ?? undefined;
 
   return (

--- a/ui/src/pages/Deliverables.test.tsx
+++ b/ui/src/pages/Deliverables.test.tsx
@@ -118,7 +118,7 @@ describe("Deliverables page", () => {
     expect(container.textContent).toContain("Internal");
 
     const downloadLinks = Array.from(container.querySelectorAll("a")).filter(
-      (a) => a.getAttribute("href") === "/api/attachments/abc/content",
+      (a) => a.getAttribute("href") === "/api/deliverables/deliverable-1/content",
     );
     expect(downloadLinks.length).toBeGreaterThan(0);
     const firstDownload = downloadLinks[0]!;

--- a/ui/src/pages/Deliverables.tsx
+++ b/ui/src/pages/Deliverables.tsx
@@ -244,7 +244,7 @@ function DeliverableRow({ item }: { item: DeliverableListItem }) {
       </td>
       <td className="px-3 py-2 text-right align-top">
         <a
-          href={item.contentPath}
+          href={`/api/deliverables/${item.id}/content`}
           download={item.originalFilename ?? undefined}
           className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
           onClick={(event) => event.stopPropagation()}


### PR DESCRIPTION
## Thinking Path
> - Paperclip/Bizbox exposes deliverables as downloadable outputs in the board UI
> - The failing behavior was limited to deliverable download links, not the preview/render flow
> - The existing list/detail pages used raw `contentPath` values on the client
> - A minimal fix is to make both views use the canonical deliverable content route
> - This PR keeps the change localized to the two UI surfaces that render deliverable download links
> - The benefit is consistent download behavior without widening server-side scope

## What Changed
- Switched the deliverable detail download button to `/api/deliverables/:id/content`
- Switched the deliverables list download links to the same canonical route
- Updated the affected UI tests to assert the canonical route instead of raw attachment paths

## Verification
- `pnpm vitest run ui/src/pages/DeliverableDetail.test.tsx ui/src/pages/Deliverables.test.tsx server/src/__tests__/deliverables-routes.test.ts`
- Browser-checked deliverable detail and deliverables list download links after the UI change

## Risks
- Low risk: change is limited to link targets in two deliverable views
- Existing artifact/document download behavior outside deliverables is untouched
- If any deliverable content route is slow or unavailable, download UX could still fail at the endpoint level

## Model Used
- OpenAI GPT-5 via Codex desktop, tool-using mode

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
