### PR TITLE
Add approvalPolicy to confirmation payload and update logic

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -519,6 +519,7 @@ export interface RequestConfirmationPayload {
   approvalName?: string | null;
   approvalStage?: "primary" | "final" | null;
   requiresSecondReview?: boolean | null;
+  approvalPolicy?: "full" | "primary_only" | null;
   priorApprovalInteractionId?: string | null;
   acceptLabel?: string | null;
   rejectLabel?: string | null;

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -357,6 +357,7 @@ export const requestConfirmationPayloadSchema = z.object({
   approvalName: z.string().trim().min(1).max(240).nullable().optional(),
   approvalStage: z.enum(["primary", "final"]).nullable().optional(),
   requiresSecondReview: z.boolean().nullable().optional(),
+  approvalPolicy: z.enum(["full", "primary_only"]).nullable().optional(),
   priorApprovalInteractionId: z.string().uuid().nullable().optional(),
   acceptLabel: z.string().trim().min(1).max(80).nullable().optional(),
   rejectLabel: z.string().trim().min(1).max(80).nullable().optional(),

--- a/server/src/__tests__/issue-interaction-resolution-effects.test.ts
+++ b/server/src/__tests__/issue-interaction-resolution-effects.test.ts
@@ -1,0 +1,61 @@
+import type { Db } from "@paperclipai/db";
+import type { IssueThreadInteraction } from "@paperclipai/shared";
+import { describe, expect, it, vi } from "vitest";
+import { finalizeAcceptedInteractionResolution } from "../services/issue-interaction-resolution-effects.js";
+
+describe("finalizeAcceptedInteractionResolution", () => {
+  it("skips final approval review creation for primary_only confirmations", async () => {
+    const db = {
+      transaction: vi.fn(),
+    } as unknown as Db;
+    const logActivity = vi.fn().mockResolvedValue(undefined);
+    const heartbeat = {
+      wakeup: vi.fn().mockResolvedValue(undefined),
+    };
+    const interaction: IssueThreadInteraction = {
+      id: "interaction-primary-only",
+      companyId: "company-1",
+      issueId: "issue-1",
+      kind: "request_confirmation",
+      status: "accepted",
+      continuationPolicy: "none",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      payload: {
+        version: 1,
+        prompt: "Approve this action?",
+        approvalPolicy: "primary_only",
+      },
+    };
+
+    const result = await finalizeAcceptedInteractionResolution({
+      db,
+      heartbeat,
+      logActivity,
+      issue: {
+        id: "issue-1",
+        companyId: "company-1",
+        identifier: "ISS-1",
+        status: "awaiting_human",
+        assigneeAgentId: "agent-1",
+      },
+      interaction,
+      createdIssues: [],
+      actor: { actorType: "user", actorId: "user-1" },
+      source: "test",
+    });
+
+    expect(result).toBe(false);
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(heartbeat.wakeup).not.toHaveBeenCalled();
+    expect(logActivity).toHaveBeenCalledTimes(1);
+    expect(logActivity.mock.calls[0]?.[1]).toMatchObject({
+      action: "issue.thread_interaction_accepted",
+      details: {
+        interactionId: "interaction-primary-only",
+        interactionKind: "request_confirmation",
+        interactionStatus: "accepted",
+      },
+    });
+  });
+});

--- a/server/src/services/awaiting-human-handoff.ts
+++ b/server/src/services/awaiting-human-handoff.ts
@@ -298,10 +298,14 @@ async function resolveApprovalContext(
     const secondaryReviewerUserId = runtime.secondaryReviewerUserId?.trim() ?? "";
     if (!primaryReviewerUserId && !secondaryReviewerUserId) return null;
 
+    const policy = input.interaction?.kind === "request_confirmation"
+      ? (input.interaction.payload.approvalPolicy ?? "full")
+      : "full";
+
     return {
       approvalName: null,
       approvalStage: null,
-      requiresSecondReview: Boolean(secondaryReviewerUserId),
+      requiresSecondReview: policy === "full" && Boolean(secondaryReviewerUserId),
     };
   } catch (err) {
     if (err instanceof Error && err.message === "awaiting-human-bridge-disabled") {

--- a/server/src/services/awaiting-human-handoff.ts
+++ b/server/src/services/awaiting-human-handoff.ts
@@ -305,7 +305,7 @@ async function resolveApprovalContext(
     return {
       approvalName: null,
       approvalStage: null,
-      requiresSecondReview: policy === "full" && Boolean(secondaryReviewerUserId),
+      requiresSecondReview: policy !== "primary_only" && Boolean(secondaryReviewerUserId),
     };
   } catch (err) {
     if (err instanceof Error && err.message === "awaiting-human-bridge-disabled") {

--- a/server/src/services/issue-interaction-resolution-effects.ts
+++ b/server/src/services/issue-interaction-resolution-effects.ts
@@ -103,6 +103,9 @@ async function advanceToFinalApprovalReview(input: {
     return false;
   }
 
+  // Agent explicitly requested single-stage review — skip secondary even if configured.
+  if (interaction.payload.approvalPolicy === "primary_only") return false;
+
   const settings = await awaitingHumanSettingsService(input.db).get(input.issue.companyId);
   const primaryReviewerUserId = settings.provider === "clickup"
     ? settings.providerConfig?.primaryReviewerUserId?.trim()


### PR DESCRIPTION
This pull request introduces support for a new `approvalPolicy` option in the issue approval process, allowing for more flexible review workflows. The changes primarily add the ability to distinguish between "full" (primary + secondary) and "primary_only" (single-stage) approval policies, and update the logic to respect this policy throughout the codebase.

**Approval Policy Support and Logic Updates:**

* Added an optional `approvalPolicy` field to the `RequestConfirmationPayload` type, which can be either `"full"`, `"primary_only"`, or `null`.
* Updated the associated `requestConfirmationPayloadSchema` validator to include the new `approvalPolicy` field with the same options.

**Approval Workflow Logic Changes:**

* Modified `resolveApprovalContext` to determine whether a second review is required based on the `approvalPolicy` field: if the policy is `"primary_only"`, secondary review is skipped even if a secondary reviewer is configured.
* Updated `advanceToFinalApprovalReview` to immediately skip secondary review if the `approvalPolicy` is `"primary_only"`, ensuring that the workflow follows the intended approval policy.