### PR TITLE
docs: Build Log — week of 16 July 2026

### DIFF
--- a/community/build-logs/2026-07-23.md
+++ b/community/build-logs/2026-07-23.md
@@ -1,0 +1,121 @@
+---
+slug: build-log-2026-07-23
+channels: [discourse, devto, x]
+date: 2026-07-23
+week: "2026-07-16"
+---
+
+# Build Log — Week of 16 July 2026
+
+This week we made the workflow runtime more useful in the places that matter
+once automation leaves the demo: working with real company resources, retiring
+old workflows safely, and carrying larger human handoffs without losing the
+message on the way through. We also tightened dependency hygiene and fixed a
+production UI bundling regression.
+
+## Shipped this week
+
+**Merged PRs:** [#123](https://github.com/zesthq/bizbox/pull/123), [#125](https://github.com/zesthq/bizbox/pull/125), [#135](https://github.com/zesthq/bizbox/pull/135), [#136](https://github.com/zesthq/bizbox/pull/136), [#137](https://github.com/zesthq/bizbox/pull/137), [#138](https://github.com/zesthq/bizbox/pull/138), [#139](https://github.com/zesthq/bizbox/pull/139), [#140](https://github.com/zesthq/bizbox/pull/140), [#141](https://github.com/zesthq/bizbox/pull/141), [#142](https://github.com/zesthq/bizbox/pull/142), [#143](https://github.com/zesthq/bizbox/pull/143), [#144](https://github.com/zesthq/bizbox/pull/144), [#145](https://github.com/zesthq/bizbox/pull/145), [#151](https://github.com/zesthq/bizbox/pull/151), [#152](https://github.com/zesthq/bizbox/pull/152), [#153](https://github.com/zesthq/bizbox/pull/153), [#154](https://github.com/zesthq/bizbox/pull/154), and [#157](https://github.com/zesthq/bizbox/pull/157).
+
+**Company-scoped Resources** ([PR #145](https://github.com/zesthq/bizbox/pull/145), released in [v2026.721.0](https://github.com/zesthq/bizbox/releases/tag/v2026.721.0))
+
+Resources are now first-class workflow inputs and outputs. A workflow can
+check out a Git-backed Resource into its isolated runtime, make changes, and
+publish them as a push or pull request. The control plane owns Resource CRUD,
+validation, audit events, archive behavior, and opaque credential references;
+the workflow itself does not need to know about Git internals. Run history now
+records publication metadata, making the path from automation to reviewable
+code easier to follow.
+
+**Workflow archival lifecycle** ([PR #154](https://github.com/zesthq/bizbox/pull/154), released in [v2026.723.0](https://github.com/zesthq/bizbox/releases/tag/v2026.723.0))
+
+Archived workflows are now genuinely retired without being deleted. They are
+hidden from normal lists, blocked from new manual, routine, capability, and
+scheduled launches, and still available through explicit historical access.
+Existing runs, schedules, deliverables, and portability data remain intact.
+Operators get Active / Archived / All filters, confirmation before archive,
+and a restore action. In-flight runs are allowed to finish and remain visible.
+
+**Larger human handoffs** ([PR #153](https://github.com/zesthq/bizbox/pull/153), released in [v2026.723.1](https://github.com/zesthq/bizbox/releases/tag/v2026.723.1))
+
+ClickUp-backed handoffs can now carry more questions and much larger message
+bodies. The reply reader also follows up to 100 paginated pages, up from 20.
+That gives operators room to explain a decision without the transport silently
+truncating the context.
+
+**Production UI compatibility fix** ([PR #157](https://github.com/zesthq/bizbox/pull/157), released in [v2026.723.2](https://github.com/zesthq/bizbox/releases/tag/v2026.723.2))
+
+We pinned the UI to patched Vite 6.4.2 after the Vite 8 production bundle
+reproduced a `Prism is not defined` failure in the Lexical code-highlighting
+path. The production build now completes against the known-good bundle shape,
+while retaining the security fix in Vite 6.4.2.
+
+**Dependency hygiene** ([PRs #125](https://github.com/zesthq/bizbox/pull/125), [#135](https://github.com/zesthq/bizbox/pull/135), [#136](https://github.com/zesthq/bizbox/pull/136), [#137](https://github.com/zesthq/bizbox/pull/137), [#138](https://github.com/zesthq/bizbox/pull/138), [#139](https://github.com/zesthq/bizbox/pull/139), [#140](https://github.com/zesthq/bizbox/pull/140), [#141](https://github.com/zesthq/bizbox/pull/141), [#142](https://github.com/zesthq/bizbox/pull/142), [#143](https://github.com/zesthq/bizbox/pull/143), [#144](https://github.com/zesthq/bizbox/pull/144), [#151](https://github.com/zesthq/bizbox/pull/151), and [#152](https://github.com/zesthq/bizbox/pull/152); release [v2026.723.3](https://github.com/zesthq/bizbox/releases/tag/v2026.723.3))
+
+The dependency sweep refreshed packages across the server, UI, CLI, database,
+and plugin examples. Dependabot now checks daily and keeps one update PR open
+at a time, reducing review noise. The set included security and compatibility
+updates across Vite, esbuild, Drizzle, Better Auth, Vitest, Storybook, and the
+supporting toolchain.
+
+## Decisions
+
+- **Resources are company-scoped and workflow-agnostic.** The control plane
+  owns checkout, credentials, and publication while workflow configuration only
+  describes which Resource goes in and what output action is requested. This
+  keeps reusable workflows independent of Git provider details. ([PR #145](https://github.com/zesthq/bizbox/pull/145))
+- **Archiving is soft and reversible.** We preserve history and portability,
+  hide archived workflows by default, and make launches fail explicitly until a
+  workflow is restored. ([PR #154](https://github.com/zesthq/bizbox/pull/154))
+- **Dependency updates trade batch size for reviewability.** Daily checks with
+  one open Dependabot PR at a time should keep changes moving without creating
+  a queue that nobody can meaningfully inspect. ([PR #152](https://github.com/zesthq/bizbox/pull/152))
+- **Vite stays on a patched 6.x line for now.** Compatibility with the
+  production Lexical bundle wins until a future major upgrade includes a
+  production build and browser smoke check. ([PR #157](https://github.com/zesthq/bizbox/pull/157))
+
+## Trade-offs
+
+- Resource publication is intentionally strict: credential resolution,
+  provider availability, ref divergence, and publication failures can fail the
+  workflow rather than quietly producing an untracked result. That favors
+  auditability over best-effort output. ([PR #145](https://github.com/zesthq/bizbox/pull/145))
+- Archived workflows remain retrievable with `includeArchived=true`, and an
+  active schedule becomes eligible again after restore. Consumers need to make
+  that explicit in history and export views. ([PR #154](https://github.com/zesthq/bizbox/pull/154))
+- The Vite fix pins one workspace to Vite 6.4.2 while other tooling may still
+  resolve Vite 8 entries. That is a deliberate compatibility boundary, but it
+  adds a follow-up obligation for the next bundler upgrade. ([PR #157](https://github.com/zesthq/bizbox/pull/157))
+- The broad dependency batch improves freshness but increases the surface area
+  of a single review. Focused follow-up PRs and the new one-at-a-time policy
+  should make the next cycle easier to reason about. ([PRs #125](https://github.com/zesthq/bizbox/pull/125) and [#152](https://github.com/zesthq/bizbox/pull/152))
+
+## Open challenges
+
+- **Release pipeline reliability:** Several PR and Release workflow runs were
+  red or cancelled during this window even when the merged change later had
+  successful Docker or production-build signals. The release workflow needs a
+  clear, public explanation of which failures are expected environment gates
+  and which block shipping. See [the CI run history](https://github.com/zesthq/bizbox/actions).
+- **Resource provider coverage:** Git publication currently depends on
+  server-side credential resolution and provider API availability. More
+  provider-level integration coverage would make failure modes easier to
+  diagnose. ([PR #145](https://github.com/zesthq/bizbox/pull/145))
+- **Vite upgrade path:** Before moving the UI back to a newer Vite major, add a
+  production browser smoke check for the Prism/Lexical path. ([PR #157](https://github.com/zesthq/bizbox/pull/157))
+- **No new issue was returned by the GitHub closed-issues query for this
+  window.** That is useful context, but it also means unresolved work is
+  represented here through PR risk notes and CI signals rather than a neatly
+  labelled issue list.
+
+## Reviewer notes
+
+- **For Dennis:** Please review the wording around the `Prism is not defined`
+  production regression, the Vite security-fix rationale, and the release-pipeline
+  failures before publication. These are accurate, public-facing details but
+  are the most brand-sensitive parts of this week's story.
+- The draft contains no credentials, internal incident identifiers, customer
+  data, or private operational details. It describes only merged public PRs,
+  tagged releases, and aggregate CI outcomes returned by GitHub.
+
+<!-- Source data: bizbox-build-log-summarizer, repo=zesthq/bizbox, since=2026-07-16T00:00:00Z, until=2026-07-23T23:59:59Z. -->


### PR DESCRIPTION
## Summary

Adds the weekly public Build Log for the 7-day window ending 23 July 2026.

- Covers merged PRs, releases, and CI signals returned by the Build Log summarizer
- Sections the draft as Shipped this week / Decisions / Trade-offs / Open challenges
- Includes Dennis reviewer notes for the Vite production regression and release-pipeline failures
- Does not publish or syndicate content

Source issue: CITA-8