### PR TITLE
feat: normalize malformed pipeline definitions in workflow service

### DIFF
--- a/server/src/__tests__/workflow-service-update.test.ts
+++ b/server/src/__tests__/workflow-service-update.test.ts
@@ -159,6 +159,53 @@ describeEmbeddedPostgres("workflowService.update", () => {
     });
   });
 
+  it("normalizes malformed pipeline definitions before returning workflows", async () => {
+    const companyId = randomUUID();
+    const workflowId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(workflows).values({
+      id: workflowId,
+      companyId,
+      title: "Brief generator",
+      status: "active",
+      runnerType: "google_adk",
+      runnerConfig: {
+        agentPath: "/tmp/agent.py",
+      },
+      pipelineDefinition: {},
+      pipelineSourceHash: "hash-1",
+    });
+
+    const svc = workflowService(db);
+    const listed = await svc.list(companyId);
+    const detail = await svc.getDetail(workflowId);
+    const byId = await svc.get(workflowId);
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.pipelineDefinition).toMatchObject({
+      entrypoint: "agent.py",
+      generatedAt: new Date(0).toISOString(),
+      phases: [],
+    });
+    expect(detail?.pipelineDefinition).toMatchObject({
+      entrypoint: "agent.py",
+      generatedAt: new Date(0).toISOString(),
+      phases: [],
+    });
+    expect(byId?.pipelineDefinition).toMatchObject({
+      entrypoint: "agent.py",
+      generatedAt: new Date(0).toISOString(),
+      phases: [],
+    });
+  });
+
   it("returns a user-facing error when workflow key allocation collides during create", async () => {
     const companyId = randomUUID();
 

--- a/server/src/__tests__/workflow-service-update.test.ts
+++ b/server/src/__tests__/workflow-service-update.test.ts
@@ -61,6 +61,11 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("workflowService.update", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  const normalizedPipelineDefinition = {
+    entrypoint: "agent.py",
+    generatedAt: new Date(0).toISOString(),
+    phases: [],
+  } as const;
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workflow-service-update-");
@@ -189,21 +194,54 @@ describeEmbeddedPostgres("workflowService.update", () => {
     const byId = await svc.get(workflowId);
 
     expect(listed).toHaveLength(1);
-    expect(listed[0]?.pipelineDefinition).toMatchObject({
-      entrypoint: "agent.py",
-      generatedAt: new Date(0).toISOString(),
-      phases: [],
+    expect(listed[0]?.pipelineDefinition).toMatchObject(normalizedPipelineDefinition);
+    expect(detail?.pipelineDefinition).toMatchObject(normalizedPipelineDefinition);
+    expect(byId?.pipelineDefinition).toMatchObject(normalizedPipelineDefinition);
+  });
+
+  it.each([
+    ["null pipeline definitions", null],
+    [
+      "individually malformed pipeline fields",
+      {
+        entrypoint: 0,
+        generatedAt: "bad-date",
+        phases: "not-an-array",
+      },
+    ],
+  ])("normalizes %s before returning workflows", async (_, pipelineDefinition) => {
+    const companyId = randomUUID();
+    const workflowId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
     });
-    expect(detail?.pipelineDefinition).toMatchObject({
-      entrypoint: "agent.py",
-      generatedAt: new Date(0).toISOString(),
-      phases: [],
+
+    await db.insert(workflows).values({
+      id: workflowId,
+      companyId,
+      title: "Brief generator",
+      status: "active",
+      runnerType: "google_adk",
+      runnerConfig: {
+        agentPath: "/tmp/agent.py",
+      },
+      pipelineDefinition,
+      pipelineSourceHash: "hash-1",
     });
-    expect(byId?.pipelineDefinition).toMatchObject({
-      entrypoint: "agent.py",
-      generatedAt: new Date(0).toISOString(),
-      phases: [],
-    });
+
+    const svc = workflowService(db);
+    const listed = await svc.list(companyId);
+    const detail = await svc.getDetail(workflowId);
+    const byId = await svc.get(workflowId);
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.pipelineDefinition).toMatchObject(normalizedPipelineDefinition);
+    expect(detail?.pipelineDefinition).toMatchObject(normalizedPipelineDefinition);
+    expect(byId?.pipelineDefinition).toMatchObject(normalizedPipelineDefinition);
   });
 
   it("returns a user-facing error when workflow key allocation collides during create", async () => {

--- a/server/src/__tests__/workflow-service-update.test.ts
+++ b/server/src/__tests__/workflow-service-update.test.ts
@@ -200,7 +200,14 @@ describeEmbeddedPostgres("workflowService.update", () => {
   });
 
   it.each([
-    ["null pipeline definitions", null],
+    [
+      "null-like pipeline fields",
+      {
+        entrypoint: null,
+        generatedAt: null,
+        phases: null,
+      },
+    ],
     [
       "individually malformed pipeline fields",
       {

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -52,6 +52,8 @@ type WorkflowRunLaunchContext = {
 };
 
 function toWorkflow(row: typeof workflows.$inferSelect): Workflow {
+  const pipelineDefinition = (row.pipelineDefinition as Record<string, unknown> | null) ?? {};
+  const phases = Array.isArray(pipelineDefinition.phases) ? (pipelineDefinition.phases as Workflow["pipelineDefinition"]["phases"]) : [];
   return {
     id: row.id,
     companyId: row.companyId,
@@ -62,10 +64,14 @@ function toWorkflow(row: typeof workflows.$inferSelect): Workflow {
     capabilities: Array.isArray(row.capabilities) ? (row.capabilities as string[]) : [],
     runnerType: row.runnerType as "google_adk",
     runnerConfig: (row.runnerConfig as Record<string, unknown> | null) ?? {},
-    pipelineDefinition: (row.pipelineDefinition as Workflow["pipelineDefinition"] | null) ?? {
-      entrypoint: "agent.py",
-      generatedAt: new Date(0).toISOString(),
-      phases: [],
+    pipelineDefinition: {
+      entrypoint: typeof pipelineDefinition.entrypoint === "string" && pipelineDefinition.entrypoint.trim().length > 0
+        ? pipelineDefinition.entrypoint
+        : "agent.py",
+      generatedAt: typeof pipelineDefinition.generatedAt === "string" && pipelineDefinition.generatedAt.trim().length > 0
+        ? pipelineDefinition.generatedAt
+        : new Date(0).toISOString(),
+      phases,
     },
     pipelineSourceHash: row.pipelineSourceHash ?? null,
     createdByUserId: row.createdByUserId ?? null,

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -54,6 +54,12 @@ type WorkflowRunLaunchContext = {
 function toWorkflow(row: typeof workflows.$inferSelect): Workflow {
   const pipelineDefinition = (row.pipelineDefinition as Record<string, unknown> | null) ?? {};
   const phases = Array.isArray(pipelineDefinition.phases) ? (pipelineDefinition.phases as Workflow["pipelineDefinition"]["phases"]) : [];
+  const generatedAt =
+    typeof pipelineDefinition.generatedAt === "string" &&
+    pipelineDefinition.generatedAt.trim().length > 0 &&
+    !Number.isNaN(Date.parse(pipelineDefinition.generatedAt))
+      ? pipelineDefinition.generatedAt
+      : new Date(0).toISOString();
   return {
     id: row.id,
     companyId: row.companyId,
@@ -68,9 +74,7 @@ function toWorkflow(row: typeof workflows.$inferSelect): Workflow {
       entrypoint: typeof pipelineDefinition.entrypoint === "string" && pipelineDefinition.entrypoint.trim().length > 0
         ? pipelineDefinition.entrypoint
         : "agent.py",
-      generatedAt: typeof pipelineDefinition.generatedAt === "string" && pipelineDefinition.generatedAt.trim().length > 0
-        ? pipelineDefinition.generatedAt
-        : new Date(0).toISOString(),
+      generatedAt,
       phases,
     },
     pipelineSourceHash: row.pipelineSourceHash ?? null,


### PR DESCRIPTION
This pull request improves the handling and normalization of malformed or incomplete `pipelineDefinition` objects when retrieving workflow data. The main change ensures that workflows with missing or incorrect pipeline definitions are always returned with a consistent, valid structure, preventing potential runtime issues and simplifying downstream usage.

**Pipeline definition normalization:**

* Updated the `toWorkflow` function in `server/src/services/workflows.ts` to always return a normalized `pipelineDefinition` object with default values for `entrypoint`, `generatedAt`, and `phases` if they are missing or malformed. This prevents workflows with empty or invalid pipeline definitions from causing errors or inconsistencies. [[1]](diffhunk://#diff-953a5dab93d8a0f3012a3e95e6d1c25cf2493e04de4bb74190973b76fb09fd95R55-R56) [[2]](diffhunk://#diff-953a5dab93d8a0f3012a3e95e6d1c25cf2493e04de4bb74190973b76fb09fd95L65-R74)

**Testing and validation:**

* Added a new test in `server/src/__tests__/workflow-service-update.test.ts` to verify that malformed pipeline definitions are normalized before being returned by the workflow service, ensuring the new logic works as intended.