### PR TITLE
Record July 2026 syndication metrics

### DIFF
--- a/community/metrics/2026-07.md
+++ b/community/metrics/2026-07.md
@@ -18,3 +18,14 @@ artifacts:
 
 experiments_run:
 
+  - title: "Bizbox Build Log — Week of 2026-05-31"
+    kind: weekly_build_log
+    slug: bizbox-build-log-2026-05-31
+    channels:
+      github-discussions: "skipped — publisher-not-implemented"
+      devto: "https://dev.to/joincitro/bizbox-build-log-week-of-2026-05-31-4eae"
+      discourse: "error — forum host unreachable during publish attempt"
+      x: ""
+      linkedin: ""
+    participation: 0
+    notes: "Published 2026-07-23 after confirming status: approved on the landed master artifact. Dev.to publish succeeded. Discourse was not reached after the CLI metrics-path failure; follow-up retry is required once DISCOURSE_BASE_URL resolves."


### PR DESCRIPTION
Records the approved Build Log 2026-05-31 syndication result: Dev.to published, Discourse unavailable, GitHub Discussions publisher unimplemented.