### PR TITLE
feat(workflows): add archival lifecycle

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -407,6 +407,20 @@ Operational policy:
   - `document_id` uuid fk not null
   - `key` text not null (`plan`, `design`, `notes`, etc.)
 
+## 7.16 Workflows
+
+Workflows are company-scoped, soft-archivable execution definitions. Their status is
+`active | paused | archived`.
+
+- `active`: manual, scheduled, and routine-invoked runs are eligible.
+- `paused`: retained and visible; scheduler eligibility follows existing paused-state behavior.
+- `archived`: hidden from default workflow lists; configuration, runs, schedules, deliverables,
+  and activity history remain retained.
+- Archiving blocks new manual, scheduled, and routine-invoked runs.
+- Existing `queued`, `running`, and `awaiting_human` runs continue to terminal completion.
+- Restore always changes `archived` to `active`; retained active schedules become eligible again.
+- Archive and restore are auditable as `workflow.archived` and `workflow.restored` activity actions.
+
 ## 8. State Machines
 
 ## 8.1 Agent Status
@@ -591,7 +605,19 @@ Dashboard payload must include:
 - month-to-date spend and budget utilization
 - pending approvals count
 
-## 10.9 Error Semantics
+## 10.9 Workflows
+
+- `GET /companies/:companyId/workflows`
+- `GET /companies/:companyId/workflows?includeArchived=true`
+- `POST /companies/:companyId/workflows`
+- `GET /workflows/:workflowId`
+- `PATCH /workflows/:workflowId` with `{ "status": "archived" | "active" }`
+- `POST /workflows/:workflowId/run`
+
+The default workflow list excludes archived workflows. Archived workflow launch attempts return
+`409 Conflict`; direct detail and explicit archived-inclusive listing retain historical access.
+
+## 10.10 Error Semantics
 
 - `400` validation error
 - `401` unauthenticated

--- a/server/src/__tests__/workflow-schedules.test.ts
+++ b/server/src/__tests__/workflow-schedules.test.ts
@@ -182,4 +182,27 @@ describeEmbeddedPostgres("workflowScheduleService", () => {
     expect(updated?.nextRunAt).toBeInstanceOf(Date);
     expect(updated?.lastFiredAt).toBeNull();
   });
+
+  it("skips scheduled fires when the workflow is archived while retaining schedule", async () => {
+    const { workflowId } = await seedWorkflow("archived");
+    const svc = workflowScheduleService(db);
+    const schedule = await svc.create(workflowId, {
+      title: "Daily brief",
+      cronExpression: "0 9 * * *",
+      templateMarkdown: "Send the morning brief.",
+      status: "active",
+    }, { userId: "board-user" });
+
+    await db.update(workflowSchedules).set({
+      nextRunAt: new Date("2026-06-10T08:59:00.000Z"),
+    }).where(eq(workflowSchedules.id, schedule.id));
+
+    const result = await svc.tickScheduledRuns(new Date("2026-06-10T09:00:00.000Z"));
+
+    expect(result.triggered).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(mockRunManual).not.toHaveBeenCalled();
+    await expect(db.select().from(workflowSchedules).where(eq(workflowSchedules.id, schedule.id)))
+      .resolves.toHaveLength(1);
+  });
 });

--- a/server/src/__tests__/workflow-selector-resolver.test.ts
+++ b/server/src/__tests__/workflow-selector-resolver.test.ts
@@ -63,6 +63,23 @@ describe("resolveWorkflowByInvocationTarget", () => {
     );
   });
 
+  it("rejects archived workflows from invocation targets", async () => {
+    const db = createMockDb([[
+      {
+        id: "workflow-archived",
+        companyId: "company-1",
+        title: "Archived workflow",
+        status: "archived",
+        workflowKey: "archived-workflow",
+        capabilities: ["briefing"],
+      },
+    ]]);
+
+    await expect(resolveWorkflowByInvocationTarget(db, "company-1", {
+      workflowId: "workflow-archived",
+    })).rejects.toThrow(/archived.*restore/i);
+  });
+
   it("falls back through key and capability selectors when higher-precedence selectors are absent", async () => {
     const db = createMockDb([
       [

--- a/server/src/__tests__/workflow-service-run-manual.test.ts
+++ b/server/src/__tests__/workflow-service-run-manual.test.ts
@@ -175,6 +175,32 @@ describeEmbeddedPostgres("workflowService.runManual", () => {
     expect(phases[0]?.phaseKey).toBe("phase-1");
   });
 
+  it("rejects manual runs for archived workflows", async () => {
+    const companyId = randomUUID();
+    const workflowId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(workflows).values({
+      id: workflowId,
+      companyId,
+      title: "Archived workflow",
+      status: "archived",
+      runnerType: "google_adk",
+      runnerConfig: { agentPath: "/tmp/agent.py" },
+      pipelineDefinition: { entrypoint: "agent.py", generatedAt: new Date(0).toISOString(), phases: [] },
+      pipelineSourceHash: null,
+    });
+
+    await expect(workflowService(db).runManual(workflowId, { inputMarkdown: "generate" }))
+      .rejects.toThrow(/archived.*restore/i);
+    expect(mockInvokeGoogleAdk).not.toHaveBeenCalled();
+  });
+
   it("closes active phases when the ADK invocation exits", async () => {
     const companyId = randomUUID();
     const workflowId = randomUUID();

--- a/server/src/__tests__/workflow-service-update.test.ts
+++ b/server/src/__tests__/workflow-service-update.test.ts
@@ -199,6 +199,40 @@ describeEmbeddedPostgres("workflowService.update", () => {
     expect(byId?.pipelineDefinition).toMatchObject(normalizedPipelineDefinition);
   });
 
+  it("hides archived workflows by default and includes them when requested", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(workflows).values([
+      {
+        companyId,
+        title: "Active workflow",
+        status: "active",
+        runnerType: "google_adk",
+        runnerConfig: { agentPath: "/tmp/active.py" },
+        pipelineDefinition: normalizedPipelineDefinition,
+        pipelineSourceHash: null,
+      },
+      {
+        companyId,
+        title: "Archived workflow",
+        status: "archived",
+        runnerType: "google_adk",
+        runnerConfig: { agentPath: "/tmp/archived.py" },
+        pipelineDefinition: normalizedPipelineDefinition,
+        pipelineSourceHash: null,
+      },
+    ]);
+
+    const svc = workflowService(db);
+    await expect(svc.list(companyId)).resolves.toHaveLength(1);
+    await expect(svc.list(companyId, { includeArchived: true })).resolves.toHaveLength(2);
+  });
+
   it.each([
     [
       "null-like pipeline fields",

--- a/server/src/__tests__/workflows-routes.test.ts
+++ b/server/src/__tests__/workflows-routes.test.ts
@@ -83,6 +83,53 @@ describe("workflow routes", () => {
     });
   });
 
+  it("forwards includeArchived list query to workflow service", async () => {
+    mockWorkflowService.list.mockResolvedValue([]);
+
+    const res = await request(createApp())
+      .get(`/api/companies/${companyId}/workflows?includeArchived=true`);
+
+    expect(res.status).toBe(200);
+    expect(mockWorkflowService.list).toHaveBeenCalledWith(companyId, { includeArchived: true });
+  });
+
+  it("logs dedicated archive and restore activity actions", async () => {
+    mockWorkflowService.get
+      .mockResolvedValueOnce({
+      id: "workflow-1",
+      companyId,
+      title: "Social",
+      status: "active",
+      })
+      .mockResolvedValueOnce({
+        id: "workflow-1",
+        companyId,
+        title: "Social",
+        status: "archived",
+      });
+    mockWorkflowService.update
+      .mockResolvedValueOnce({ id: "workflow-1", companyId, title: "Social", status: "archived" })
+      .mockResolvedValueOnce({ id: "workflow-1", companyId, title: "Social", status: "active" });
+
+    const archive = await request(createApp())
+      .patch("/api/workflows/workflow-1")
+      .send({ status: "archived" });
+    const restore = await request(createApp())
+      .patch("/api/workflows/workflow-1")
+      .send({ status: "active" });
+
+    expect(archive.status).toBe(200);
+    expect(restore.status).toBe(200);
+    expect(mockLogActivity).toHaveBeenNthCalledWith(1, expect.anything(), expect.objectContaining({
+      action: "workflow.archived",
+      details: expect.objectContaining({ previousStatus: "active", newStatus: "archived" }),
+    }));
+    expect(mockLogActivity).toHaveBeenNthCalledWith(2, expect.anything(), expect.objectContaining({
+      action: "workflow.restored",
+      details: expect.objectContaining({ previousStatus: "archived", newStatus: "active" }),
+    }));
+  });
+
   it("cancels a workflow run", async () => {
     mockWorkflowService.getRunDetail.mockResolvedValue({
       id: runId,

--- a/server/src/__tests__/workflows-routes.test.ts
+++ b/server/src/__tests__/workflows-routes.test.ts
@@ -130,6 +130,26 @@ describe("workflow routes", () => {
     }));
   });
 
+  it("rejects archived workflows being changed to paused", async () => {
+    mockWorkflowService.get.mockResolvedValue({
+      id: "workflow-1",
+      companyId,
+      title: "Social",
+      status: "archived",
+    });
+
+    const res = await request(createApp())
+      .patch("/api/workflows/workflow-1")
+      .send({ status: "paused" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Archived workflows can only be restored to active. Restore the workflow before making other changes.",
+    });
+    expect(mockWorkflowService.update).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
   it("cancels a workflow run", async () => {
     mockWorkflowService.getRunDetail.mockResolvedValue({
       id: runId,

--- a/server/src/__tests__/workflows-routes.test.ts
+++ b/server/src/__tests__/workflows-routes.test.ts
@@ -150,6 +150,32 @@ describe("workflow routes", () => {
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
 
+  it("allows metadata edits while keeping archived status", async () => {
+    mockWorkflowService.get.mockResolvedValue({
+      id: "workflow-1",
+      companyId,
+      title: "Social",
+      status: "archived",
+    });
+    mockWorkflowService.update.mockResolvedValue({
+      id: "workflow-1",
+      companyId,
+      title: "Updated Social",
+      status: "archived",
+    });
+
+    const res = await request(createApp())
+      .patch("/api/workflows/workflow-1")
+      .send({ title: "Updated Social", status: "archived" });
+
+    expect(res.status).toBe(200);
+    expect(mockWorkflowService.update).toHaveBeenCalledWith(
+      "workflow-1",
+      { title: "Updated Social", status: "archived" },
+      { userId: "board-user" },
+    );
+  });
+
   it("cancels a workflow run", async () => {
     mockWorkflowService.getRunDetail.mockResolvedValue({
       id: runId,

--- a/server/src/__tests__/workflows-routes.test.ts
+++ b/server/src/__tests__/workflows-routes.test.ts
@@ -2,6 +2,7 @@ import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { errorHandler } from "../middleware/index.js";
+import { HttpError } from "../errors.js";
 
 const companyId = "22222222-2222-4222-8222-222222222222";
 const runId = "33333333-3333-4333-8333-333333333333";
@@ -174,6 +175,26 @@ describe("workflow routes", () => {
       { title: "Updated Social", status: "archived" },
       { userId: "board-user" },
     );
+  });
+
+  it("returns 409 when the HTTP run endpoint targets an archived workflow", async () => {
+    mockWorkflowService.get.mockResolvedValue({
+      id: "workflow-1",
+      companyId,
+      title: "Social",
+      status: "archived",
+    });
+    mockWorkflowService.runManual.mockRejectedValue(
+      new HttpError(409, 'Workflow "Social" is archived. Restore it before running.'),
+    );
+
+    const res = await request(createApp())
+      .post("/api/workflows/workflow-1/run")
+      .send({ inputMarkdown: "Run this workflow." });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ error: 'Workflow "Social" is archived. Restore it before running.' });
+    expect(mockLogActivity).not.toHaveBeenCalled();
   });
 
   it("cancels a workflow run", async () => {

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -43,7 +43,9 @@ export function workflowRoutes(db: Db) {
     assertBoard(req);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    res.json(await svc.list(companyId));
+    res.json(await svc.list(companyId, {
+      includeArchived: req.query.includeArchived === "true",
+    }));
   });
 
   router.post("/companies/:companyId/workflows", validate(createWorkflowSchema), async (req, res) => {
@@ -89,14 +91,27 @@ export function workflowRoutes(db: Db) {
       return;
     }
     const actor = getActorInfo(req);
+    const statusTransitionAction = existing.status !== updated.status
+      ? updated.status === "archived"
+        ? "workflow.archived"
+        : existing.status === "archived" && updated.status === "active"
+          ? "workflow.restored"
+          : "workflow.updated"
+      : "workflow.updated";
     await logActivity(db, {
       companyId: existing.companyId,
       actorType: actor.actorType,
       actorId: actor.actorId,
-      action: "workflow.updated",
+      action: statusTransitionAction,
       entityType: "workflow",
       entityId: existing.id,
-      details: { title: updated.title },
+      details: {
+        title: updated.title,
+        workflowId: existing.id,
+        ...(existing.status !== updated.status
+          ? { previousStatus: existing.status, newStatus: updated.status }
+          : {}),
+      },
     });
     res.json(updated);
   });

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -85,6 +85,12 @@ export function workflowRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
+    if (existing.status === "archived" && req.body.status !== undefined && req.body.status !== "active") {
+      res.status(409).json({
+        error: "Archived workflows can only be restored to active. Restore the workflow before making other changes.",
+      });
+      return;
+    }
     const updated = await svc.update(existing.id, req.body, { userId: req.actor.userId ?? "board" });
     if (!updated) {
       res.status(404).json({ error: "Workflow not found" });

--- a/server/src/routes/workflows.ts
+++ b/server/src/routes/workflows.ts
@@ -85,7 +85,12 @@ export function workflowRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    if (existing.status === "archived" && req.body.status !== undefined && req.body.status !== "active") {
+    if (
+      existing.status === "archived" &&
+      req.body.status !== undefined &&
+      req.body.status !== existing.status &&
+      req.body.status !== "active"
+    ) {
       res.status(409).json({
         error: "Archived workflows can only be restored to active. Restore the workflow before making other changes.",
       });

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -3636,7 +3636,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     }
 
     if (include.workflows) {
-      const allWorkflows = await workflows.list(companyId);
+      const allWorkflows = await workflows.list(companyId, { includeArchived: true });
       for (const wf of allWorkflows) {
         const runnerConfig = (wf.runnerConfig as Record<string, unknown> | null) ?? {};
         const adkPath = typeof runnerConfig.agentPath === "string" ? runnerConfig.agentPath : "";
@@ -4008,7 +4008,9 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
         }
       }
 
-      const existingWorkflowRows = include.workflows ? await workflows.list(input.target.companyId) : [];
+      const existingWorkflowRows = include.workflows
+        ? await workflows.list(input.target.companyId, { includeArchived: true })
+        : [];
       for (const wf of existingWorkflowRows) {
         existingWorkflowTitleToId.set(wf.title, wf.id);
       }

--- a/server/src/services/workflows.ts
+++ b/server/src/services/workflows.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { and, asc, desc, eq, inArray, isNotNull, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, ne, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   workflowDeliverables,
@@ -35,7 +35,7 @@ import type {
   WorkflowResourceManifest,
 } from "@paperclipai/shared";
 import { resourceRunOverridesSchema, workflowResourceManifestSchema } from "@paperclipai/shared";
-import { unprocessable } from "../errors.js";
+import { conflict, unprocessable } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { getStorageService } from "../storage/index.js";
 import { type StorageService } from "../storage/types.js";
@@ -348,6 +348,12 @@ function formatWorkflowSelectorAttempt(target: WorkflowInvocationTargetSelector)
   return parts.length > 0 ? parts.join(", ") : "no workflow selector";
 }
 
+function assertWorkflowRunnable(workflow: Pick<typeof workflows.$inferSelect, "status" | "title">) {
+  if (workflow.status === "archived") {
+    throw conflict(`Workflow "${workflow.title}" is archived. Restore it before running.`);
+  }
+}
+
 export async function resolveWorkflowByInvocationTarget(
   db: Db,
   companyId: string,
@@ -364,6 +370,7 @@ export async function resolveWorkflowByInvocationTarget(
         `Workflow id not found for this company (attempted ${formatWorkflowSelectorAttempt(target)})`,
       );
     }
+    assertWorkflowRunnable(row);
     return row;
   }
 
@@ -379,6 +386,7 @@ export async function resolveWorkflowByInvocationTarget(
         `Workflow key not found for this company (attempted ${formatWorkflowSelectorAttempt(target)})`,
       );
     }
+    assertWorkflowRunnable(row);
     return row;
   }
 
@@ -396,12 +404,16 @@ export async function resolveWorkflowByInvocationTarget(
         `No workflow matches the requested capability (attempted ${formatWorkflowSelectorAttempt(target)})`,
       );
     }
-    if (rows.length > 1) {
+    const runnableRows = rows.filter((row) => row.status !== "archived");
+    if (runnableRows.length === 0) {
+      assertWorkflowRunnable(rows[0]);
+    }
+    if (runnableRows.length > 1) {
       throw unprocessable(
         `Capability selector is ambiguous; provide a workflow key or workflow id (attempted ${formatWorkflowSelectorAttempt(target)})`,
       );
     }
-    return rows[0] ?? null;
+    return runnableRows[0] ?? null;
   }
 
   throw unprocessable(`Missing workflow selector (attempted ${formatWorkflowSelectorAttempt(target)})`);
@@ -935,8 +947,11 @@ export function workflowService(db: Db) {
       return { failed: rows.length, runIds: failedRunIds };
     },
 
-    list: async (companyId: string): Promise<WorkflowListItem[]> => {
-      const rows = await db.select().from(workflows).where(eq(workflows.companyId, companyId)).orderBy(desc(workflows.updatedAt));
+    list: async (companyId: string, options: { includeArchived?: boolean } = {}): Promise<WorkflowListItem[]> => {
+      const rows = await db.select().from(workflows).where(and(
+        eq(workflows.companyId, companyId),
+        options.includeArchived ? sql`true` : ne(workflows.status, "archived"),
+      )).orderBy(desc(workflows.updatedAt));
       const items = rows.map(toWorkflow);
       const workflowIds = items.map((item) => item.id);
       const latestRunMap = await selectLatestRunMap(db, workflowIds);
@@ -1067,6 +1082,7 @@ export function workflowService(db: Db) {
       if (!workflowRow) {
         throw unprocessable("Workflow not found");
       }
+      assertWorkflowRunnable(workflowRow);
       assertWorkflowRuntimeJwtConfigured();
       const refreshed = await refreshWorkflowAnalysis(workflowRow);
       return launchWorkflowRun(refreshed.workflow, refreshed.analysis, input.inputMarkdown, {
@@ -1083,6 +1099,7 @@ export function workflowService(db: Db) {
       if (!workflowRow) {
         throw unprocessable("Workflow not found");
       }
+      assertWorkflowRunnable(workflowRow);
       assertWorkflowRuntimeJwtConfigured();
       const refreshed = await refreshWorkflowAnalysis(workflowRow);
       const resourceManifest = workflowResourceManifestSchema.safeParse(input.invocationInputJson?.resourceManifest);

--- a/ui/src/api/workflows.ts
+++ b/ui/src/api/workflows.ts
@@ -22,6 +22,10 @@ export interface WorkflowMutationInput {
   runnerConfig: Record<string, unknown>;
 }
 
+export interface WorkflowListOptions {
+  includeArchived?: boolean;
+}
+
 export interface WorkflowInvocationInput {
   sourceRoutineRunId: string;
   invocation: {
@@ -49,12 +53,16 @@ export interface WorkflowScheduleMutationInput {
 }
 
 export const workflowsApi = {
-  list: (companyId: string) => api.get<WorkflowListItem[]>(`/companies/${companyId}/workflows`),
+  list: (companyId: string, options: WorkflowListOptions = {}) => api.get<WorkflowListItem[]>(
+    `/companies/${companyId}/workflows${options.includeArchived ? "?includeArchived=true" : ""}`,
+  ),
   create: (companyId: string, data: WorkflowMutationInput) =>
     api.post<Workflow>(`/companies/${companyId}/workflows`, data),
   get: (id: string) => api.get<WorkflowDetail>(`/workflows/${id}`),
   update: (id: string, data: Partial<WorkflowMutationInput>) =>
     api.patch<Workflow>(`/workflows/${id}`, data),
+  archive: (id: string) => api.patch<Workflow>(`/workflows/${id}`, { status: "archived" }),
+  restore: (id: string) => api.patch<Workflow>(`/workflows/${id}`, { status: "active" }),
   run: (id: string, data: { inputMarkdown: string; resourceManifest?: WorkflowResourceManifest }) =>
     api.post<WorkflowRun>(`/workflows/${id}/run`, data),
   invokeFromRoutine: (routineId: string, data: WorkflowInvocationInput) =>

--- a/ui/src/pages/WorkflowDetail.test.tsx
+++ b/ui/src/pages/WorkflowDetail.test.tsx
@@ -576,6 +576,25 @@ describe("WorkflowDetail page", () => {
     );
   });
 
+  it("keeps archived workflow history visible but disables new runs", async () => {
+    getWorkflowMock.mockResolvedValueOnce({
+      ...workflowDetail,
+      status: "archived",
+    });
+
+    await renderAt(container, "/workflows/workflow-1");
+    await flushReact();
+    await flushReact();
+
+    const runButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("Run workflow"));
+
+    expect(runButton).toBeTruthy();
+    expect(runButton?.disabled).toBe(true);
+    expect(container.textContent).toContain("Workflow archived. Restore it before starting new runs.");
+    expect(container.textContent).toContain("Latest run summary");
+  });
+
   it("shows stderr details by default and still lets the user collapse them", async () => {
     await renderAt(container, "/workflows/workflow-1");
     await flushReact();

--- a/ui/src/pages/WorkflowDetail.tsx
+++ b/ui/src/pages/WorkflowDetail.tsx
@@ -1591,7 +1591,7 @@ export function WorkflowDetail() {
                   <Button
                     onClick={() => runMutation.mutate()}
                     disabled={
-                      runMutation.isPending || inputMarkdown.trim().length === 0
+                      workflow.status === "archived" || runMutation.isPending || inputMarkdown.trim().length === 0
                     }
                   >
                     {runMutation.isPending ? (
@@ -1602,6 +1602,11 @@ export function WorkflowDetail() {
                     Run workflow
                   </Button>
                 </div>
+                {workflow.status === "archived" ? (
+                  <p className="text-xs text-muted-foreground">
+                    Workflow archived. Restore it before starting new runs. Existing runs and history remain available.
+                  </p>
+                ) : null}
               </CardContent>
             </Card>
 
@@ -1671,7 +1676,7 @@ export function WorkflowDetail() {
                     className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
                   >
                     <option value="active">Active</option>
-                    <option value="paused">Paused</option>
+                    {editDraft.status !== "archived" ? <option value="paused">Paused</option> : null}
                     <option value="archived">Archived</option>
                   </select>
                 </div>

--- a/ui/src/pages/Workflows.test.tsx
+++ b/ui/src/pages/Workflows.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { WorkflowListItem } from "@paperclipai/shared";
-import { filterWorkflowItems } from "./Workflows";
+import { filterWorkflowItems, getWorkflowEmptyStateMessage } from "./Workflows";
 
 function workflow(status: string, id: string): WorkflowListItem {
   return {
@@ -36,5 +36,12 @@ describe("workflow list archival filter", () => {
 
   it("shows all workflows in all view", () => {
     expect(filterWorkflowItems(items, "all").map((item) => item.id)).toEqual(["active-1", "paused-1", "archived-1"]);
+  });
+
+  it("explains when active view contains only archived workflows", () => {
+    expect(getWorkflowEmptyStateMessage([workflow("archived", "archived-1")], "active"))
+      .toBe("All workflows are archived. Switch to the Archived view to see them.");
+    expect(getWorkflowEmptyStateMessage([], "active"))
+      .toContain("No workflows yet.");
   });
 });

--- a/ui/src/pages/Workflows.test.tsx
+++ b/ui/src/pages/Workflows.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
 
-import { act } from "react";
+import { act, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 import type { WorkflowListItem } from "@paperclipai/shared";
-import { ArchiveConfirmation, filterWorkflowItems, getWorkflowEmptyStateMessage } from "./Workflows";
+import { ArchiveConfirmation, filterWorkflowItems, getWorkflowEmptyStateMessage, WorkflowCard } from "./Workflows";
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ to, children, ...props }: { to: string; children: ReactNode }) => <a href={to} {...props}>{children}</a>,
+}));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -70,6 +74,56 @@ describe("workflow list archival filter", () => {
     });
     expect(onCancel).toHaveBeenCalledOnce();
     expect(onConfirm).toHaveBeenCalledOnce();
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("renders lifecycle actions and shared status treatment by workflow state", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const onArchive = vi.fn();
+    const onRestore = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <WorkflowCard
+          item={workflow("active", "active-1")}
+          archiveConfirmationOpen={false}
+          onArchive={onArchive}
+          onConfirmArchive={vi.fn()}
+          onCancelArchive={vi.fn()}
+          onRestore={onRestore}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("active");
+    expect(container.textContent).toContain("Archive");
+    expect(container.textContent).not.toContain("Restore");
+    expect(container.querySelector('[data-slot="card"]')?.className).toContain("rounded-xl");
+    container.querySelector("button")?.click();
+    expect(onArchive).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root.render(
+        <WorkflowCard
+          item={workflow("archived", "archived-1")}
+          archiveConfirmationOpen={false}
+          onArchive={onArchive}
+          onConfirmArchive={vi.fn()}
+          onCancelArchive={vi.fn()}
+          onRestore={onRestore}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("archived");
+    expect(container.textContent).toContain("Restore");
+    expect(Array.from(container.querySelectorAll("button")).map((button) => button.textContent)).not.toContain("Archive");
+    container.querySelector("button")?.click();
+    expect(onRestore).toHaveBeenCalledOnce();
+
     await act(async () => {
       root.unmount();
     });

--- a/ui/src/pages/Workflows.test.tsx
+++ b/ui/src/pages/Workflows.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { WorkflowListItem } from "@paperclipai/shared";
+import { filterWorkflowItems } from "./Workflows";
+
+function workflow(status: string, id: string): WorkflowListItem {
+  return {
+    id,
+    companyId: "company-1",
+    title: id,
+    description: null,
+    status,
+    runnerType: "google_adk",
+    runnerConfig: {},
+    pipelineDefinition: { entrypoint: "agent.py", generatedAt: new Date(0).toISOString(), phases: [] },
+    pipelineSourceHash: null,
+    createdByUserId: null,
+    updatedByUserId: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    latestRun: null,
+    currentPhase: null,
+    latestDeliverable: null,
+  };
+}
+
+describe("workflow list archival filter", () => {
+  const items = [workflow("active", "active-1"), workflow("paused", "paused-1"), workflow("archived", "archived-1")];
+
+  it("excludes archived workflows from default active view", () => {
+    expect(filterWorkflowItems(items, "active").map((item) => item.id)).toEqual(["active-1", "paused-1"]);
+  });
+
+  it("shows only archived workflows in archived view", () => {
+    expect(filterWorkflowItems(items, "archived").map((item) => item.id)).toEqual(["archived-1"]);
+  });
+
+  it("shows all workflows in all view", () => {
+    expect(filterWorkflowItems(items, "all").map((item) => item.id)).toEqual(["active-1", "paused-1", "archived-1"]);
+  });
+});

--- a/ui/src/pages/Workflows.test.tsx
+++ b/ui/src/pages/Workflows.test.tsx
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
 import type { WorkflowListItem } from "@paperclipai/shared";
-import { filterWorkflowItems, getWorkflowEmptyStateMessage } from "./Workflows";
+import { ArchiveConfirmation, filterWorkflowItems, getWorkflowEmptyStateMessage } from "./Workflows";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 function workflow(status: string, id: string): WorkflowListItem {
   return {
@@ -43,5 +50,28 @@ describe("workflow list archival filter", () => {
       .toBe("All workflows are archived. Switch to the Archived view to see them.");
     expect(getWorkflowEmptyStateMessage([], "active"))
       .toContain("No workflows yet.");
+  });
+
+  it("renders inline archive confirmation and exposes confirm/cancel actions", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    await act(async () => {
+      root.render(<ArchiveConfirmation title="Social" onConfirm={onConfirm} onCancel={onCancel} />);
+    });
+
+    expect(container.textContent).toContain("Runs and history remain available.");
+    const buttons = Array.from(container.querySelectorAll("button"));
+    await act(async () => {
+      buttons.find((button) => button.textContent === "Cancel")?.click();
+      buttons.find((button) => button.textContent === "Archive workflow")?.click();
+    });
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onConfirm).toHaveBeenCalledOnce();
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/ui/src/pages/Workflows.tsx
+++ b/ui/src/pages/Workflows.tsx
@@ -59,6 +59,7 @@ export function Workflows() {
   const [draft, setDraft] = useState<WorkflowCreateDraft>(defaultDraft);
   const [clickUpWarnDismissed, setClickUpWarnDismissed] = useState(false);
   const [workflowFilter, setWorkflowFilter] = useState<WorkflowFilter>("active");
+  const [archiveConfirmationId, setArchiveConfirmationId] = useState<string | null>(null);
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Workflows" }]);
@@ -300,11 +301,13 @@ export function Workflows() {
             <WorkflowCard
               key={item.id}
               item={item}
-              onArchive={() => {
-                if (window.confirm(`Archive workflow "${item.title}"? Existing runs and history remain available. New runs stop; in-flight runs finish.`)) {
-                  statusMutation.mutate({ id: item.id, status: "archived" });
-                }
+              archiveConfirmationOpen={archiveConfirmationId === item.id}
+              onArchive={() => setArchiveConfirmationId(item.id)}
+              onConfirmArchive={() => {
+                setArchiveConfirmationId(null);
+                statusMutation.mutate({ id: item.id, status: "archived" });
               }}
+              onCancelArchive={() => setArchiveConfirmationId(null)}
               onRestore={() => statusMutation.mutate({ id: item.id, status: "active" })}
             />
           ))}
@@ -314,13 +317,19 @@ export function Workflows() {
   );
 }
 
-function WorkflowCard({
+export function WorkflowCard({
   item,
+  archiveConfirmationOpen,
   onArchive,
+  onConfirmArchive,
+  onCancelArchive,
   onRestore,
 }: {
   item: WorkflowListItem;
+  archiveConfirmationOpen: boolean;
   onArchive: () => void;
+  onConfirmArchive: () => void;
+  onCancelArchive: () => void;
   onRestore: () => void;
 }) {
   return (
@@ -388,8 +397,14 @@ function WorkflowCard({
             />
           </div>
         </Link>
-        <div className="flex justify-end border-t border-border/70 pt-3">
-          {item.status === "archived" ? (
+        <div className="border-t border-border/70 pt-3">
+          {archiveConfirmationOpen ? (
+            <ArchiveConfirmation
+              title={item.title}
+              onConfirm={onConfirmArchive}
+              onCancel={onCancelArchive}
+            />
+          ) : item.status === "archived" ? (
             <Button variant="outline" size="sm" onClick={onRestore}>
               <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
               Restore
@@ -403,6 +418,31 @@ function WorkflowCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+export function ArchiveConfirmation({
+  title,
+  onConfirm,
+  onCancel,
+}: {
+  title: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div role="alertdialog" aria-label={`Archive workflow ${title}`} className="space-y-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3">
+      <div>
+        <p className="text-sm font-medium">Archive “{title}”?</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Runs and history remain available. New runs stop; in-flight runs finish.
+        </p>
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onCancel}>Cancel</Button>
+        <Button variant="outline" size="sm" onClick={onConfirm}>Archive workflow</Button>
+      </div>
+    </div>
   );
 }
 

--- a/ui/src/pages/Workflows.tsx
+++ b/ui/src/pages/Workflows.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@/lib/router";
-import { AlertTriangle, GitBranch, Play, Plus, Sparkles, Workflow as WorkflowIcon, X } from "lucide-react";
+import { AlertTriangle, Archive, GitBranch, Play, Plus, RotateCcw, Sparkles, Workflow as WorkflowIcon, X } from "lucide-react";
 import type { WorkflowListItem } from "@paperclipai/shared";
 import { workflowsApi } from "../api/workflows";
 import { companyAwaitingHumanSettingsApi } from "../api/companyAwaitingHumanSettings";
@@ -27,6 +27,14 @@ type WorkflowCreateDraft = {
   model: string;
 };
 
+type WorkflowFilter = "active" | "archived" | "all";
+
+export function filterWorkflowItems(items: WorkflowListItem[], filter: WorkflowFilter) {
+  return items.filter((item) => filter === "all" || (filter === "archived"
+    ? item.status === "archived"
+    : item.status !== "archived"));
+}
+
 const defaultDraft: WorkflowCreateDraft = {
   title: "",
   description: "",
@@ -44,6 +52,7 @@ export function Workflows() {
   const navigate = useNavigate();
   const [draft, setDraft] = useState<WorkflowCreateDraft>(defaultDraft);
   const [clickUpWarnDismissed, setClickUpWarnDismissed] = useState(false);
+  const [workflowFilter, setWorkflowFilter] = useState<WorkflowFilter>("active");
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Workflows" }]);
@@ -70,7 +79,7 @@ export function Workflows() {
 
   const workflowsQuery = useQuery({
     queryKey: queryKeys.workflows.list(selectedCompanyId ?? ""),
-    queryFn: () => workflowsApi.list(selectedCompanyId!),
+    queryFn: () => workflowsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
     refetchInterval: (query) => {
       const items = (query.state.data ?? []) as WorkflowListItem[];
@@ -106,7 +115,37 @@ export function Workflows() {
     },
   });
 
+  const statusMutation = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: "archived" | "active" }) =>
+      status === "archived" ? workflowsApi.archive(id) : workflowsApi.restore(id),
+    onSuccess: async (updated) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.workflows.list(selectedCompanyId!) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.workflows.detail(updated.id) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.workflows.schedules(updated.id) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.workflows.activity(selectedCompanyId!, updated.id) }),
+      ]);
+      pushToast({
+        title: updated.status === "archived" ? "Workflow archived" : "Workflow restored",
+        body: updated.title,
+        tone: "success",
+      });
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Failed to update workflow status",
+        body: error instanceof Error ? error.message : String(error),
+        tone: "error",
+      });
+    },
+  });
+
   const items = workflowsQuery.data ?? [];
+  const archivedCount = items.filter((item) => item.status === "archived").length;
+  const visibleItems = useMemo(
+    () => filterWorkflowItems(items, workflowFilter),
+    [items, workflowFilter],
+  );
   const activeCount = useMemo(
     () => items.filter((item) => item.latestRun && ["queued", "running", "awaiting_human"].includes(item.latestRun.status)).length,
     [items],
@@ -149,9 +188,21 @@ export function Workflows() {
           <h1 className="text-xl font-semibold">Workflows</h1>
           <p className="text-sm text-muted-foreground">
             Company-scoped ADK automations with live pipeline runs and workflow-backed deliverables.
-            {items.length > 0 ? ` ${items.length} total, ${activeCount} active.` : ""}
+            {items.length > 0 ? ` ${items.length} total, ${activeCount} active${archivedCount > 0 ? `, ${archivedCount} archived` : ""}.` : ""}
           </p>
         </div>
+        <label className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span>Show</span>
+          <select
+            value={workflowFilter}
+            onChange={(event) => setWorkflowFilter(event.target.value as WorkflowFilter)}
+            className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+          >
+            <option value="active">Active</option>
+            <option value="archived">Archived</option>
+            <option value="all">All</option>
+          </select>
+        </label>
       </div>
 
       <Card className="overflow-hidden">
@@ -232,15 +283,26 @@ export function Workflows() {
         </p>
       ) : null}
 
-      {items.length === 0 ? (
+      {visibleItems.length === 0 ? (
         <EmptyState
           icon={Sparkles}
-          message="No workflows yet. Create one and point it at a Google ADK project to generate its first pipeline."
+          message={workflowFilter === "archived"
+            ? "No archived workflows."
+            : "No workflows yet. Create one and point it at a Google ADK project to generate its first pipeline."}
         />
       ) : (
         <div className="grid gap-4 xl:grid-cols-2">
-          {items.map((item) => (
-            <WorkflowCard key={item.id} item={item} />
+          {visibleItems.map((item) => (
+            <WorkflowCard
+              key={item.id}
+              item={item}
+              onArchive={() => {
+                if (window.confirm(`Archive workflow "${item.title}"? Existing runs and history remain available. New runs stop; in-flight runs finish.`)) {
+                  statusMutation.mutate({ id: item.id, status: "archived" });
+                }
+              }}
+              onRestore={() => statusMutation.mutate({ id: item.id, status: "active" })}
+            />
           ))}
         </div>
       )}
@@ -248,11 +310,19 @@ export function Workflows() {
   );
 }
 
-function WorkflowCard({ item }: { item: WorkflowListItem }) {
+function WorkflowCard({
+  item,
+  onArchive,
+  onRestore,
+}: {
+  item: WorkflowListItem;
+  onArchive: () => void;
+  onRestore: () => void;
+}) {
   return (
-    <Link to={`/workflows/${item.id}`} className="no-underline text-inherit">
-      <Card className="h-full transition-colors hover:border-foreground/30">
-        <CardContent className="space-y-4 p-5">
+    <Card className="h-full transition-colors hover:border-foreground/30">
+      <CardContent className="space-y-4 p-5">
+        <Link to={`/workflows/${item.id}`} className="block no-underline text-inherit">
           <div className="flex items-start justify-between gap-3">
             <div className="space-y-1">
               <div className="flex items-center gap-2">
@@ -313,9 +383,22 @@ function WorkflowCard({ item }: { item: WorkflowListItem }) {
               hint={item.latestDeliverable ? formatDateTime(item.latestDeliverable.createdAt) : null}
             />
           </div>
-        </CardContent>
-      </Card>
-    </Link>
+        </Link>
+        <div className="flex justify-end border-t border-border/70 pt-3">
+          {item.status === "archived" ? (
+            <Button variant="outline" size="sm" onClick={onRestore}>
+              <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+              Restore
+            </Button>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={onArchive}>
+              <Archive className="mr-1.5 h-3.5 w-3.5" />
+              Archive
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/ui/src/pages/Workflows.tsx
+++ b/ui/src/pages/Workflows.tsx
@@ -35,6 +35,12 @@ export function filterWorkflowItems(items: WorkflowListItem[], filter: WorkflowF
     : item.status !== "archived"));
 }
 
+export function getWorkflowEmptyStateMessage(items: WorkflowListItem[], filter: WorkflowFilter) {
+  if (filter === "archived") return "No archived workflows.";
+  if (items.length > 0) return "All workflows are archived. Switch to the Archived view to see them.";
+  return "No workflows yet. Create one and point it at a Google ADK project to generate its first pipeline.";
+}
+
 const defaultDraft: WorkflowCreateDraft = {
   title: "",
   description: "",
@@ -78,7 +84,7 @@ export function Workflows() {
   })();
 
   const workflowsQuery = useQuery({
-    queryKey: queryKeys.workflows.list(selectedCompanyId ?? ""),
+    queryKey: [...queryKeys.workflows.list(selectedCompanyId ?? ""), { includeArchived: true }],
     queryFn: () => workflowsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
     refetchInterval: (query) => {
@@ -286,9 +292,7 @@ export function Workflows() {
       {visibleItems.length === 0 ? (
         <EmptyState
           icon={Sparkles}
-          message={workflowFilter === "archived"
-            ? "No archived workflows."
-            : "No workflows yet. Create one and point it at a Google ADK project to generate its first pipeline."}
+          message={getWorkflowEmptyStateMessage(items, workflowFilter)}
         />
       ) : (
         <div className="grid gap-4 xl:grid-cols-2">

--- a/ui/src/pages/Workflows.tsx
+++ b/ui/src/pages/Workflows.tsx
@@ -17,6 +17,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { StatusBadge } from "../components/StatusBadge";
 
 type WorkflowCreateDraft = {
   title: string;
@@ -212,7 +213,7 @@ export function Workflows() {
         </label>
       </div>
 
-      <Card className="overflow-hidden">
+      <Card className="overflow-hidden rounded-xl">
         <CardHeader>
           <CardTitle className="text-base">Create workflow</CardTitle>
         </CardHeader>
@@ -296,7 +297,7 @@ export function Workflows() {
           message={getWorkflowEmptyStateMessage(items, workflowFilter)}
         />
       ) : (
-        <div className="grid gap-4 xl:grid-cols-2">
+        <div className="grid items-start gap-4 xl:grid-cols-2">
           {visibleItems.map((item) => (
             <WorkflowCard
               key={item.id}
@@ -333,10 +334,10 @@ export function WorkflowCard({
   onRestore: () => void;
 }) {
   return (
-    <Card className="h-full transition-colors hover:border-foreground/30">
-      <CardContent className="space-y-4 p-5">
+    <Card className="gap-0 rounded-xl py-0 transition-colors hover:border-foreground/30">
+      <CardContent className="space-y-3 p-4 pb-3">
         <Link to={`/workflows/${item.id}`} className="block no-underline text-inherit">
-          <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start justify-between gap-3 pb-3">
             <div className="space-y-1">
               <div className="flex items-center gap-2">
                 <WorkflowIcon className="h-4 w-4 text-muted-foreground" />
@@ -346,10 +347,10 @@ export function WorkflowCard({
                 <p className="text-sm text-muted-foreground line-clamp-2">{item.description}</p>
               ) : null}
             </div>
-            <StatusPill status={item.status} />
+            <StatusBadge status={item.status} />
           </div>
 
-          <div className="rounded-xl border border-border/70 bg-muted/20 p-3">
+          <div className="border-y border-border/70 pb-4 pt-2.5">
             <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
               <span>Pipeline</span>
               <span>{item.pipelineDefinition.phases.length} phases</span>
@@ -360,8 +361,8 @@ export function WorkflowCard({
                 return (
                   <div
                     key={phase.key}
-                    className={`rounded-full border px-3 py-1 text-xs ${
-                      isCurrent ? "border-amber-500 bg-amber-500/10 text-amber-100 animate-pulse" : "border-border bg-background"
+                    className={`rounded-md border px-2.5 py-1 text-xs ${
+                      isCurrent ? "border-amber-500/60 bg-amber-500/10 text-amber-100" : "border-border bg-muted/30 text-muted-foreground"
                     }`}
                   >
                     {phase.label}
@@ -369,14 +370,14 @@ export function WorkflowCard({
                 );
               })}
               {item.pipelineDefinition.phases.length > 4 ? (
-                <div className="rounded-full border border-border px-3 py-1 text-xs text-muted-foreground">
+                <div className="rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground">
                   +{item.pipelineDefinition.phases.length - 4} more
                 </div>
               ) : null}
             </div>
           </div>
 
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid divide-y divide-border/70 sm:grid-cols-3 sm:divide-x sm:divide-y-0">
             <InfoBlock
               icon={<Play className="h-3.5 w-3.5" />}
               label="Latest run"
@@ -397,7 +398,9 @@ export function WorkflowCard({
             />
           </div>
         </Link>
-        <div className="border-t border-border/70 pt-3">
+      </CardContent>
+      <footer className="border-t border-border/70 px-4 py-2">
+        <div className="w-full">
           {archiveConfirmationOpen ? (
             <ArchiveConfirmation
               title={item.title}
@@ -410,13 +413,15 @@ export function WorkflowCard({
               Restore
             </Button>
           ) : (
-            <Button variant="ghost" size="sm" onClick={onArchive}>
-              <Archive className="mr-1.5 h-3.5 w-3.5" />
-              Archive
-            </Button>
+            <div className="flex justify-end">
+              <Button variant="ghost" size="sm" onClick={onArchive}>
+                <Archive className="mr-1.5 h-3.5 w-3.5" />
+                Archive
+              </Button>
+            </div>
           )}
         </div>
-      </CardContent>
+      </footer>
     </Card>
   );
 }
@@ -431,14 +436,14 @@ export function ArchiveConfirmation({
   onCancel: () => void;
 }) {
   return (
-    <div role="alertdialog" aria-label={`Archive workflow ${title}`} className="space-y-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3">
-      <div>
+    <div role="alertdialog" aria-label={`Archive workflow ${title}`} className="flex flex-col gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-2.5 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
         <p className="text-sm font-medium">Archive “{title}”?</p>
         <p className="mt-1 text-xs text-muted-foreground">
           Runs and history remain available. New runs stop; in-flight runs finish.
         </p>
       </div>
-      <div className="flex justify-end gap-2">
+      <div className="flex shrink-0 justify-end gap-2">
         <Button variant="ghost" size="sm" onClick={onCancel}>Cancel</Button>
         <Button variant="outline" size="sm" onClick={onConfirm}>Archive workflow</Button>
       </div>
@@ -458,7 +463,7 @@ function InfoBlock({
   hint: string | null;
 }) {
   return (
-    <div className="rounded-lg border border-border/70 bg-background p-3">
+    <div className="min-w-0 px-3 py-1.5 first:pl-0 last:pr-0">
       <div className="mb-1 flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
         {icon}
         <span>{label}</span>
@@ -466,18 +471,5 @@ function InfoBlock({
       <div className="text-sm font-medium text-foreground">{value}</div>
       {hint ? <div className="mt-1 text-xs text-muted-foreground">{hint}</div> : null}
     </div>
-  );
-}
-
-function StatusPill({ status }: { status: string }) {
-  const tone = status === "active"
-    ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
-    : status === "paused"
-      ? "border-amber-500/40 bg-amber-500/10 text-amber-100"
-      : "border-border bg-muted text-muted-foreground";
-  return (
-    <span className={`rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${tone}`}>
-      {status.replaceAll("_", " ")}
-    </span>
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Bizbox orchestrates AI agents for zero-human companies.
> - Workflow orchestration defines reusable, runnable company automation.
> - Workflows already had an `archived` status, but runtime/list/UI behavior treated it as incomplete metadata.
> - That gap allowed stale workflows to remain launchable and gave operators no safe archival lifecycle.
> - This pull request completes soft archival across DB-backed services, invocation/scheduler paths, API activity, UI, tests, and implementation docs.
> - The benefit is reversible, auditable workflow retirement without deleting history or interrupting in-flight runs.

## What Changed

- Exclude archived workflows from default API lists; support `includeArchived=true` for explicit historical access.
- Block new manual, routine, capability, and scheduled launches for archived workflows with `409 Conflict`.
- Preserve queued/running/awaiting-human runs, schedules, deliverables, history, and portability data.
- Add dedicated `workflow.archived` and `workflow.restored` activity events with status transition details.
- Enforce archived workflow transitions: restore only to `active`; unchanged archived status permits metadata edits.
- Add UI Active/Archived/All filters, archive confirmation, restore action, archived run protection, and query invalidation.
- Add regression tests and update `doc/SPEC-implementation.md`.

## Verification

- `pnpm exec vitest run server/src/__tests__/workflows-routes.test.ts ui/src/pages/Workflows.test.tsx` — 13/13 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm -r typecheck` and production build passed before final review fixes.
- Full `pnpm test` baseline: 2,603 passed; unrelated pre-existing localStorage/test-fixture failures remain in 6 files.
- Greptile findings addressed through commits `5df39607` and `f6ab6f59`; latest review dispatched before PR creation and pending backend score retrieval.

## Risks

- Archived workflows are hidden by default but remain explicitly retrievable; clients must use `includeArchived=true` for history/export views.
- Restoring always returns `active`, so retained active schedules become eligible again.
- In-flight runs can finish after archive and update visible history by design.
- No migration or hard-delete behavior introduced.

## Model Used

- OpenAI Codex, GPT-5, agentic code execution with repository inspection, test execution, and GitHub CLI integration.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run focused tests locally and they pass; full-suite baseline failures are documented above
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — not included; behavior covered by UI tests
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
