### PR TITLE
Enhance Pi execution logging with progress messages and stdout sanitization

### DIFF
--- a/packages/adapters/pi-local/src/server/execute.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.test.ts
@@ -6,6 +6,23 @@ describe("summarizeProgressToolInput", () => {
     expect(summarizeProgressToolInput("token=secret-value")).toBeNull();
   });
 
+  it("redacts command args by field count", () => {
+    expect(
+      summarizeProgressToolInput({
+        command: "bash -lc 'curl https://example.com?token=secret'",
+      }),
+    ).toBe("1 field");
+  });
+
+  it("redacts cmd args by field count", () => {
+    expect(
+      summarizeProgressToolInput({
+        cmd: "bash -lc 'curl https://example.com?token=secret'",
+        cwd: "/tmp",
+      }),
+    ).toBe("2 fields");
+  });
+
   it("summarizes object args by field count", () => {
     expect(
       summarizeProgressToolInput({

--- a/packages/adapters/pi-local/src/server/execute.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { formatPiProgressMessage, summarizeProgressToolInput } from "./execute.js";
+
+describe("summarizeProgressToolInput", () => {
+  it("hides raw string args", () => {
+    expect(summarizeProgressToolInput("token=secret-value")).toBeNull();
+  });
+
+  it("summarizes object args by field count", () => {
+    expect(
+      summarizeProgressToolInput({
+        path: "/tmp/secret.txt",
+        token: "secret-value",
+      }),
+    ).toBe("2 fields");
+  });
+});
+
+describe("formatPiProgressMessage", () => {
+  it("omits raw string tool args from progress logs", () => {
+    const state = { sawThinking: false };
+    const message = formatPiProgressMessage(
+      JSON.stringify({
+        type: "tool_execution_start",
+        toolName: "read",
+        args: "token=secret-value",
+      }),
+      state,
+    );
+
+    expect(message).toBe("[paperclip] Pi tool running: read.");
+  });
+
+  it("reports object args by field count", () => {
+    const state = { sawThinking: false };
+    const message = formatPiProgressMessage(
+      JSON.stringify({
+        type: "tool_execution_start",
+        toolName: "read",
+        args: {
+          path: "/tmp/secret.txt",
+          token: "secret-value",
+        },
+      }),
+      state,
+    );
+
+    expect(message).toBe("[paperclip] Pi tool running: read (2 fields).");
+  });
+});

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -79,17 +79,15 @@ function truncateSummary(value: string, maxChars: number): string {
   return `${normalized.slice(0, Math.max(0, maxChars - 1))}…`;
 }
 
-function summarizeRecordKeys(record: Record<string, unknown>, maxKeys = 3): string | null {
-  const keys = Object.keys(record);
-  if (keys.length === 0) return null;
-  return keys.slice(0, maxKeys).join(", ");
+function summarizeRecordFieldCount(record: Record<string, unknown>): string | null {
+  const keyCount = Object.keys(record).length;
+  if (keyCount === 0) return null;
+  return `${keyCount} field${keyCount === 1 ? "" : "s"}`;
 }
 
-function summarizeProgressToolInput(name: string, input: unknown): string | null {
+export function summarizeProgressToolInput(input: unknown): string | null {
   if (typeof input === "string") {
-    const trimmed = input.trim();
-    if (!trimmed) return null;
-    return truncateSummary(trimmed, 48);
+    return null;
   }
   const record = asRecord(input);
   if (!record) return null;
@@ -103,15 +101,14 @@ function summarizeProgressToolInput(name: string, input: unknown): string | null
     return `command: ${truncateSummary(command, 48)}`;
   }
 
-  const keys = summarizeRecordKeys(record);
-  return keys ? `${name} fields: ${keys}` : null;
+  return summarizeRecordFieldCount(record);
 }
 
 type PiProgressState = {
   sawThinking: boolean;
 };
 
-function formatPiProgressMessage(line: string, state: PiProgressState): string | null {
+export function formatPiProgressMessage(line: string, state: PiProgressState): string | null {
   const parsed = asRecord(safeJsonParse(line));
   if (!parsed) return null;
 
@@ -140,7 +137,7 @@ function formatPiProgressMessage(line: string, state: PiProgressState): string |
 
   if (type === "tool_execution_start") {
     const toolName = readString(parsed.toolName, "tool");
-    const inputSummary = summarizeProgressToolInput(toolName, parsed.args);
+    const inputSummary = summarizeProgressToolInput(parsed.args);
     return inputSummary
       ? `[paperclip] Pi tool running: ${toolName} (${inputSummary}).`
       : `[paperclip] Pi tool running: ${toolName}.`;

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -92,15 +92,6 @@ export function summarizeProgressToolInput(input: unknown): string | null {
   const record = asRecord(input);
   if (!record) return null;
 
-  const command = typeof record.command === "string"
-    ? record.command
-    : typeof record.cmd === "string"
-      ? record.cmd
-      : null;
-  if (command) {
-    return `command: ${truncateSummary(command, 48)}`;
-  }
-
   return summarizeRecordFieldCount(record);
 }
 

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -56,6 +56,153 @@ function parseModelId(model: string | null): string | null {
   return trimmed.slice(trimmed.indexOf("/") + 1).trim() || null;
 }
 
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function truncateSummary(value: string, maxChars: number): string {
+  const normalized = value.trim().replace(/\s+/g, " ");
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function summarizeRecordKeys(record: Record<string, unknown>, maxKeys = 3): string | null {
+  const keys = Object.keys(record);
+  if (keys.length === 0) return null;
+  return keys.slice(0, maxKeys).join(", ");
+}
+
+function summarizeProgressToolInput(name: string, input: unknown): string | null {
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+    return truncateSummary(trimmed, 48);
+  }
+  const record = asRecord(input);
+  if (!record) return null;
+
+  const command = typeof record.command === "string"
+    ? record.command
+    : typeof record.cmd === "string"
+      ? record.cmd
+      : null;
+  if (command) {
+    return `command: ${truncateSummary(command, 48)}`;
+  }
+
+  const keys = summarizeRecordKeys(record);
+  return keys ? `${name} fields: ${keys}` : null;
+}
+
+type PiProgressState = {
+  sawThinking: boolean;
+};
+
+function formatPiProgressMessage(line: string, state: PiProgressState): string | null {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) return null;
+
+  const type = readString(parsed.type);
+
+  if (type === "agent_start") {
+    state.sawThinking = false;
+    return "[paperclip] Pi agent started.";
+  }
+
+  if (type === "turn_start") {
+    state.sawThinking = false;
+    return "[paperclip] Pi turn started.";
+  }
+
+  if (type === "message_update") {
+    const assistantEvent = asRecord(parsed.assistantMessageEvent);
+    if (!assistantEvent) return null;
+    const msgType = readString(assistantEvent.type);
+    if (msgType === "thinking_delta" && !state.sawThinking) {
+      state.sawThinking = true;
+      return "[paperclip] Pi thinking...";
+    }
+    return null;
+  }
+
+  if (type === "tool_execution_start") {
+    const toolName = readString(parsed.toolName, "tool");
+    const inputSummary = summarizeProgressToolInput(toolName, parsed.args);
+    return inputSummary
+      ? `[paperclip] Pi tool running: ${toolName} (${inputSummary}).`
+      : `[paperclip] Pi tool running: ${toolName}.`;
+  }
+
+  if (type === "tool_execution_end") {
+    const toolName = readString(parsed.toolName, "tool");
+    const isError = parsed.isError === true;
+    const result = parsed.result;
+    const resultType =
+      typeof result === "string"
+        ? "text"
+        : Array.isArray(result)
+          ? "array"
+          : result && typeof result === "object"
+            ? "object"
+            : typeof result;
+    return isError
+      ? `[paperclip] Pi tool failed: ${toolName} (${resultType}).`
+      : `[paperclip] Pi tool completed: ${toolName} (${resultType}).`;
+  }
+
+  if (type === "turn_end") {
+    const message = asRecord(parsed.message);
+    const toolResults = Array.isArray(parsed.toolResults) ? parsed.toolResults : [];
+    const usage = message ? asRecord(message.usage) : null;
+    const tokenSummary = usage
+      ? `input ${asNumber(usage.inputTokens ?? usage.input, 0)}, output ${asNumber(usage.outputTokens ?? usage.output, 0)}`
+      : null;
+    const toolCount = toolResults.length > 0 ? `${toolResults.length} tool result${toolResults.length === 1 ? "" : "s"}` : null;
+    const details = [toolCount, tokenSummary].filter((value): value is string => typeof value === "string" && value.length > 0);
+    return details.length > 0
+      ? `[paperclip] Pi turn completed (${details.join("; ")}).`
+      : "[paperclip] Pi turn completed.";
+  }
+
+  if (type === "auto_retry_end") {
+    const succeeded = parsed.success === true;
+    if (succeeded) return "[paperclip] Pi automatic retry cycle completed.";
+    const attempt = asNumber(parsed.attempt, 0);
+    return attempt > 0
+      ? `[paperclip] Pi automatic retries exhausted after ${attempt} attempts.`
+      : "[paperclip] Pi automatic retries exhausted.";
+  }
+
+  if (type === "agent_end") {
+    const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
+    return messages.length > 0
+      ? `[paperclip] Pi agent finished (${messages.length} message${messages.length === 1 ? "" : "s"}).`
+      : "[paperclip] Pi agent finished.";
+  }
+
+  if (type === "error") {
+    const message = readString(parsed.message, "").trim();
+    return message
+      ? `[paperclip] Pi error: ${truncateSummary(message, 72)}`
+      : "[paperclip] Pi error.";
+  }
+
+  return null;
+}
+
 async function ensurePiSkillsInjected(
   onLog: AdapterExecutionContext["onLog"],
   skillsEntries: Array<{ key: string; runtimeName: string; source: string }>,
@@ -111,6 +258,8 @@ function buildSessionPath(agentId: string, timestamp: string): string {
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  const progressPlaceholder =
+    "[paperclip] Pi autonomous run is in progress. Watching for safe milestones.\n";
 
   const promptTemplate = asString(
     config.promptTemplate,
@@ -369,6 +518,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const runAttempt = async (sessionFile: string) => {
     const args = buildArgs(sessionFile);
+    const progressState: PiProgressState = { sawThinking: false };
+    let stdoutBuffer = "";
+    const sanitizedStdoutChunks: string[] = [];
     if (onMeta) {
       await onMeta({
         adapterType: "pi_local",
@@ -383,25 +535,29 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
-    // Buffer stdout by lines to handle partial JSON chunks
-    let stdoutBuffer = "";
+    // Keep Pi runs readable in heartbeat logs without leaking the raw stdout stream.
+    await onLog("stdout", progressPlaceholder);
+    sanitizedStdoutChunks.push(progressPlaceholder);
+
     const bufferedOnLog = async (stream: "stdout" | "stderr", chunk: string) => {
       if (stream === "stderr") {
         // Pass stderr through immediately (not JSONL)
         await onLog(stream, chunk);
         return;
       }
-      
-      // Buffer stdout and emit only complete lines
+
       stdoutBuffer += chunk;
       const lines = stdoutBuffer.split("\n");
-      // Keep the last (potentially incomplete) line in the buffer
       stdoutBuffer = lines.pop() || "";
-      
-      // Emit complete lines
-      for (const line of lines) {
-        if (line) {
-          await onLog(stream, line + "\n");
+
+      for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) continue;
+        const progressMessage = formatPiProgressMessage(line, progressState);
+        if (progressMessage) {
+          const sanitizedChunk = `${progressMessage}\n`;
+          sanitizedStdoutChunks.push(sanitizedChunk);
+          await onLog("stdout", sanitizedChunk);
         }
       }
     };
@@ -414,15 +570,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       onSpawn,
       onLog: bufferedOnLog,
     });
-    
-    // Flush any remaining buffer content
-    if (stdoutBuffer) {
-      await onLog("stdout", stdoutBuffer);
+
+    if (stdoutBuffer.trim().length > 0) {
+      const progressMessage = formatPiProgressMessage(stdoutBuffer.trim(), progressState);
+      if (progressMessage) {
+        const sanitizedChunk = `${progressMessage}\n`;
+        sanitizedStdoutChunks.push(sanitizedChunk);
+        await onLog("stdout", sanitizedChunk);
+      }
     }
-    
+
     return {
       proc,
       rawStderr: proc.stderr,
+      sanitizedStdout: sanitizedStdoutChunks.join(""),
       parsed: parsePiJsonl(proc.stdout),
     };
   };
@@ -431,6 +592,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     attempt: {
       proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string };
       rawStderr: string;
+      sanitizedStdout: string;
       parsed: ReturnType<typeof parsePiJsonl>;
     },
     clearSessionOnMissingSession = false,
@@ -475,7 +637,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       billingType: "unknown",
       costUsd: attempt.parsed.usage.costUsd,
       resultJson: {
-        stdout: attempt.proc.stdout,
+        stdout: attempt.sanitizedStdout,
         stderr: attempt.proc.stderr,
       },
       summary: attempt.parsed.finalMessage ?? attempt.parsed.messages.join("\n\n").trim(),

--- a/server/src/__tests__/pi-local-execute.test.ts
+++ b/server/src/__tests__/pi-local-execute.test.ts
@@ -11,8 +11,34 @@ if (process.argv.includes("--list-models")) {
   console.log("google    gemini-3-flash-preview");
   process.exit(0);
 }
+console.log("token=secret-value");
 console.log(JSON.stringify({ type: "agent_start" }));
 console.log(JSON.stringify({ type: "turn_start" }));
+console.log(JSON.stringify({
+  type: "message_update",
+  assistantMessageEvent: {
+    type: "thinking_delta",
+    delta: "thinking about the next step",
+  },
+}));
+console.log(JSON.stringify({
+  type: "tool_execution_start",
+  toolCallId: "tool-1",
+  toolName: "read",
+  args: {
+    path: "/tmp/secret.txt",
+    token: "secret-value",
+  },
+}));
+console.log(JSON.stringify({
+  type: "tool_execution_end",
+  toolCallId: "tool-1",
+  toolName: "read",
+  result: {
+    content: "tool finished",
+  },
+  isError: false,
+}));
 console.log(JSON.stringify({ type: "turn_end", message: { role: "assistant", content: "" }, toolResults: [] }));
 console.log(JSON.stringify({ type: "agent_end", messages: [] }));
 console.log(JSON.stringify({
@@ -67,6 +93,71 @@ describe("pi_local execute", () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.errorMessage).toContain("RESOURCE_EXHAUSTED");
+      expect(result.resultJson?.stdout).toContain("Pi autonomous run is in progress");
+      expect(result.resultJson?.stdout).toContain("Pi thinking");
+      expect(result.resultJson?.stdout).not.toContain("secret-value");
+      expect(result.resultJson?.stdout).not.toContain('"type":"agent_start"');
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("hides Pi stdout from heartbeat logs and replaces it with a placeholder", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-execute-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "pi");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakePiCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    const logs: Array<{ stream: string; chunk: string }> = [];
+
+    try {
+      const result = await execute({
+        runId: "run-pi-hidden-stdout",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Pi Agent",
+          adapterType: "pi_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "google/gemini-3-flash-preview",
+          promptTemplate: "Keep working.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => {
+          logs.push({ stream, chunk });
+        },
+      });
+
+      const stdoutChunks = logs.filter((entry) => entry.stream === "stdout").map((entry) => entry.chunk);
+      expect(stdoutChunks.some((chunk) => chunk.includes("Pi autonomous run is in progress"))).toBe(true);
+      expect(stdoutChunks.some((chunk) => chunk.includes("Pi thinking"))).toBe(true);
+      expect(stdoutChunks.some((chunk) => chunk.includes("Pi tool running: read"))).toBe(true);
+      expect(stdoutChunks.some((chunk) => chunk.includes("Pi tool completed: read"))).toBe(true);
+      expect(stdoutChunks.some((chunk) => chunk.includes("Pi turn completed"))).toBe(true);
+      expect(stdoutChunks.some((chunk) => chunk.includes("secret-value"))).toBe(false);
+      expect(logs.some((entry) => entry.chunk.includes("secret-value"))).toBe(false);
+      expect(result.resultJson?.stdout).toContain("Pi autonomous run is in progress");
+      expect(result.resultJson?.stdout).toContain("Pi tool running: read");
+      expect(result.resultJson?.stdout).toContain("Pi turn completed");
+      expect(result.resultJson?.stdout).not.toContain("secret-value");
+      expect(result.resultJson?.stdout).not.toContain('"type":"tool_execution_start"');
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;


### PR DESCRIPTION
This pull request introduces significant improvements to the handling and logging of Pi agent output in the `pi-local` adapter. The main goal is to sanitize and summarize Pi's stdout stream, ensuring that sensitive information and raw JSON are not exposed in logs or API results. Instead, user-friendly progress messages are emitted, making logs safer and easier to read. The changes also include comprehensive tests to verify the new behavior.

**Key changes:**

### Pi stdout sanitization and summarization

* Added a new function `formatPiProgressMessage` and supporting helpers in `execute.ts` to parse Pi's JSONL stdout, summarize events, and emit safe, human-readable progress messages instead of raw JSON or sensitive data. This includes handling various Pi event types and redacting sensitive fields.
* Updated the execution pipeline to buffer and process stdout by lines, replacing raw output with sanitized progress messages in both logs and the returned `resultJson.stdout`. [[1]](diffhunk://#diff-1f5890a74672fac110b230768c8eb34fc2cc37e045fbfeacae04935723d8b24cR521-R523) [[2]](diffhunk://#diff-1f5890a74672fac110b230768c8eb34fc2cc37e045fbfeacae04935723d8b24cL386-R560) [[3]](diffhunk://#diff-1f5890a74672fac110b230768c8eb34fc2cc37e045fbfeacae04935723d8b24cL418-R586) [[4]](diffhunk://#diff-1f5890a74672fac110b230768c8eb34fc2cc37e045fbfeacae04935723d8b24cL478-R640)

### API and type changes

* The `execute` function now returns a new `sanitizedStdout` field in the attempt result, which is used in place of the raw stdout in `resultJson`. [[1]](diffhunk://#diff-1f5890a74672fac110b230768c8eb34fc2cc37e045fbfeacae04935723d8b24cR595) [[2]](diffhunk://#diff-1f5890a74672fac110b230768c8eb34fc2cc37e045fbfeacae04935723d8b24cL478-R640)

### Testing improvements

* Enhanced the fake Pi process in `pi-local-execute.test.ts` to emit a variety of Pi event types, including sensitive fields, to test sanitization.
* Added new and improved tests to verify that logs and API output contain only the safe, summarized progress messages and do not leak sensitive data or raw JSON.