### PR TITLE
Update Dependabot configuration for daily updates and limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
+      interval: daily
+    open-pull-requests-limit: 1
     labels:
       - dependencies
     commit-message:


### PR DESCRIPTION
This pull request updates the Dependabot configuration to make dependency updates more frequent and to limit the number of open pull requests.

Dependabot configuration changes:

* Changed the update schedule for npm dependencies from weekly to daily to ensure dependencies are kept up-to-date more regularly.
* Reduced the maximum number of open Dependabot pull requests from 10 to 1 to minimize noise and make it easier to review updates.