### PR TITLE
Use ADK workflow output for run summaries

### DIFF
--- a/packages/adapters/google-adk/src/server/parse.test.ts
+++ b/packages/adapters/google-adk/src/server/parse.test.ts
@@ -53,4 +53,25 @@ describe("parseGoogleAdkJsonl", () => {
     expect(parsed.toolResults).toEqual([{ name: "calculator", output: { result: 2 } }]);
     expect(parsed.usage).toEqual({ inputTokens: 10, outputTokens: 4, cachedInputTokens: 2 });
   });
+
+  it("uses final workflow output as the summary when present", () => {
+    const stdout = [
+      JSON.stringify({
+        content: {
+          role: "model",
+          parts: [{ text: '{"decision":"approve","feedback_text":""}' }],
+        },
+      }),
+      JSON.stringify({
+        author: "landing_page_strategist",
+        node_path: "landing_page_strategist@1/landing_page_workspace_final_output@1",
+        output:
+          "## Final output\n\nFinal URL: https://citro-pages.fly.dev/dry-july-savings-challenge/",
+      }),
+    ].join("\n");
+
+    const parsed = parseGoogleAdkJsonl(stdout);
+
+    expect(parsed.summary).toContain("Final URL: https://citro-pages.fly.dev/dry-july-savings-challenge/");
+  });
 });

--- a/packages/adapters/google-adk/src/server/parse.ts
+++ b/packages/adapters/google-adk/src/server/parse.ts
@@ -24,6 +24,7 @@ function asErrorText(value: unknown): string {
 
 export function parseGoogleAdkJsonl(stdout: string) {
   let lastAssistantText = "";
+  let lastWorkflowOutput = "";
   const toolCalls: Array<{ name: string; input: unknown }> = [];
   const toolResults: Array<{ name: string; output: unknown }> = [];
   let errorMessage: string | null = null;
@@ -68,6 +69,11 @@ export function parseGoogleAdkJsonl(stdout: string) {
       lastAssistantText = modelTexts.join("\n\n").trim();
     }
 
+    const output = asString(parsed.output, "").trim();
+    if (output) {
+      lastWorkflowOutput = output;
+    }
+
     const explicitError = asErrorText(parsed.error ?? parsed.message ?? parsed.detail);
     if (explicitError) errorMessage = explicitError;
 
@@ -89,7 +95,7 @@ export function parseGoogleAdkJsonl(stdout: string) {
   }
 
   return {
-    summary: lastAssistantText,
+    summary: lastWorkflowOutput || lastAssistantText,
     toolCalls,
     toolResults,
     usage,


### PR DESCRIPTION
## Summary
- update the Google ADK parser to prefer final workflow `output` events for run summaries
- keep model-message summaries as the fallback
- add coverage for workflow final output winning over an approval-interpreter model message

## Root cause
Google ADK workflow nodes emit final workflow results as top-level `output` events, while the parser only considered `content.parts[].text` model messages. That made BizBox summarize the approval classifier output instead of the final deliverable text containing the live URL.

## Validation
- `/opt/homebrew/bin/pnpm vitest run packages/adapters/google-adk/src/server/parse.test.ts`
- `git diff --check`
