### PR TITLE
chore(metrics): July 2026 Deep Dive syndication log

### DIFF
--- a/community/metrics/2026-07.md
+++ b/community/metrics/2026-07.md
@@ -1,0 +1,20 @@
+# Bizbox Dev Community Metrics — July 2026
+
+## Published Artifacts
+
+artifacts:
+
+  - title: "Deep Dive: Workflows as a First-Class Primitive — How Bizbox Added a Full Pipeline Platform in June 2026"
+    kind: monthly_deep_dive
+    slug: deep-dive-workflows-adk-2026-07
+    channels:
+      github: "skipped — publisher-not-implemented"
+      discourse: "error — 503 site read-only at time of publish; retry pending"
+      devto: "https://dev.to/joincitro/deep-dive-workflows-as-a-first-class-primitive-how-bizbox-added-a-full-pipeline-platform-in-june-2ebk"
+      x: "https://x.com/BizboxAI/status/2067881263042859423"
+      linkedin: ""
+    participation: 0
+    notes: "PR #115 merged 2026-06-19. Dev.to and X published successfully. Discourse returned 503 read-only on publish attempt. GitHub publisher not yet implemented. Syndicated via CITAAAA-344."
+
+experiments_run:
+


### PR DESCRIPTION
Records Dev.to and X publication URLs for the July 2026 Deep Dive ("Workflows as a First-Class Primitive"). PR #115 was merged and content-syndication ran on 2026-06-19.

- Dev.to: published ✅
- X: published ✅
- Discourse: 503 read-only (retry needed)
- GitHub publisher: not yet implemented

Related: CITAAAA-344