### PR TITLE
community: Publish Build Log — Week of 2026-06-21

### DIFF
--- a/community/build-logs/2026-06-21.md
+++ b/community/build-logs/2026-06-21.md
@@ -1,0 +1,54 @@
+---
+slug: build-log-2026-06-21
+channels: [discourse, devto, x]
+date: 2026-06-25
+week: "2026-06-21"
+---
+
+# Build Log — Week of 21 June 2026
+
+Another solid week in the Bizbox engine room. Two meaningful features landed for the Workflows surface, a new release was tagged, and the dev-community side closed out the July 2026 Deep Dive syndication. Here's what moved.
+
+---
+
+## Shipped this week
+
+**Merged PRs:** [#116](https://github.com/zesthq/bizbox/pull/116) · [#117](https://github.com/zesthq/bizbox/pull/117) · [#118](https://github.com/zesthq/bizbox/pull/118) | **Release:** `v2026.622.0`
+
+---
+
+**Workflow run cancellation** ([PR #116](https://github.com/zesthq/bizbox/pull/116), released in `v2026.622.0`)
+Board operators can now cancel a workflow run mid-flight — whether it's queued, actively running, or sitting in an awaiting-human handoff. A new `POST /api/workflow-runs/:id/cancel` route marks the run and all open phases as `cancelled`, records a `workflow.run_cancelled` activity event, and cleans up any pending ClickUp-backed handoffs. The workflow detail page gains a clearly destructive "Cancel run" control in the Pipeline header. Before this, the board had to either wait out a stalled run or intervene at the database level. Now it's a first-class operator action.
+
+**Workflow schedules** ([PR #118](https://github.com/zesthq/bizbox/pull/118))
+Recurring workflow runs are now a thing. A new `workflow_schedules` table, cron-backed scheduler integration, and board-only CRUD routes let you define a prompt template that fires on a schedule — entirely separate from the existing Routines system. The workflow detail UI adds create/edit/pause/archive/delete controls for schedules. Today this is UTC-only with skip-missed-fires semantics; time-zone support is the natural follow-on. *Merged this week; ships in the next release (`v2026.630.0`).*
+
+**July 2026 Deep Dive syndication log** ([PR #117](https://github.com/zesthq/bizbox/pull/117))
+The July 2026 Deep Dive ("Workflows as a First-Class Primitive") landed on Dev.to and X. Discourse hit a 503 read-only window and needs a retry; GitHub publisher is not yet implemented.
+
+**Release `v2026.622.0`** — released Monday, 22 June, capturing the cancellation feature and the Deep Dive content drop.
+
+---
+
+## Decisions
+
+- **Workflow schedules live alongside Routines, not inside them.** Routines are agent-assignment–driven; Workflow schedules are company-scoped and dispatch rendered prompt bodies directly. Keeping them separate avoids adding workflow-specific semantics to an already established abstraction.
+- **UTC-only for schedule dispatch.** Deliberate simplification for v1. The skip-on-missed-fires default follows the Routine precedent already set in the codebase.
+- **Cancellation cleanup runs synchronously in the route handler.** ClickUp handoff closure happens immediately on cancel rather than via a background job to keep the operator's cancel action visibly atomic.
+
+---
+
+## Trade-offs
+
+- Cancellation currently relies on an in-memory child-process registry for active local execution. Forced-shutdown edge cases fall back to the existing interrupted-run recovery path — that path works, but it's indirect.
+- The cancel route tests AND the embedded-Postgres workflow-service cancellation tests were written but could not execute in the PR sandbox due to `EPERM` on localhost sockets. Coverage there is currently code-review + typecheck rather than a green Vitest run. ⚠️ *Flagged for Dennis: test gap on both the cancel route and the workflow-service cancellation path.*
+- Workflow schedules require migration `0080_workflow_schedules.sql` to be applied before the new routes go live. Deployments need to sequence this explicitly.
+
+---
+
+## Open challenges
+
+- Discourse retry for the Deep Dive is outstanding — someone needs to re-run content-syndication once the forum is writable again.
+- GitHub publisher for the content-syndication pipeline is not yet implemented; the Deep Dive has no GitHub presence yet.
+- Time-zone support for workflow schedules is an obvious community ask; worth opening a tracking issue.
+- ADK workflow graph parsing landed in PR #113 last week and is fairly complex. Would benefit from a follow-up integration test pass against real multi-branch workflow definitions.


### PR DESCRIPTION
Adds the weekly Build Log for the week of 2026-06-21.

## Review trail
- ✅ Tech Reviewer (CITAAAA-350) — 4 findings, all applied
- ✅ DevRel Lead editorial (CITAAAA-356) — approved
- ⏳ Dennis approval pending (CITAAAA-349)

## Changes
- `community/build-logs/2026-06-21.md` — new file

## Channels (on merge)
- Discourse, Dev.to, X

## Flagged for reviewer
- ⚠️ Test gap: cancel route tests AND embedded-Postgres workflow-service cancellation tests could not run in the PR sandbox (EPERM on localhost sockets). Coverage is code-review + typecheck only.