### PR TITLE
Implement workflow bridge extraction and enhance payload construction

### DIFF
--- a/server/src/__tests__/heartbeat-paperclip-wake-payload.test.ts
+++ b/server/src/__tests__/heartbeat-paperclip-wake-payload.test.ts
@@ -127,7 +127,7 @@ describe("buildPaperclipWakePayload", () => {
         priority: "medium",
       },
     });
-    expect(payload?.workflowBridge).toBeUndefined();
+    expect(payload?.workflowBridge).toBeNull();
   });
 
   it("keeps an explicit workflow bridge even when the description conflicts", async () => {

--- a/server/src/__tests__/heartbeat-paperclip-wake-payload.test.ts
+++ b/server/src/__tests__/heartbeat-paperclip-wake-payload.test.ts
@@ -99,6 +99,37 @@ describe("buildPaperclipWakePayload", () => {
     });
   });
 
+  it("does not materialize workflow bridge selectors from stale issue descriptions on non-workflow wakes", async () => {
+    const payload = await buildPaperclipWakePayload({
+      db: {} as never,
+      companyId: "company-1",
+      contextSnapshot: {
+        wakeReason: "issue_assigned",
+      },
+      issueSummary: {
+        id: "issue-3",
+        identifier: "CITAAAAAA-113",
+        title: "assignment wake",
+        description: canonicalWorkflowTargetDescription,
+        status: "in_progress",
+        priority: "medium",
+      },
+    });
+
+    expect(payload).toMatchObject({
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-3",
+        identifier: "CITAAAAAA-113",
+        title: "assignment wake",
+        description: canonicalWorkflowTargetDescription,
+        status: "in_progress",
+        priority: "medium",
+      },
+    });
+    expect(payload?.workflowBridge).toBeUndefined();
+  });
+
   it("keeps an explicit workflow bridge even when the description conflicts", async () => {
     const payload = await buildPaperclipWakePayload({
       db: {} as never,

--- a/server/src/__tests__/heartbeat-paperclip-wake-payload.test.ts
+++ b/server/src/__tests__/heartbeat-paperclip-wake-payload.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { buildPaperclipWakePayload } from "../services/heartbeat.js";
 
+const canonicalWorkflowTargetDescription = [
+  "Notes for the next agent.",
+  "",
+  "Workflow target: workflowId=CITAAAAAA-111, workflowKey=CITAAAAAA-112, capability=CITAAAAAA-113",
+  "",
+  "Keep the rest of the description intact.",
+].join("\n");
+
 describe("buildPaperclipWakePayload", () => {
   it("preserves issue description in the serialized paperclip wake issue payload", async () => {
     const payload = await buildPaperclipWakePayload({
@@ -50,6 +58,72 @@ describe("buildPaperclipWakePayload", () => {
       reason: "workflow_invoked",
       workflowBridge: {
         workflowId: "workflow-1",
+        workflowKey: "content_strategist",
+        capability: "content-strategist",
+      },
+    });
+  });
+
+  it("materializes workflow bridge selectors from the issue description when the structured field is absent", async () => {
+    const payload = await buildPaperclipWakePayload({
+      db: {} as never,
+      companyId: "company-1",
+      contextSnapshot: {
+        wakeReason: "workflow_invoked",
+      },
+      issueSummary: {
+        id: "issue-1",
+        identifier: "CITAAAAAA-111",
+        title: "workflow handoff",
+        description: canonicalWorkflowTargetDescription,
+        status: "in_progress",
+        priority: "medium",
+      },
+    });
+
+    expect(payload).toMatchObject({
+      reason: "workflow_invoked",
+      issue: {
+        id: "issue-1",
+        identifier: "CITAAAAAA-111",
+        title: "workflow handoff",
+        description: canonicalWorkflowTargetDescription,
+        status: "in_progress",
+        priority: "medium",
+      },
+      workflowBridge: {
+        workflowId: "CITAAAAAA-111",
+        workflowKey: "CITAAAAAA-112",
+        capability: "CITAAAAAA-113",
+      },
+    });
+  });
+
+  it("keeps an explicit workflow bridge even when the description conflicts", async () => {
+    const payload = await buildPaperclipWakePayload({
+      db: {} as never,
+      companyId: "company-1",
+      contextSnapshot: {
+        wakeReason: "workflow_invoked",
+        workflowBridge: {
+          workflowId: "workflow-explicit",
+          workflowKey: "content_strategist",
+          capability: "content-strategist",
+        },
+      },
+      issueSummary: {
+        id: "issue-2",
+        identifier: "CITAAAAAA-112",
+        title: "workflow handoff",
+        description: canonicalWorkflowTargetDescription,
+        status: "in_progress",
+        priority: "medium",
+      },
+    });
+
+    expect(payload).toMatchObject({
+      workflowBridge: {
+        workflowId: "workflow-explicit",
         workflowKey: "content_strategist",
         capability: "content-strategist",
       },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1597,6 +1597,7 @@ function readWakeWorkflowBridgeFromDescription(description: string | null | unde
     }
     if (key === "capability") {
       workflowBridge.capability = value;
+      continue;
     }
   }
 
@@ -1606,10 +1607,13 @@ function readWakeWorkflowBridgeFromDescription(description: string | null | unde
 }
 
 function materializeWakeWorkflowBridge(input: {
+  wakeReason: string | null | undefined;
   workflowBridge: WakeWorkflowBridge | null;
   issueDescription: string | null | undefined;
 }): WakeWorkflowBridge | null {
-  return input.workflowBridge ?? readWakeWorkflowBridgeFromDescription(input.issueDescription);
+  if (input.workflowBridge) return input.workflowBridge;
+  if (input.wakeReason !== "workflow_invoked") return null;
+  return readWakeWorkflowBridgeFromDescription(input.issueDescription);
 }
 
 function enrichWakeContextSnapshot(input: {
@@ -1736,6 +1740,7 @@ export async function buildPaperclipWakePayload(input: {
           .then((rows) => rows[0] ?? null)
       : null);
   const workflowBridge = materializeWakeWorkflowBridge({
+    wakeReason: readNonEmptyString(input.contextSnapshot.wakeReason),
     workflowBridge: readWakeWorkflowBridgeSelector(input.contextSnapshot),
     issueDescription: issueSummary?.description ?? null,
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1561,6 +1561,57 @@ function readWakeWorkflowBridgeSelector(contextSnapshot: Record<string, unknown>
   };
 }
 
+function readWakeWorkflowBridgeFromDescription(description: string | null | undefined): WakeWorkflowBridge | null {
+  const rawDescription = readNonEmptyString(description);
+  if (!rawDescription) return null;
+
+  const targetLine = rawDescription
+    .split(/\r?\n/)
+    .find((line) => line.trim().startsWith("Workflow target:"));
+  if (!targetLine) return null;
+
+  const selectorText = targetLine.slice(targetLine.indexOf(":") + 1).trim();
+  if (!selectorText) return null;
+
+  const workflowBridge: WakeWorkflowBridge = {
+    workflowId: null,
+    workflowKey: null,
+    capability: null,
+    workflowRunId: null,
+    workflowHandoffId: null,
+  };
+
+  for (const entry of selectorText.split(",")) {
+    const [rawKey, ...rawValueParts] = entry.split("=");
+    const key = rawKey.trim();
+    const value = rawValueParts.join("=").trim();
+    if (!value) continue;
+
+    if (key === "workflowId" || key === "workflow_id") {
+      workflowBridge.workflowId = value;
+      continue;
+    }
+    if (key === "workflowKey" || key === "workflow_key") {
+      workflowBridge.workflowKey = value;
+      continue;
+    }
+    if (key === "capability") {
+      workflowBridge.capability = value;
+    }
+  }
+
+  return workflowBridge.workflowId || workflowBridge.workflowKey || workflowBridge.capability
+    ? workflowBridge
+    : null;
+}
+
+function materializeWakeWorkflowBridge(input: {
+  workflowBridge: WakeWorkflowBridge | null;
+  issueDescription: string | null | undefined;
+}): WakeWorkflowBridge | null {
+  return input.workflowBridge ?? readWakeWorkflowBridgeFromDescription(input.issueDescription);
+}
+
 function enrichWakeContextSnapshot(input: {
   contextSnapshot: Record<string, unknown>;
   reason: string | null;
@@ -1667,7 +1718,6 @@ export async function buildPaperclipWakePayload(input: {
   const issueId = readNonEmptyString(input.contextSnapshot.issueId);
   const agentThreadId = readNonEmptyString(input.contextSnapshot.agentThreadId);
   const agentThreadMessageId = readNonEmptyString(input.contextSnapshot.agentThreadMessageId);
-  const workflowBridge = readWakeWorkflowBridgeSelector(input.contextSnapshot);
   const continuationSummary = input.continuationSummary ?? null;
   const issueSummary =
     input.issueSummary ??
@@ -1685,6 +1735,10 @@ export async function buildPaperclipWakePayload(input: {
           .where(and(eq(issues.id, issueId), eq(issues.companyId, input.companyId)))
           .then((rows) => rows[0] ?? null)
       : null);
+  const workflowBridge = materializeWakeWorkflowBridge({
+    workflowBridge: readWakeWorkflowBridgeSelector(input.contextSnapshot),
+    issueDescription: issueSummary?.description ?? null,
+  });
   const threadSummary =
     agentThreadId
       ? await input.db


### PR DESCRIPTION
This pull request enhances the workflow bridge extraction logic in the paperclip wake payload process, ensuring that workflow bridge selectors can be derived from the issue description if the structured field is absent, and that explicit workflow bridges take precedence even in the presence of conflicting descriptions. The changes also add comprehensive tests for these scenarios.

**Workflow Bridge Extraction Improvements:**

* Added a new function `readWakeWorkflowBridgeFromDescription` to parse workflow bridge selectors from the `description` field when the structured field is missing, enabling more robust extraction of workflow context from issue descriptions.
* Introduced `materializeWakeWorkflowBridge` to prioritize explicit workflow bridges from the context snapshot, falling back to extraction from the issue description only if necessary.
* Updated the `buildPaperclipWakePayload` function to use the new materialization logic for determining the workflow bridge, improving data consistency and flexibility. [[1]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79L1670) [[2]](diffhunk://#diff-129bd98899d97995a76229221d1c932577543f32254b477492ae25441993af79R1738-R1741)

**Testing Enhancements:**

* Added tests to verify that workflow bridge selectors are correctly extracted from the issue description when the structured field is absent, and that explicit workflow bridges override conflicting descriptions. (`server/src/__tests__/heartbeat-paperclip-wake-payload.test.ts`) [[1]](diffhunk://#diff-ba1d1afc0a1a25365619b1a92d8b0f1bc8242bda366e67c8ff6e423b67e72778R4-R11) [[2]](diffhunk://#diff-ba1d1afc0a1a25365619b1a92d8b0f1bc8242bda366e67c8ff6e423b67e72778R66-R131)