### PR TITLE
feat(clickup): include reply attachments in human feedback

### DIFF
--- a/server/src/__tests__/clickup-awaiting-human-transport.test.ts
+++ b/server/src/__tests__/clickup-awaiting-human-transport.test.ts
@@ -359,6 +359,87 @@ describe("getClickUpChatMessageReplies", () => {
     ]);
   });
 
+  it("extracts generic attachments from attachment-like reply fields", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const briefUrl = "https://t90161423646.p.clickup-attachments.com/t90161423646/brief.pdf?view=open";
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: "reply-row-1",
+            parent_message: "message-42",
+            content: "Use the attached brief.",
+            attachments: [
+              {
+                id: "attachment-1",
+                title: "brief.pdf",
+                mime_type: "application/pdf",
+                url: briefUrl,
+              },
+            ],
+            links: {
+              reactions: "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/reply-row-1/reactions",
+            },
+          },
+        ],
+      }),
+    }) as typeof fetch;
+
+    const result = await getClickUpChatMessageReplies("message-42");
+
+    expect(result.status).toBe("sent");
+    expect(result.replies[0]?.attachments).toEqual([
+      {
+        url: briefUrl,
+        label: "brief.pdf",
+        mimeType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("deduplicates attachment URLs and leaves pasted links as reply text", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const attachmentUrl = "https://cdn.example.test/hero.jpg";
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: "reply-row-1",
+            parent_message: "message-42",
+            content: `${attachmentUrl} https://example.test/brief`,
+            attachments: [
+              { title: "Hero", url: attachmentUrl },
+              { title: "Hero duplicate", url: attachmentUrl },
+            ],
+            links: {
+              reactions: "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/reply-row-1/reactions",
+            },
+          },
+        ],
+      }),
+    }) as typeof fetch;
+
+    const result = await getClickUpChatMessageReplies("message-42");
+
+    expect(result.status).toBe("sent");
+    expect(result.replies[0]?.content).toBe(`${attachmentUrl} https://example.test/brief`);
+    expect(result.replies[0]?.attachments).toEqual([
+      {
+        url: attachmentUrl,
+        label: "Hero",
+        mimeType: null,
+      },
+    ]);
+  });
+
   it("paginates replies and orders them chronologically across all pages", async () => {
     process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
     process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
@@ -1122,6 +1203,54 @@ describe("detectClickUpAwaitingHumanBridgeEvents", () => {
       }],
     });
   });
+
+  it("returns attachment-only replies with an attached files markdown section", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const attachmentUrl = "https://t90161423646.p.clickup-attachments.com/t90161423646/hero.jpeg?view=open";
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{
+          id: "reply-1",
+          parent_message: "message-42",
+          content: "",
+          attachments: [{
+            title: "Hero reference",
+            mime_type: "image/jpeg",
+            url: attachmentUrl,
+          }],
+          links: {
+            reactions: "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/reply-1/reactions",
+            tagged_users: "https://api.clickup.com/api/v3/workspaces/workspace-1/chat/messages/reply-1/tagged_users",
+          },
+        }],
+      }),
+    }) as typeof fetch;
+
+    const result = await detectClickUpAwaitingHumanBridgeEvents("message-42");
+
+    expect(result).toEqual({
+      status: "sent",
+      detail: "replies-detected",
+      events: [{
+        kind: "reply",
+        externalEventId: "reply-1",
+        externalMessageId: "message-42",
+        body: `## Attachments from ClickUp\n1. Hero reference: ${attachmentUrl}`,
+        metadata: {
+          clickupReplyId: "reply-1",
+          clickupAttachments: [{
+            url: attachmentUrl,
+            label: "Hero reference",
+            mimeType: "image/jpeg",
+          }],
+        },
+      }],
+    });
+  });
 });
 
 describe("detectClickUpAwaitingHumanBridgeEventsAfterMessage", () => {
@@ -1177,6 +1306,63 @@ describe("detectClickUpAwaitingHumanBridgeEventsAfterMessage", () => {
           clickupReplyId: "human-reply-2",
           clickupThreadId: "thread-root-1",
           clickupQuestionMessageId: "question-reply-2",
+        },
+      }],
+    });
+  });
+
+  it("appends attachments to replies after the current bot question marker", async () => {
+    process.env.CLICKUP_PERSONAL_TOKEN = "token-123";
+    process.env.CLICKUP_WORKSPACE_ID = "workspace-1";
+
+    const attachmentUrl = "https://cdn.example.test/product.png";
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: "question-reply-2",
+            parent_message: "thread-root-1",
+            content: "Which asset?",
+            date: 2000,
+            links: { reactions: "https://example.test/reactions/question" },
+          },
+          {
+            id: "human-reply-2",
+            parent_message: "thread-root-1",
+            content: "Use this as the big image.",
+            attachments: [{ title: "product.png", mime_type: "image/png", url: attachmentUrl }],
+            date: 3000,
+            links: { reactions: "https://example.test/reactions/answer" },
+          },
+        ],
+      }),
+    }) as typeof fetch;
+
+    const result = await detectClickUpAwaitingHumanBridgeEventsAfterMessage(
+      "thread-root-1",
+      "question-reply-2",
+    );
+
+    expect(result).toEqual({
+      status: "sent",
+      detail: "replies-detected",
+      events: [{
+        kind: "reply",
+        externalEventId: "human-reply-2",
+        externalThreadId: "thread-root-1",
+        externalMessageId: "question-reply-2",
+        body: `Use this as the big image.\n\n## Attachments from ClickUp\n1. product.png: ${attachmentUrl}`,
+        metadata: {
+          clickupReplyId: "human-reply-2",
+          clickupThreadId: "thread-root-1",
+          clickupQuestionMessageId: "question-reply-2",
+          clickupAttachments: [{
+            url: attachmentUrl,
+            label: "product.png",
+            mimeType: "image/png",
+          }],
         },
       }],
     });

--- a/server/src/__tests__/workflow-handoff-bridge.test.ts
+++ b/server/src/__tests__/workflow-handoff-bridge.test.ts
@@ -327,12 +327,14 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
   });
 
   it("polls threaded bridges from the workflow root and resolves replies after the question marker", async () => {
-    const { runId, bridgeId } = await insertWaitingWorkflowBridge(db, {
+    const { runId, bridgeId, handoffId } = await insertWaitingWorkflowBridge(db, {
       runStatus: "awaiting_human",
       runError: null,
       externalThreadId: "thread-root-1",
       externalMessageId: "question-reply-1",
     });
+    const attachmentUrl = "https://cdn.example.test/hero.png";
+    const enrichedReply = `Use this as the hero image.\n\n## Attachments from ClickUp\n1. hero.png: ${attachmentUrl}`;
     mocks.detectClickUpAwaitingHumanBridgeEventsAfterMessage.mockResolvedValueOnce({
       status: "sent",
       detail: "replies-detected",
@@ -341,8 +343,15 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
         externalEventId: "human-reply-1",
         externalThreadId: "thread-root-1",
         externalMessageId: "question-reply-1",
-        body: "Sydney",
-        metadata: { clickupReplyId: "human-reply-1" },
+        body: enrichedReply,
+        metadata: {
+          clickupReplyId: "human-reply-1",
+          clickupAttachments: [{
+            url: attachmentUrl,
+            label: "hero.png",
+            mimeType: "image/png",
+          }],
+        },
       }],
     });
 
@@ -366,6 +375,8 @@ describeEmbeddedPostgres("workflowHandoffBridgeService", () => {
     expect(bridge?.closeOutcome).toBe("responded");
     const [run] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, runId));
     expect(run?.status).toBe("running");
+    const [handoff] = await db.select().from(workflowHandoffs).where(eq(workflowHandoffs.id, handoffId));
+    expect(handoff?.responseMarkdown).toBe(enrichedReply);
   });
 
   it("records missing threaded question markers as poll failures", async () => {

--- a/server/src/services/clickup-awaiting-human-transport.ts
+++ b/server/src/services/clickup-awaiting-human-transport.ts
@@ -65,7 +65,14 @@ export interface ClickUpChatMessageReply {
   reactionsUrl: string | null;
   content: string | null;
   dateMs: number | null;
+  attachments?: ClickUpReplyAttachment[];
 }
+
+export type ClickUpReplyAttachment = {
+  url: string;
+  label: string;
+  mimeType: string | null;
+};
 
 type ClickUpTransportMessageResult = AwaitingHumanNotificationResult & {
   messageLink: string | null;
@@ -459,6 +466,9 @@ type ClickUpReplyMessageResponse = {
   date?: number | string | null;
   date_assigned?: number | string | null;
   links: ClickUpReplyMessageLinksResponse;
+  attachments?: unknown;
+  attachment?: unknown;
+  files?: unknown;
 };
 
 type ClickUpGetChatMessageRepliesResponse = {
@@ -503,14 +513,65 @@ function compareClickUpRepliesChronologically(
   return 0;
 }
 
+function extractClickUpReplyAttachments(row: ClickUpReplyMessageResponse) {
+  const attachments: ClickUpReplyAttachment[] = [];
+  const seenUrls = new Set<string>();
+
+  for (const field of [row.attachments, row.attachment, row.files]) {
+    const values = Array.isArray(field) ? field : [field];
+    for (const value of values) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+      const record = value as Record<string, unknown>;
+      const url = readString(record.url)
+        ?? readString(record.download_url)
+        ?? readString(record.downloadUrl);
+      if (!url || seenUrls.has(url)) continue;
+      seenUrls.add(url);
+      attachments.push({
+        url,
+        label: readString(record.title)
+          ?? readString(record.name)
+          ?? readString(record.filename)
+          ?? readString(record.file_name)
+          ?? url,
+        mimeType: readString(record.mime_type)
+          ?? readString(record.mimeType)
+          ?? readString(record.content_type)
+          ?? readString(record.contentType),
+      });
+    }
+  }
+
+  return attachments;
+}
+
+function formatClickUpReplyBodyWithAttachments(
+  replyBody: string | null,
+  attachments: ClickUpReplyAttachment[] | undefined,
+) {
+  const body = replyBody?.trim() ?? "";
+  const files = attachments ?? [];
+  if (files.length === 0) return body || null;
+
+  const attachmentLines = files.map((attachment, index) =>
+    `${index + 1}. ${attachment.label}: ${attachment.url}`,
+  );
+  const attachmentSection = ["## Attachments from ClickUp", ...attachmentLines].join("\n");
+  return body ? `${body}\n\n${attachmentSection}` : attachmentSection;
+}
+
 function extractReplyRowsFromRows(rows: ClickUpReplyMessageResponse[]): ClickUpChatMessageReply[] {
-  return [...rows].sort(compareClickUpRepliesChronologically).map((row) => ({
-    id: row.id,
-    parentMessageId: row.parent_message,
-    reactionsUrl: row.links.reactions,
-    content: row.content,
-    dateMs: readClickUpReplyDate(row),
-  }));
+  return [...rows].sort(compareClickUpRepliesChronologically).map((row) => {
+    const attachments = extractClickUpReplyAttachments(row);
+    return {
+      id: row.id,
+      parentMessageId: row.parent_message,
+      reactionsUrl: row.links.reactions,
+      content: row.content,
+      dateMs: readClickUpReplyDate(row),
+      ...(attachments.length > 0 ? { attachments } : {}),
+    };
+  });
 }
 
 function extractReplyRows(payload: ClickUpGetChatMessageRepliesResponse): ClickUpChatMessageReply[] {
@@ -1358,7 +1419,7 @@ export async function detectClickUpAwaitingHumanBridgeEvents(
   const events: AwaitingHumanBridgePollEvent[] = [];
   for (const reply of repliesResult.replies) {
     const replyId = readString(reply.id);
-    const replyBody = readString(reply.content);
+    const replyBody = formatClickUpReplyBodyWithAttachments(readString(reply.content), reply.attachments);
     if (!replyId) {
       logger.warn(
         { messageId, reply },
@@ -1374,6 +1435,7 @@ export async function detectClickUpAwaitingHumanBridgeEvents(
       body: replyBody,
       metadata: {
         clickupReplyId: replyId,
+        ...(reply.attachments?.length ? { clickupAttachments: reply.attachments } : {}),
       },
     });
   }
@@ -1429,7 +1491,7 @@ export async function detectClickUpAwaitingHumanBridgeEventsAfterMessage(
     }
     if (!markerFound) continue;
 
-    const replyBody = readString(reply.content);
+    const replyBody = formatClickUpReplyBodyWithAttachments(readString(reply.content), reply.attachments);
     if (!replyBody) continue;
     events.push({
       kind: "reply",
@@ -1441,6 +1503,7 @@ export async function detectClickUpAwaitingHumanBridgeEventsAfterMessage(
         clickupReplyId: replyId,
         clickupThreadId: threadId,
         clickupQuestionMessageId: markerId,
+        ...(reply.attachments?.length ? { clickupAttachments: reply.attachments } : {}),
       },
     });
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and workflow runs with human checkpoints.
> - ClickUp-backed awaiting-human bridges are the path where external reviewers reply to those checkpoints.
> - Workflow handoffs already return reviewer feedback to the runtime as markdown, so the smallest compatible path is to enrich that markdown rather than add a new API or runtime contract.
> - Humans can attach files in ClickUp replies, but those attachment objects were not included in the parsed reply payload consumed by the bridge.
> - That meant workflow agents could receive the text feedback but miss the human-provided files needed for landing-page image placement.
> - This pull request keeps the behavior local to the ClickUp transport and reuses the existing reply-event flow.
> - The benefit is that ClickUp attachments now reach approval and workflow consumers as ordinary markdown links while preserving existing string-based ADK/runtime contracts.

## What Changed

- Added attachment extraction for ClickUp chat reply payload fields such as `attachments`, `attachment`, and `files`.
- Appended detected attachments to reply markdown under `## Attachments from ClickUp`.
- Allowed attachment-only replies to produce reply events instead of being skipped as empty text.
- Included parsed attachment metadata on ClickUp reply events for diagnostics while keeping consumers reliant on markdown.
- Added transport and workflow handoff bridge tests covering attachment parsing, deduplication, attachment-only replies, and enriched workflow responses.

## Verification

- `rtk pnpm vitest server/src/__tests__/clickup-awaiting-human-transport.test.ts server/src/__tests__/workflow-handoff-bridge.test.ts`
- Manual local smoke test with the Landing Page Strategist workflow: multiple ClickUp feedback rounds with uploaded images were imported into the workflow and used by the downstream page agent.

## Risks

- Low database/API risk: no schema migration, REST endpoint, or ADK runtime contract change.
- ClickUp payload shape risk: this handles the observed attachment-like fields, but ClickUp may return other attachment shapes that still need future support.
- URL accessibility risk: v1 passes ClickUp-hosted links through as-is; if links expire or require inaccessible auth context, a later storage-backed attachment flow may be needed.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent with local shell/tool execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
